### PR TITLE
fix(admin): daycog AWS profile fallback for Aurora IAM DB auth

### DIFF
--- a/admin/db_pool.py
+++ b/admin/db_pool.py
@@ -144,6 +144,7 @@ def _attach_aurora_password_provider(
     host: str,
     port: int,
     user: str,
+    aws_profile: Optional[str],
     iam_auth: bool,
     password: str,
 ) -> Callable:
@@ -157,6 +158,7 @@ def _attach_aurora_password_provider(
                 host=host,
                 port=port,
                 user=user,
+                profile=aws_profile,
             )
         else:
             if not password:
@@ -169,7 +171,7 @@ def _attach_aurora_password_provider(
     return _on_do_connect
 
 
-def _build_engine_for_cfg(cfg: dict[str, str]) -> Engine:
+def _build_engine_for_cfg(cfg: dict[str, str], *, env_name: str) -> Engine:
     engine_type = (cfg.get("engine_type") or "local").strip().lower()
     echo_sql = _parse_bool(os.environ.get("ECHO_SQL"), default=False)
 
@@ -182,6 +184,20 @@ def _build_engine_for_cfg(cfg: dict[str, str]) -> Engine:
     if engine_type == "aurora":
         region = str(cfg.get("region") or "us-west-2").strip()
         iam_auth = _parse_bool(cfg.get("iam_auth"), default=True)
+        aws_profile = (
+            str(cfg.get("aws_profile") or "").strip()
+            or (os.environ.get("AWS_PROFILE") or "").strip()
+            or None
+        )
+        if iam_auth and not aws_profile:
+            # Prefer daycog-selected profile when TAPDB config keeps only pool ID.
+            try:
+                from admin.cognito import resolve_tapdb_pool_config
+
+                pool_cfg = resolve_tapdb_pool_config(env_name)
+                aws_profile = (pool_cfg.aws_profile or "").strip() or None
+            except Exception as exc:
+                logger.debug("No daycog AWS profile fallback for env %s: %s", env_name, exc)
         ca_path = AuroraConnectionBuilder.ensure_ca_bundle()
         url = URL.create(
             "postgresql+psycopg2",
@@ -199,6 +215,7 @@ def _build_engine_for_cfg(cfg: dict[str, str]) -> Engine:
             host=host,
             port=port,
             user=user,
+            aws_profile=aws_profile,
             iam_auth=iam_auth,
             password=password,
         )
@@ -224,7 +241,7 @@ def get_engine_bundle(env_name: str) -> EngineBundle:
             return cached
 
         cfg = get_db_config_for_env(env)
-        engine = _build_engine_for_cfg(cfg)
+        engine = _build_engine_for_cfg(cfg, env_name=env)
         from admin.db_metrics import maybe_install_engine_metrics
 
         maybe_install_engine_metrics(engine, env_name=env)

--- a/daylily_tapdb/aurora/connection.py
+++ b/daylily_tapdb/aurora/connection.py
@@ -70,6 +70,7 @@ class AuroraConnectionBuilder:
         host: str,
         port: int,
         user: str,
+        profile: Optional[str] = None,
     ) -> str:
         """Generate an RDS IAM authentication token.
 
@@ -85,7 +86,7 @@ class AuroraConnectionBuilder:
         Returns:
             Short-lived IAM auth token string.
         """
-        cache_key = (region, host, port, user)
+        cache_key = (region, host, port, user, profile or "")
         if cache_key in _iam_token_cache:
             token, expires_at = _iam_token_cache[cache_key]
             if time.monotonic() < expires_at:
@@ -93,7 +94,11 @@ class AuroraConnectionBuilder:
                 return token
 
         boto3 = _ensure_boto3()
-        client = boto3.client("rds", region_name=region)
+        if profile:
+            session = boto3.session.Session(profile_name=profile)
+            client = session.client("rds", region_name=region)
+        else:
+            client = boto3.client("rds", region_name=region)
         token = client.generate_db_auth_token(
             DBHostname=host,
             Port=port,

--- a/daylily_tapdb/cli/db_config.py
+++ b/daylily_tapdb/cli/db_config.py
@@ -247,6 +247,10 @@ def get_db_config_for_env(env_name: str) -> dict[str, str]:
             f"{env_prefix}SUPPORT_EMAIL",
             _file_str("support_email") or "",
         ),
+        "aws_profile": os.environ.get(
+            f"{env_prefix}AWS_PROFILE",
+            os.environ.get("AWS_PROFILE", _file_str("aws_profile") or ""),
+        ),
     }
 
     if ctx:

--- a/tests/test_admin_db_connection.py
+++ b/tests/test_admin_db_connection.py
@@ -54,6 +54,7 @@ def test_attach_aurora_password_provider_refreshes_iam_token(monkeypatch):
         host="dev.cluster-abc.us-west-2.rds.amazonaws.com",
         port=5432,
         user="tapdb_admin",
+        aws_profile=None,
         iam_auth=True,
         password="",
     )
@@ -70,10 +71,10 @@ def test_attach_aurora_password_provider_uses_static_password_when_iam_disabled(
         host="dev.cluster-abc.us-west-2.rds.amazonaws.com",
         port=5432,
         user="tapdb_admin",
+        aws_profile=None,
         iam_auth=False,
         password="pw123",
     )
     cparams = {}
     listener(None, None, None, cparams)
     assert cparams["password"] == "pw123"
-

--- a/tests/test_aurora_connection.py
+++ b/tests/test_aurora_connection.py
@@ -348,7 +348,7 @@ def test_iam_token_cache_expires(monkeypatch):
     assert len(mod._iam_token_cache) == 1
 
     # Expire the cache by manipulating the stored expiry
-    cache_key = ("us-east-1", "host.rds.amazonaws.com", 5432, "user1")
+    cache_key = ("us-east-1", "host.rds.amazonaws.com", 5432, "user1", "")
     token, _ = mod._iam_token_cache[cache_key]
     mod._iam_token_cache[cache_key] = (token, time_mod.monotonic() - 1)
 


### PR DESCRIPTION
## Summary\n- add optional AWS profile support to Aurora IAM token generation\n- make admin pooled DB engine resolve/fallback to daycog AWS profile for IAM auth\n- surface aws_profile in env config resolution and update related tests\n\n## Validation\n- pytest -q tests/test_admin_db_connection.py tests/test_aurora_connection.py\n