### PR TITLE
feat(cli): core-first template config precedence for seed/validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,15 @@ Bundled TAPDB core templates are:
 Non-core domain packs (workflow/action/content/etc.) are expected to live in
 client repositories or external config directories, not in TAPDB core.
 
+When seeding or validating templates with `tapdb db data seed` or
+`tapdb db config validate`, TAPDB loads template configs in this order:
+
+1. TAPDB core config bundle (`daylily_tapdb/core_config` or repo `config/`)
+2. Client-specified `--config` directory (if provided)
+
+Duplicate template keys across merged sources are a hard failure; TAPDB does
+not silently override by load order.
+
 ### Canonical fields (v2)
 
 Each element in `templates` is a template definition with:
@@ -765,11 +774,11 @@ tapdb db schema apply <env>  # Apply TAPDB schema to existing database
 tapdb db schema status <env> # Check schema status and row counts
 tapdb db schema reset <env>  # Drop TAPDB schema objects (⚠️ destructive)
 tapdb db schema migrate <env># Apply schema migrations
-tapdb db data seed <env>     # Seed bundled core templates from config/
+tapdb db data seed <env>     # Seed core templates first, then optional client --config
 tapdb db data seed <env> -w  # Include optional non-core packs if present
 tapdb db data backup <env>   # Backup database (--output/-o FILE)
 tapdb db data restore <env>  # Restore from backup (--input/-i FILE)
-tapdb db config validate     # Validate template JSON config files (no DB required)
+tapdb db config validate     # Validate merged core + client template config set
 
 # User management
 tapdb user list              # List users

--- a/daylily_tapdb/cli/db.py
+++ b/daylily_tapdb/cli/db.py
@@ -1,5 +1,6 @@
 """Database management commands for TAPDB CLI."""
 
+import importlib
 import json
 import os
 import re
@@ -217,6 +218,76 @@ def _find_config_dir() -> Path:
         "Cannot find config/ directory with template JSON files. "
         "Run from the daylily-tapdb repo root or ensure config is installed."
     )
+
+
+def _find_tapdb_core_config_dir() -> Path:
+    """Find TAPDB's built-in core template config directory."""
+    candidates: list[Path] = []
+
+    try:
+        tapdb_pkg = importlib.import_module("daylily_tapdb")
+        pkg_file = Path(tapdb_pkg.__file__).resolve()
+        candidates.extend(
+            [
+                pkg_file.parent / "core_config",
+                pkg_file.parents[1] / "config",
+                pkg_file.parents[2] / "config",
+            ]
+        )
+    except Exception:
+        pass
+
+    current = Path(__file__).resolve()
+    candidates.extend(
+        [
+            current.parents[1] / "core_config",
+            current.parents[2] / "config",
+            current.parents[3] / "config",
+        ]
+    )
+
+    for candidate in candidates:
+        if not candidate.exists() or not candidate.is_dir():
+            continue
+        if (candidate / "actor" / "actor.json").exists() and (
+            candidate / "generic" / "generic.json"
+        ).exists():
+            return candidate
+
+    raise FileNotFoundError(
+        "Cannot find TAPDB core config directory with actor/generic templates."
+    )
+
+
+def _resolve_seed_config_dirs(config_path: Optional[Path]) -> list[Path]:
+    """Resolve ordered template config directories for seeding.
+
+    Always includes TAPDB core config first, then caller-provided/auto-discovered
+    client config when different.
+    """
+    core_dir = _find_tapdb_core_config_dir().resolve()
+    dirs: list[Path] = [core_dir]
+
+    client_dir: Path | None = config_path.resolve() if config_path is not None else None
+
+    if client_dir is not None and client_dir != core_dir:
+        dirs.append(client_dir)
+
+    return dirs
+
+
+def _normalize_config_dirs(config_dirs: Path | list[Path]) -> list[Path]:
+    """Normalize config directory input into a de-duplicated ordered list."""
+    dirs = [config_dirs] if isinstance(config_dirs, Path) else list(config_dirs)
+    seen_dirs: set[Path] = set()
+    unique_dirs: list[Path] = []
+    for directory in dirs:
+        resolved = directory.resolve()
+        if resolved in seen_dirs:
+            continue
+        seen_dirs.add(resolved)
+        unique_dirs.append(resolved)
+    return unique_dirs
 
 
 # Environment enum
@@ -1095,12 +1166,12 @@ OPTIONAL_CATEGORIES: set[str] = set()
 
 
 def _load_template_configs(
-    config_dir: Path, include_optional: bool = False
+    config_dirs: Path | list[Path], include_optional: bool = False
 ) -> list[dict]:
-    """Load template configurations from JSON files in config directory.
+    """Load template configurations from one or more config directories.
 
     Args:
-        config_dir: Path to config directory
+        config_dirs: Path or list of paths to config directories
         include_optional: If True, include optional non-core template packs
 
     Returns list of template dicts ready for database insertion.
@@ -1110,32 +1181,53 @@ def _load_template_configs(
     if include_optional:
         allowed_categories.update(OPTIONAL_CATEGORIES)
 
-    # Walk through config subdirectories
-    for category_dir in sorted(config_dir.iterdir()):
-        if not category_dir.is_dir() or category_dir.name.startswith("_"):
+    unique_dirs = _normalize_config_dirs(config_dirs)
+
+    for config_dir in unique_dirs:
+        if not config_dir.exists() or not config_dir.is_dir():
+            console.print(
+                f"[yellow]⚠[/yellow] Config directory not found or not a directory: {config_dir}"
+            )
             continue
 
-        # Filter by allowed categories
-        if category_dir.name not in allowed_categories:
-            continue
+        for category_dir in sorted(config_dir.iterdir()):
+            if not category_dir.is_dir() or category_dir.name.startswith("_"):
+                continue
 
-        for json_file in sorted(category_dir.glob("*.json")):
-            try:
-                with open(json_file, "r") as f:
-                    data = json.load(f)
+            # Filter by allowed categories
+            if category_dir.name not in allowed_categories:
+                continue
 
-                # Extract templates from the file
-                if "templates" in data:
-                    for tmpl in data["templates"]:
-                        tmpl["_source_file"] = str(json_file.relative_to(config_dir))
-                        templates.append(tmpl)
+            for json_file in sorted(category_dir.glob("*.json")):
+                try:
+                    with open(json_file, "r") as f:
+                        data = json.load(f)
 
-            except json.JSONDecodeError as e:
-                console.print(f"[yellow]⚠[/yellow] Invalid JSON in {json_file}: {e}")
-            except Exception as e:
-                console.print(f"[yellow]⚠[/yellow] Error reading {json_file}: {e}")
+                    # Extract templates from the file
+                    if "templates" in data:
+                        for tmpl in data["templates"]:
+                            tmpl = dict(tmpl)
+                            tmpl["_source_file"] = str(json_file)
+                            templates.append(tmpl)
+
+                except json.JSONDecodeError as e:
+                    console.print(f"[yellow]⚠[/yellow] Invalid JSON in {json_file}: {e}")
+                except Exception as e:
+                    console.print(f"[yellow]⚠[/yellow] Error reading {json_file}: {e}")
 
     return templates
+
+
+def _find_duplicate_template_keys(
+    templates: list[dict],
+) -> dict[tuple[str, str, str, str], list[str]]:
+    """Return duplicate template keys with source files for hard-fail checks."""
+    key_sources: dict[tuple[str, str, str, str], list[str]] = {}
+    for tmpl in templates:
+        key = _template_key(tmpl)
+        source = str(tmpl.get("_source_file") or "(unknown)")
+        key_sources.setdefault(key, []).append(source)
+    return {key: sources for key, sources in key_sources.items() if len(sources) > 1}
 
 
 @dataclass(frozen=True)
@@ -1210,7 +1302,7 @@ def _extract_template_refs(obj: Any) -> list[str]:
 
 
 def _validate_template_configs(
-    config_dir: Path, *, strict: bool
+    config_dirs: Path | list[Path], *, strict: bool
 ) -> tuple[list[dict], list[_ConfigIssue]]:
     """Load and validate template config JSON files.
 
@@ -1228,81 +1320,91 @@ def _validate_template_configs(
     issues: list[_ConfigIssue] = []
     templates: list[dict] = []
 
-    if not config_dir.exists():
-        return [], [
-            _ConfigIssue(
-                level="error", message=f"Config directory not found: {config_dir}"
-            )
-        ]
+    unique_dirs = _normalize_config_dirs(config_dirs)
+    if not unique_dirs:
+        return [], [_ConfigIssue(level="error", message="No config directories provided")]
 
     # Load
-    for category_dir in sorted(config_dir.iterdir()):
-        if not category_dir.is_dir() or category_dir.name.startswith("_"):
+    for config_dir in unique_dirs:
+        if not config_dir.exists() or not config_dir.is_dir():
+            issues.append(
+                _ConfigIssue(
+                    level="error",
+                    message=f"Config directory not found: {config_dir}",
+                )
+            )
             continue
 
-        for json_file in sorted(category_dir.glob("*.json")):
-            rel = str(json_file.relative_to(config_dir))
-            try:
-                data = json.loads(json_file.read_text(encoding="utf-8"))
-            except json.JSONDecodeError as e:
-                issues.append(
-                    _ConfigIssue(
-                        level="error", source_file=rel, message=f"Invalid JSON: {e}"
-                    )
-                )
-                continue
-            except Exception as e:
-                issues.append(
-                    _ConfigIssue(
-                        level="error",
-                        source_file=rel,
-                        message=f"Error reading file: {e}",
-                    )
-                )
+        for category_dir in sorted(config_dir.iterdir()):
+            if not category_dir.is_dir() or category_dir.name.startswith("_"):
                 continue
 
-            if not isinstance(data, dict):
-                issues.append(
-                    _ConfigIssue(
-                        level="error",
-                        source_file=rel,
-                        message="Config root must be an object/dict",
-                    )
-                )
-                continue
-            tmpl_list = data.get("templates")
-            if not isinstance(tmpl_list, list):
-                issues.append(
-                    _ConfigIssue(
-                        level="error",
-                        source_file=rel,
-                        message="Missing or invalid 'templates' list",
-                    )
-                )
-                continue
-
-            for i, tmpl in enumerate(tmpl_list):
-                if not isinstance(tmpl, dict):
+            for json_file in sorted(category_dir.glob("*.json")):
+                source_file = str(json_file)
+                try:
+                    data = json.loads(json_file.read_text(encoding="utf-8"))
+                except json.JSONDecodeError as e:
                     issues.append(
                         _ConfigIssue(
                             level="error",
-                            source_file=rel,
-                            message=(
-                                f"Template[{i}] must be an"
-                                f" object/dict, got"
-                                f" {type(tmpl).__name__}"
-                            ),
+                            source_file=source_file,
+                            message=f"Invalid JSON: {e}",
                         )
                     )
                     continue
-                tmpl = dict(tmpl)
-                tmpl["_source_file"] = rel
-                templates.append(tmpl)
+                except Exception as e:
+                    issues.append(
+                        _ConfigIssue(
+                            level="error",
+                            source_file=source_file,
+                            message=f"Error reading file: {e}",
+                        )
+                    )
+                    continue
+
+                if not isinstance(data, dict):
+                    issues.append(
+                        _ConfigIssue(
+                            level="error",
+                            source_file=source_file,
+                            message="Config root must be an object/dict",
+                        )
+                    )
+                    continue
+                tmpl_list = data.get("templates")
+                if not isinstance(tmpl_list, list):
+                    issues.append(
+                        _ConfigIssue(
+                            level="error",
+                            source_file=source_file,
+                            message="Missing or invalid 'templates' list",
+                        )
+                    )
+                    continue
+
+                for i, tmpl in enumerate(tmpl_list):
+                    if not isinstance(tmpl, dict):
+                        issues.append(
+                            _ConfigIssue(
+                                level="error",
+                                source_file=source_file,
+                                message=(
+                                    f"Template[{i}] must be an"
+                                    f" object/dict, got"
+                                    f" {type(tmpl).__name__}"
+                                ),
+                            )
+                        )
+                        continue
+                    tmpl = dict(tmpl)
+                    tmpl["_source_file"] = source_file
+                    templates.append(tmpl)
 
     if not templates:
         issues.append(
             _ConfigIssue(
-                level="error", message=f"No templates found under: {config_dir}"
+                level="error",
+                message="No templates found under configured directories",
             )
         )
 
@@ -1545,18 +1647,19 @@ def db_validate_config(
     """Validate template JSON config files (no database required)."""
 
     try:
-        config_dir = config_path if config_path else _find_config_dir()
+        config_dirs = _resolve_seed_config_dirs(config_path)
     except FileNotFoundError as e:
         console.print(f"[red]✗[/red] {e}")
         raise typer.Exit(1)
 
-    templates, issues = _validate_template_configs(config_dir, strict=strict)
+    templates, issues = _validate_template_configs(config_dirs, strict=strict)
     errors = [i for i in issues if i.level == "error"]
     warnings = [i for i in issues if i.level == "warning"]
 
     if json_output:
         payload = {
-            "config_dir": str(config_dir),
+            "config_dir": str(config_dirs[0]),
+            "config_dirs": [str(d) for d in config_dirs],
             "strict": strict,
             "templates": len(templates),
             "errors": len(errors),
@@ -1576,7 +1679,9 @@ def db_validate_config(
 
     mode = "strict" if strict else "non-strict"
     console.print(f"\n[bold cyan]━━━ Validate Template Config ({mode}) ━━━[/bold cyan]")
-    console.print(f"  Config directory: [dim]{config_dir}[/dim]")
+    console.print("  Config directories:")
+    for directory in config_dirs:
+        console.print(f"    - [dim]{directory}[/dim]")
     console.print(f"  Templates loaded: {len(templates)}")
 
     if issues:
@@ -1838,13 +1943,16 @@ def db_seed(
             f"  Optional categories: {', '.join(sorted(OPTIONAL_CATEGORIES))}"
         )
 
-    # Find config directory
+    # Resolve config directories (always include TAPDB core config first)
     try:
-        config_dir = config_path if config_path else _find_config_dir()
-        console.print(f"[green]✓[/green] Config directory: {config_dir}")
+        seed_config_dirs = _resolve_seed_config_dirs(config_path)
     except FileNotFoundError as e:
         console.print(f"[red]✗[/red] {e}")
         raise typer.Exit(1)
+
+    console.print("[green]✓[/green] Seed config directories:")
+    for directory in seed_config_dirs:
+        console.print(f"  - {directory}")
 
     # Check database and schema exist
     if not _check_db_exists(env, cfg["database"]):
@@ -1861,11 +1969,25 @@ def db_seed(
 
     # Load templates
     console.print("[yellow]►[/yellow] Loading template configurations...")
-    templates = _load_template_configs(config_dir, include_optional=include_workflow)
+    templates = _load_template_configs(
+        seed_config_dirs, include_optional=include_workflow
+    )
 
     if not templates:
-        console.print(f"[yellow]⚠[/yellow] No templates found in {config_dir}")
+        console.print("[yellow]⚠[/yellow] No templates found in configured seed directories")
         return
+
+    duplicates = _find_duplicate_template_keys(templates)
+    if duplicates:
+        console.print(
+            "[red]✗[/red] Duplicate template keys detected across seed configs. "
+            "Aborting to prevent clashing templates:"
+        )
+        for key, sources in sorted(duplicates.items()):
+            console.print(f"  • {key}")
+            for source in sources:
+                console.print(f"      - {source}")
+        raise typer.Exit(1)
 
     console.print(f"[green]✓[/green] Found {len(templates)} template(s)")
 

--- a/daylily_tapdb/core_config/_metadata.json
+++ b/daylily_tapdb/core_config/_metadata.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "tapdb-template-v2",
+  "version": "2.0.0",
+  "description": "TAPDB core template configuration schema",
+  "field_mapping": {
+    "polymorphic_discriminator": "Path: category/type/subtype/version (e.g., container/tube/generic/1.0)",
+    "category": "Top-level category (core TAPDB bundles use generic)",
+    "type": "Type within category (core TAPDB bundles use generic and actor)",
+    "subtype": "Specific variant (e.g., generic, system_user, external_object_link)",
+    "version": "Template version (e.g., 1.0)",
+    "instance_prefix": "EUID prefix for instances (core TAPDB bundles use ACT and GX)",
+    "json_addl": "Flexible JSON data for template-specific properties"
+  },
+  "euid_prefixes": {
+    "generic_template": "GT",
+    "generic_instance": "GX",
+    "generic_instance_lineage": "GN",
+    "actor": "ACT",
+    "external_object_link": "GX"
+  }
+}

--- a/daylily_tapdb/core_config/actor/actor.json
+++ b/daylily_tapdb/core_config/actor/actor.json
@@ -1,0 +1,65 @@
+{
+  "$comment": "TAPDB v2 Template: Actor - users, systems, agents",
+  "templates": [
+    {
+      "name": "Generic Actor",
+      "polymorphic_discriminator": "actor_template",
+      "category": "generic",
+      "type": "actor",
+      "subtype": "generic",
+      "version": "1.0",
+      "instance_prefix": "ACT",
+      "is_singleton": false,
+      "bstatus": "active",
+      "json_addl": {
+        "description": "Base actor template for users, systems, and agents",
+        "properties": {
+          "name": "Generic Actor",
+          "actor_type": "user",
+          "comments": ""
+        },
+        "expected_inputs": [],
+        "expected_outputs": [],
+        "instantiation_layouts": [],
+        "cogs": {
+          "state": "active",
+          "cost": "0.00",
+          "allocation_type": ""
+        }
+      }
+    },
+    {
+      "name": "System User Actor",
+      "polymorphic_discriminator": "actor_template",
+      "category": "generic",
+      "type": "actor",
+      "subtype": "system_user",
+      "version": "1.0",
+      "instance_prefix": "ACT",
+      "is_singleton": false,
+      "bstatus": "active",
+      "json_addl": {
+        "description": "Dedicated actor template for TAPDB auth users",
+        "properties": {
+          "login_identifier": "",
+          "email": "",
+          "display_name": "",
+          "role": "user",
+          "is_active": true,
+          "require_password_change": false,
+          "password_hash": null,
+          "last_login_dt": null,
+          "cognito_username": ""
+        },
+        "expected_inputs": [],
+        "expected_outputs": [],
+        "instantiation_layouts": [],
+        "cogs": {
+          "state": "active",
+          "cost": "0.00",
+          "allocation_type": ""
+        }
+      }
+    }
+  ]
+}

--- a/daylily_tapdb/core_config/generic/generic.json
+++ b/daylily_tapdb/core_config/generic/generic.json
@@ -1,0 +1,62 @@
+{
+  "$comment": "TAPDB v2 Templates: Generic core objects",
+  "templates": [
+    {
+      "name": "Generic Object",
+      "polymorphic_discriminator": "generic_template",
+      "category": "generic",
+      "type": "generic",
+      "subtype": "generic",
+      "version": "1.0",
+      "instance_prefix": "GX",
+      "is_singleton": false,
+      "bstatus": "active",
+      "json_addl": {
+        "description": "Base generic object template",
+        "properties": {
+          "name": "Generic Object",
+          "comments": ""
+        },
+        "expected_inputs": [],
+        "expected_outputs": [],
+        "instantiation_layouts": [],
+        "cogs": {
+          "state": "active",
+          "cost": "0.00",
+          "allocation_type": ""
+        }
+      }
+    },
+    {
+      "name": "External Object Link",
+      "polymorphic_discriminator": "generic_template",
+      "category": "generic",
+      "type": "generic",
+      "subtype": "external_object_link",
+      "version": "1.0",
+      "instance_prefix": "GX",
+      "is_singleton": false,
+      "bstatus": "active",
+      "json_addl": {
+        "description": "Core object used to map/link external system entities into TAPDB",
+        "properties": {
+          "name": "External Object Link",
+          "comments": "",
+          "external_system": "",
+          "external_euid": "",
+          "external_type": "",
+          "external_url": "",
+          "external_payload": {}
+        },
+        "expected_inputs": [],
+        "expected_outputs": [],
+        "instantiation_layouts": [],
+        "cogs": {
+          "state": "active",
+          "cost": "0.00",
+          "allocation_type": ""
+        }
+      }
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,10 @@ where = ["."]
 include = ["daylily_tapdb*", "admin*"]
 
 [tool.setuptools.package-data]
+daylily_tapdb = [
+    "core_config/_metadata.json",
+    "core_config/*/*.json",
+]
 # Admin UI ships HTML templates + static assets.
 admin = [
     "templates/*.html",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,10 +15,13 @@ from daylily_tapdb.cli import app
 from daylily_tapdb.cli.db import (
     Environment,
     _ensure_dirs,
+    _find_duplicate_template_keys,
     _find_config_dir,
     _find_schema_file,
+    _find_tapdb_core_config_dir,
     _get_db_config,
     _load_template_configs,
+    _resolve_seed_config_dirs,
 )
 from daylily_tapdb.cli.db_config import get_config_path
 
@@ -1074,7 +1077,7 @@ class TestCLIDBSeed:
                             "polymorphic_discriminator": "generic_template",
                             "category": "generic",
                             "type": "generic",
-                            "subtype": "generic",
+                            "subtype": "client-generic-valid-minimal",
                             "version": "1.0",
                             "instance_prefix": "GX",
                             "is_singleton": False,
@@ -1137,7 +1140,7 @@ class TestCLIDBSeed:
                             "polymorphic_discriminator": "generic_template",
                             "category": "generic",
                             "type": "generic",
-                            "subtype": "generic",
+                            "subtype": "client-generic-valid-layouts",
                             "version": "1.0",
                             "instance_prefix": "GX",
                             "is_singleton": False,
@@ -1183,7 +1186,7 @@ class TestCLIDBSeed:
                             "polymorphic_discriminator": "generic_template",
                             "category": "generic",
                             "type": "generic",
-                            "subtype": "generic",
+                            "subtype": "client-generic-missing-ref-layouts",
                             "version": "1.0",
                             "instance_prefix": "GX",
                             "is_singleton": False,
@@ -1253,7 +1256,7 @@ class TestCLIDBSeed:
                             "polymorphic_discriminator": "generic_template",
                             "category": "generic",
                             "type": "generic",
-                            "subtype": "generic",
+                            "subtype": "client-generic-invalid-count",
                             "version": "1.0",
                             "instance_prefix": "GX",
                             "is_singleton": False,
@@ -1304,7 +1307,7 @@ class TestCLIDBSeed:
                             "polymorphic_discriminator": "generic_template",
                             "category": "generic",
                             "type": "generic",
-                            "subtype": "generic",
+                            "subtype": "client-generic-missing-template-code",
                             "version": "1.0",
                             "instance_prefix": "GX",
                             "is_singleton": False,
@@ -1345,7 +1348,7 @@ class TestCLIDBSeed:
                             "polymorphic_discriminator": "generic_template",
                             "category": "generic",
                             "type": "generic",
-                            "subtype": "generic",
+                            "subtype": "client-generic-missing-ref-strict",
                             "version": "1.0",
                             "instance_prefix": "GX",
                             "is_singleton": False,
@@ -1385,7 +1388,7 @@ class TestCLIDBSeed:
                             "polymorphic_discriminator": "generic_template",
                             "category": "generic",
                             "type": "generic",
-                            "subtype": "generic",
+                            "subtype": "client-generic-missing-ref-nonstrict",
                             "version": "1.0",
                             "instance_prefix": "GX",
                             "is_singleton": False,
@@ -1407,6 +1410,144 @@ class TestCLIDBSeed:
         )
         assert result.exit_code == 0
 
+    def test_db_validate_config_merged_core_then_client_strict_ok(
+        self, tmp_path: Path
+    ):
+        """Strict validate should consider TAPDB core templates before client config."""
+        (tmp_path / "generic").mkdir()
+        (tmp_path / "generic" / "custom.json").write_text(
+            json.dumps(
+                {
+                    "templates": [
+                        {
+                            "name": "Client Probe",
+                            "polymorphic_discriminator": "generic_template",
+                            "category": "generic",
+                            "type": "generic",
+                            "subtype": "client-probe",
+                            "version": "1.0",
+                            "instance_prefix": "GX",
+                            "is_singleton": False,
+                            "bstatus": "active",
+                            "json_addl": {
+                                "action_imports": {
+                                    "uses_core_actor": "generic/actor/system_user/1.0"
+                                }
+                            },
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "db",
+                "config",
+                "validate",
+                "--config",
+                str(tmp_path),
+                "--strict",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        core_dir = _find_tapdb_core_config_dir().resolve()
+        assert payload["errors"] == 0
+        assert payload["config_dirs"][0] == str(core_dir)
+        assert str(tmp_path.resolve()) in payload["config_dirs"]
+
+    def test_db_validate_config_json_includes_ordered_config_dirs(
+        self, tmp_path: Path
+    ):
+        """JSON validate output should expose ordered merged config directories."""
+        (tmp_path / "generic").mkdir()
+        (tmp_path / "generic" / "custom.json").write_text(
+            json.dumps(
+                {
+                    "templates": [
+                        {
+                            "name": "Custom Generic",
+                            "polymorphic_discriminator": "generic_template",
+                            "category": "generic",
+                            "type": "generic",
+                            "subtype": "custom-generic",
+                            "version": "1.0",
+                            "instance_prefix": "GX",
+                            "is_singleton": False,
+                            "bstatus": "active",
+                            "json_addl": {},
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app, ["db", "config", "validate", "--config", str(tmp_path), "--json"]
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        core_dir = _find_tapdb_core_config_dir().resolve()
+        assert payload["config_dir"] == str(core_dir)
+        assert payload["config_dirs"][0] == str(core_dir)
+        assert payload["config_dirs"][-1] == str(tmp_path.resolve())
+
+    def test_db_validate_config_fails_on_core_client_duplicate_key(
+        self, tmp_path: Path
+    ):
+        """Validation should hard-fail on duplicate template keys across sources."""
+        (tmp_path / "generic").mkdir()
+        client_file = tmp_path / "generic" / "generic.json"
+        client_file.write_text(
+            json.dumps(
+                {
+                    "templates": [
+                        {
+                            "name": "Client Duplicate Generic",
+                            "polymorphic_discriminator": "generic_template",
+                            "category": "generic",
+                            "type": "generic",
+                            "subtype": "generic",
+                            "version": "1.0",
+                            "instance_prefix": "GX",
+                            "is_singleton": False,
+                            "bstatus": "active",
+                            "json_addl": {},
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "db",
+                "config",
+                "validate",
+                "--config",
+                str(tmp_path),
+                "--strict",
+                "--json",
+            ],
+        )
+        assert result.exit_code != 0
+        payload = json.loads(result.output)
+        assert payload["errors"] >= 1
+        messages = "\n".join(i["message"] for i in payload["issues"]).lower()
+        assert "duplicate template key" in messages
+
+        core_generic = _find_tapdb_core_config_dir().resolve() / "generic" / "generic.json"
+        payload_text = json.dumps(payload).lower()
+        assert str(core_generic).lower() in payload_text
+        assert str(client_file.resolve()).lower() in payload_text
+
     def test_db_setup_help(self):
         """Test db setup --help."""
         result = runner.invoke(app, ["db", "setup", "--help"])
@@ -1421,6 +1562,29 @@ class TestCLIDBSeed:
         assert (config_dir / "_metadata.json").exists() or len(
             list(config_dir.glob("*.json"))
         ) > 0
+
+    def test_find_tapdb_core_config_dir(self):
+        """Core TAPDB seed config should always be resolvable."""
+        core_dir = _find_tapdb_core_config_dir()
+        assert core_dir.exists()
+        assert (core_dir / "actor" / "actor.json").exists()
+        assert (core_dir / "generic" / "generic.json").exists()
+
+    def test_resolve_seed_config_dirs_includes_core(self, tmp_path: Path):
+        """Seed config resolution should include core + custom dirs without duplication."""
+        custom_dir = tmp_path / "custom-config"
+        custom_dir.mkdir()
+        dirs = _resolve_seed_config_dirs(custom_dir)
+        core_dir = _find_tapdb_core_config_dir().resolve()
+        assert dirs[0] == core_dir
+        assert custom_dir.resolve() in dirs
+        assert len(dirs) == len(set(dirs))
+
+    def test_resolve_seed_config_dirs_default_is_core_only(self):
+        """Without a client config override, only core seed config should load."""
+        dirs = _resolve_seed_config_dirs(None)
+        core_dir = _find_tapdb_core_config_dir().resolve()
+        assert dirs == [core_dir]
 
     def test_load_template_configs(self):
         """Test _load_template_configs loads templates from config files."""
@@ -1445,6 +1609,75 @@ class TestCLIDBSeed:
 
         # Should have at least generic and container categories
         assert "generic" in categories or "container" in categories
+
+    def test_find_duplicate_template_keys(self):
+        """Duplicate template keys should be detected as hard errors."""
+        templates = [
+            {
+                "category": "generic",
+                "type": "generic",
+                "subtype": "generic",
+                "version": "1.0",
+                "_source_file": "/tmp/a.json",
+            },
+            {
+                "category": "generic",
+                "type": "generic",
+                "subtype": "generic",
+                "version": "1.0",
+                "_source_file": "/tmp/b.json",
+            },
+        ]
+        duplicates = _find_duplicate_template_keys(templates)
+        assert ("generic", "generic", "generic", "1.0") in duplicates
+        assert len(duplicates[("generic", "generic", "generic", "1.0")]) == 2
+
+    def test_db_seed_dry_run_fails_on_duplicate_template_keys(self, tmp_path: Path):
+        """db data seed should hard-fail when merged config sources clash."""
+        custom_generic_dir = tmp_path / "generic"
+        custom_generic_dir.mkdir(parents=True)
+        (custom_generic_dir / "generic.json").write_text(
+            json.dumps(
+                {
+                    "templates": [
+                        {
+                            "name": "Duplicate Generic Object",
+                            "polymorphic_discriminator": "generic_template",
+                            "category": "generic",
+                            "type": "generic",
+                            "subtype": "generic",
+                            "version": "1.0",
+                            "instance_prefix": "GX",
+                            "is_singleton": False,
+                            "bstatus": "active",
+                            "json_addl": {},
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("daylily_tapdb.cli.db._check_db_exists", return_value=True),
+            patch("daylily_tapdb.cli.db._schema_exists", return_value=True),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "db",
+                    "data",
+                    "seed",
+                    "dev",
+                    "--dry-run",
+                    "--config",
+                    str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code != 0
+        output = _strip_ansi(result.output).lower()
+        assert "duplicate template keys detected" in output
 
     def test_db_seed_dry_run(self):
         """Test db seed --dry-run shows templates without inserting."""


### PR DESCRIPTION
## Summary
- enforce deterministic template config precedence: TAPDB core first, then client `--config`
- apply same merged-source behavior to `db data seed` and `db config validate`
- add `config_dirs` to validate JSON output while keeping `config_dir` for compatibility
- improve duplicate-key diagnostics across merged config sources
- add packaged `daylily_tapdb/core_config` and tests/docs updates

## Validation
- pytest -q tests/test_cli.py -k "db_validate_config"
- pytest -q tests/test_cli.py -k "TestCLIDBSeed"