### PR TITLE
Add external graph references to admin UI

### DIFF
--- a/admin/external_graph.py
+++ b/admin/external_graph.py
@@ -1,0 +1,323 @@
+"""Helpers for explicit external graph references in TAPDB admin."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlencode, urljoin, urlsplit
+from urllib.request import Request as UrlRequest
+from urllib.request import urlopen
+
+from fastapi import Request
+
+
+ALLOWED_AUTH_MODES = {"none", "same_origin"}
+
+
+@dataclass(frozen=True)
+class ExternalGraphRef:
+    """Normalized external graph reference for UI and proxy routes."""
+
+    label: str
+    system: str
+    root_euid: str
+    tenant_id: str | None
+    href: str | None
+    graph_expandable: bool
+    reason: str | None
+    base_url: str | None
+    graph_data_path: str | None
+    object_detail_path_template: str | None
+    auth_mode: str
+
+    def to_public_dict(self, *, ref_index: int) -> dict[str, Any]:
+        payload = {
+            "label": self.label,
+            "system": self.system,
+            "root_euid": self.root_euid,
+            "tenant_id": self.tenant_id,
+            "href": self.href,
+            "graph_expandable": self.graph_expandable,
+            "ref_index": ref_index,
+        }
+        if self.reason:
+            payload["reason"] = self.reason
+        return payload
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _compose_object_href(
+    *,
+    base_url: str,
+    object_detail_path_template: str,
+    root_euid: str,
+) -> str:
+    template = _clean(object_detail_path_template)
+    if not template:
+        return ""
+    if "{euid}" in template:
+        relative = template.replace("{euid}", root_euid)
+    else:
+        relative = template.rstrip("/") + f"/{root_euid}"
+    return urljoin(base_url.rstrip("/") + "/", relative.lstrip("/"))
+
+
+def resolve_external_graph_refs(obj: Any) -> list[ExternalGraphRef]:
+    """Parse explicit `external_payload.tapdb_graph` refs from object JSON."""
+    json_addl = _as_dict(getattr(obj, "json_addl", None))
+    properties = _as_dict(json_addl.get("properties"))
+    external_payload = _as_dict(properties.get("external_payload"))
+    tapdb_graph = external_payload.get("tapdb_graph")
+    refs_raw: list[Any]
+    if isinstance(tapdb_graph, list):
+        refs_raw = list(tapdb_graph)
+    elif isinstance(tapdb_graph, dict):
+        refs_raw = [tapdb_graph]
+    else:
+        refs_raw = []
+
+    refs: list[ExternalGraphRef] = []
+    for raw in refs_raw:
+        item = _as_dict(raw)
+        system = _clean(item.get("system"))
+        root_euid = _clean(item.get("root_euid"))
+        tenant_id = _clean(item.get("tenant_id")) or None
+        base_url = _clean(item.get("base_url")) or None
+        graph_data_path = _clean(item.get("graph_data_path")) or None
+        object_detail_path_template = (
+            _clean(item.get("object_detail_path_template")) or None
+        )
+        auth_mode = _clean(item.get("auth_mode")) or "none"
+        href = _clean(item.get("href")) or None
+        if not href and base_url and object_detail_path_template and root_euid:
+            href = _compose_object_href(
+                base_url=base_url,
+                object_detail_path_template=object_detail_path_template,
+                root_euid=root_euid,
+            )
+
+        graph_expandable = True
+        reason: str | None = None
+        missing: list[str] = []
+        if not system:
+            missing.append("system")
+        if not root_euid:
+            missing.append("root_euid")
+        if not base_url:
+            missing.append("base_url")
+        if not graph_data_path:
+            missing.append("graph_data_path")
+        if not object_detail_path_template:
+            missing.append("object_detail_path_template")
+        if auth_mode not in ALLOWED_AUTH_MODES:
+            missing.append("auth_mode")
+        if missing:
+            graph_expandable = False
+            reason = "Missing required graph metadata: " + ", ".join(missing)
+
+        label = _clean(item.get("label")) or (
+            f"{system}:{root_euid}" if system and root_euid else "external reference"
+        )
+        refs.append(
+            ExternalGraphRef(
+                label=label,
+                system=system or "external",
+                root_euid=root_euid,
+                tenant_id=tenant_id,
+                href=href,
+                graph_expandable=graph_expandable,
+                reason=reason,
+                base_url=base_url,
+                graph_data_path=graph_data_path,
+                object_detail_path_template=object_detail_path_template,
+                auth_mode=auth_mode,
+            )
+        )
+
+    refs.sort(key=lambda ref: (ref.system, ref.label, ref.root_euid, ref.tenant_id or ""))
+    return refs
+
+
+def get_external_ref_by_index(obj: Any, ref_index: int) -> ExternalGraphRef:
+    refs = resolve_external_graph_refs(obj)
+    if ref_index < 0 or ref_index >= len(refs):
+        raise IndexError("External reference not found")
+    return refs[ref_index]
+
+
+def fetch_remote_graph(
+    request: Request,
+    ref: ExternalGraphRef,
+    *,
+    depth: int,
+) -> dict[str, Any]:
+    """Fetch a remote graph payload via the configured resolver metadata."""
+    if not ref.graph_expandable or not ref.base_url or not ref.graph_data_path:
+        raise RuntimeError(ref.reason or "External graph is not expandable")
+
+    params = {"start_euid": ref.root_euid, "depth": int(depth)}
+    if ref.tenant_id:
+        params["tenant_id"] = ref.tenant_id
+
+    url = urljoin(ref.base_url.rstrip("/") + "/", ref.graph_data_path.lstrip("/"))
+    url = f"{url}?{urlencode(params)}"
+    headers = {"Accept": "application/json"}
+    _apply_forwarded_auth(request, ref, headers)
+    with urlopen(UrlRequest(url, headers=headers), timeout=20) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("Remote graph response must be a JSON object")
+    return payload
+
+
+def fetch_remote_object_detail(
+    request: Request,
+    ref: ExternalGraphRef,
+    *,
+    euid: str,
+) -> dict[str, Any]:
+    """Fetch remote object detail via the configured resolver metadata."""
+    if (
+        not ref.graph_expandable
+        or not ref.base_url
+        or not ref.object_detail_path_template
+    ):
+        raise RuntimeError(ref.reason or "External object detail is not available")
+
+    url = _compose_object_href(
+        base_url=ref.base_url,
+        object_detail_path_template=ref.object_detail_path_template,
+        root_euid=euid,
+    )
+    if ref.tenant_id:
+        joiner = "&" if "?" in url else "?"
+        url = f"{url}{joiner}{urlencode({'tenant_id': ref.tenant_id})}"
+    headers = {"Accept": "application/json"}
+    _apply_forwarded_auth(request, ref, headers)
+    with urlopen(UrlRequest(url, headers=headers), timeout=20) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("Remote object response must be a JSON object")
+    return payload
+
+
+def namespace_external_graph(
+    payload: dict[str, Any],
+    *,
+    ref: ExternalGraphRef,
+    ref_index: int,
+    source_euid: str,
+) -> dict[str, Any]:
+    """Namespace remote graph elements so they can be merged safely."""
+    elements = _as_dict(payload.get("elements"))
+    nodes = _as_list(elements.get("nodes"))
+    edges = _as_list(elements.get("edges"))
+    namespace = f"ext::{ref.system}::{ref.tenant_id or 'global'}"
+
+    def namespaced_id(raw_id: Any) -> str:
+        return f"{namespace}::{_clean(raw_id)}"
+
+    namespaced_nodes: list[dict[str, Any]] = []
+    for node in nodes:
+        data = _as_dict(_as_dict(node).get("data"))
+        remote_euid = _clean(data.get("euid") or data.get("id"))
+        if not remote_euid:
+            continue
+        node_data = dict(data)
+        node_data["id"] = namespaced_id(remote_euid)
+        node_data["remote_euid"] = remote_euid
+        node_data["is_external"] = True
+        node_data["external_system"] = ref.system
+        node_data["external_tenant_id"] = ref.tenant_id
+        node_data["source_ref_index"] = ref_index
+        node_data["external_source_euid"] = source_euid
+        namespaced_nodes.append({"data": node_data})
+
+    namespaced_edges: list[dict[str, Any]] = []
+    for edge in edges:
+        data = _as_dict(_as_dict(edge).get("data"))
+        remote_edge_id = _clean(data.get("id"))
+        source_id = _clean(data.get("source"))
+        target_id = _clean(data.get("target"))
+        if not remote_edge_id or not source_id or not target_id:
+            continue
+        edge_data = dict(data)
+        edge_data["id"] = namespaced_id(remote_edge_id)
+        edge_data["source"] = namespaced_id(source_id)
+        edge_data["target"] = namespaced_id(target_id)
+        edge_data["remote_euid"] = remote_edge_id
+        edge_data["is_external"] = True
+        edge_data["external_system"] = ref.system
+        edge_data["external_tenant_id"] = ref.tenant_id
+        edge_data["source_ref_index"] = ref_index
+        edge_data["external_source_euid"] = source_euid
+        namespaced_edges.append({"data": edge_data})
+
+    bridge_id = f"bridge::{source_euid}::{ref.system}::{ref.tenant_id or 'global'}::{ref.root_euid}"
+    namespaced_edges.append(
+        {
+            "data": {
+                "id": bridge_id,
+                "source": source_euid,
+                "target": namespaced_id(ref.root_euid),
+                "relationship_type": "external_reference",
+                "is_external_bridge": True,
+                "external_system": ref.system,
+                "external_tenant_id": ref.tenant_id,
+                "source_ref_index": ref_index,
+                "external_source_euid": source_euid,
+            }
+        }
+    )
+
+    return {
+        "elements": {"nodes": namespaced_nodes, "edges": namespaced_edges},
+        "meta": {
+            "source_euid": source_euid,
+            "root_euid": ref.root_euid,
+            "system": ref.system,
+            "tenant_id": ref.tenant_id,
+            "ref_index": ref_index,
+            "node_count": len(namespaced_nodes),
+            "edge_count": len(namespaced_edges),
+        },
+    }
+
+
+def _apply_forwarded_auth(
+    request: Request,
+    ref: ExternalGraphRef,
+    headers: dict[str, str],
+) -> None:
+    if ref.auth_mode == "none":
+        return
+    if ref.auth_mode != "same_origin":
+        raise RuntimeError(f"Unsupported auth mode: {ref.auth_mode}")
+
+    if not ref.base_url:
+        raise RuntimeError("same_origin auth requires base_url")
+
+    incoming_origin = f"{request.url.scheme}://{request.url.netloc}"
+    remote_parts = urlsplit(ref.base_url)
+    remote_origin = f"{remote_parts.scheme}://{remote_parts.netloc}"
+    if incoming_origin != remote_origin:
+        raise RuntimeError("same_origin auth requires matching request origin and base_url")
+
+    cookie = request.headers.get("cookie")
+    authorization = request.headers.get("authorization")
+    if cookie:
+        headers["Cookie"] = cookie
+    if authorization:
+        headers["Authorization"] = authorization

--- a/admin/main.py
+++ b/admin/main.py
@@ -59,6 +59,13 @@ from admin.domain_access import (
     is_allowed_origin,
     validate_allowed_origins,
 )
+from admin.external_graph import (
+    fetch_remote_graph,
+    fetch_remote_object_detail,
+    get_external_ref_by_index,
+    namespace_external_graph,
+    resolve_external_graph_refs,
+)
 from daylily_tapdb import InstanceFactory, TemplateManager, __version__
 from daylily_tapdb.cli.db_config import get_config_path, get_db_config_for_env
 from daylily_tapdb.models.audit import audit_log
@@ -255,6 +262,26 @@ def tapdb_url(request: Request, path: str) -> str:
 
 templates.globals["tapdb_base_path"] = tapdb_base_path
 templates.globals["tapdb_url"] = tapdb_url
+
+
+def _external_ref_payloads(obj: Any) -> list[dict[str, Any]]:
+    return [
+        ref.to_public_dict(ref_index=index)
+        for index, ref in enumerate(resolve_external_graph_refs(obj))
+    ]
+
+
+def _find_object_by_euid(session: Any, euid: str) -> tuple[Any | None, str | None]:
+    obj = session.query(generic_template).filter_by(euid=euid, is_deleted=False).first()
+    if obj is not None:
+        return obj, "template"
+    obj = session.query(generic_instance).filter_by(euid=euid, is_deleted=False).first()
+    if obj is not None:
+        return obj, "instance"
+    obj = session.query(generic_instance_lineage).filter_by(euid=euid, is_deleted=False).first()
+    if obj is not None:
+        return obj, "lineage"
+    return None, None
 
 
 def get_db():
@@ -1965,29 +1992,7 @@ async def object_detail(request: Request, euid: str):
     with get_db() as conn:
         conn.app_username = user.get("username")
         with conn.session_scope() as session:
-            # Try to find in templates first
-            obj = (
-                session.query(generic_template)
-                .filter_by(euid=euid, is_deleted=False)
-                .first()
-            )
-            obj_type = "template"
-
-            if not obj:
-                obj = (
-                    session.query(generic_instance)
-                    .filter_by(euid=euid, is_deleted=False)
-                    .first()
-                )
-                obj_type = "instance"
-
-            if not obj:
-                obj = (
-                    session.query(generic_instance_lineage)
-                    .filter_by(euid=euid, is_deleted=False)
-                    .first()
-                )
-                obj_type = "lineage"
+            obj, obj_type = _find_object_by_euid(session, euid)
 
             if not obj:
                 raise HTTPException(status_code=404, detail=f"Object not found: {euid}")
@@ -2032,6 +2037,7 @@ async def object_detail(request: Request, euid: str):
                 permissions=permissions,
                 obj=obj,
                 obj_type=obj_type,
+                external_refs=_external_ref_payloads(obj),
                 parent_lineages=parent_lineages,
                 child_lineages=child_lineages,
             )
@@ -2044,6 +2050,7 @@ async def graph_view(
     request: Request,
     start_euid: Optional[str] = None,
     depth: int = Query(4, ge=1, le=10),
+    merge_ref: Optional[int] = Query(None, ge=0),
 ):
     """DAG graph visualization."""
     user = request.state.user
@@ -2056,6 +2063,7 @@ async def graph_view(
         permissions=permissions,
         start_euid=start_euid or "",
         depth=depth,
+        merge_ref=merge_ref,
     )
     return HTMLResponse(content=content)
 
@@ -2519,28 +2527,7 @@ async def api_get_object(euid: str):
     """API: Get object by EUID."""
     with get_db() as conn:
         with conn.session_scope() as session:
-            obj = (
-                session.query(generic_template)
-                .filter_by(euid=euid, is_deleted=False)
-                .first()
-            )
-            obj_type = "template"
-
-            if not obj:
-                obj = (
-                    session.query(generic_instance)
-                    .filter_by(euid=euid, is_deleted=False)
-                    .first()
-                )
-                obj_type = "instance"
-
-            if not obj:
-                obj = (
-                    session.query(generic_instance_lineage)
-                    .filter_by(euid=euid, is_deleted=False)
-                    .first()
-                )
-                obj_type = "lineage"
+            obj, obj_type = _find_object_by_euid(session, euid)
 
             if not obj:
                 raise HTTPException(status_code=404, detail=f"Object not found: {euid}")
@@ -2557,7 +2544,66 @@ async def api_get_object(euid: str):
                 "bstatus": obj.bstatus,
                 "json_addl": obj.json_addl,
                 "created_dt": obj.created_dt.isoformat() if obj.created_dt else None,
+                "external_refs": _external_ref_payloads(obj),
             }
+
+
+@app.get("/api/graph/external")
+@require_auth
+async def api_get_external_graph(
+    request: Request,
+    source_euid: str,
+    ref_index: int = Query(..., ge=0),
+    depth: int = Query(4, ge=1, le=10),
+):
+    """Proxy a configured external graph and namespace it for merge-safe rendering."""
+    user = request.state.user
+    with get_db() as conn:
+        conn.app_username = user.get("username")
+        with conn.session_scope() as session:
+            obj, _obj_type = _find_object_by_euid(session, source_euid)
+            if obj is None:
+                raise HTTPException(status_code=404, detail=f"Object not found: {source_euid}")
+            try:
+                ref = get_external_ref_by_index(obj, ref_index)
+            except IndexError as exc:
+                raise HTTPException(status_code=404, detail=str(exc)) from exc
+            try:
+                payload = fetch_remote_graph(request, ref, depth=depth)
+                return namespace_external_graph(
+                    payload,
+                    ref=ref,
+                    ref_index=ref_index,
+                    source_euid=source_euid,
+                )
+            except Exception as exc:
+                raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@app.get("/api/graph/external/object")
+@require_auth
+async def api_get_external_graph_object(
+    request: Request,
+    source_euid: str,
+    ref_index: int = Query(..., ge=0),
+    euid: str = Query(...),
+):
+    """Proxy a configured external object detail payload."""
+    user = request.state.user
+    with get_db() as conn:
+        conn.app_username = user.get("username")
+        with conn.session_scope() as session:
+            obj, _obj_type = _find_object_by_euid(session, source_euid)
+            if obj is None:
+                raise HTTPException(status_code=404, detail=f"Object not found: {source_euid}")
+            try:
+                ref = get_external_ref_by_index(obj, ref_index)
+            except IndexError as exc:
+                raise HTTPException(status_code=404, detail=str(exc)) from exc
+            try:
+                return fetch_remote_object_detail(request, ref, euid=euid)
+            except Exception as exc:
+                raise HTTPException(status_code=502, detail=str(exc)) from exc
 
 
 @app.post("/api/lineage")

--- a/admin/static/js/graph.js
+++ b/admin/static/js/graph.js
@@ -6,6 +6,12 @@ const TAPDB_BASE_PATH =
     typeof window !== 'undefined' && window.TAPDB_BASE_PATH
         ? String(window.TAPDB_BASE_PATH).replace(/\/+$/, '')
         : '';
+const graphBootstrap =
+    typeof window !== 'undefined' && window.TAPDB_GRAPH_BOOTSTRAP
+        ? window.TAPDB_GRAPH_BOOTSTRAP
+        : {};
+let pendingAutoMergeRef =
+    Number.isInteger(graphBootstrap.defaultMergeRef) ? graphBootstrap.defaultMergeRef : null;
 
 function tapdbUrl(path) {
     const normalized = (path || '').startsWith('/') ? path : `/${path}`;
@@ -91,6 +97,14 @@ const cytoscapeStyle = [
         }
     },
     {
+        selector: 'node[is_external]',
+        style: {
+            'border-style': 'dashed',
+            'border-color': '#f0d79d',
+            'background-opacity': 0.78,
+        }
+    },
+    {
         selector: 'edge',
         style: {
             // Directed edges: always render arrowhead on the *target* end.
@@ -106,6 +120,23 @@ const cytoscapeStyle = [
             'target-endpoint': 'outside-to-node',
             'target-distance-from-node': 6,
             'arrow-scale': 1.6,
+        }
+    },
+    {
+        selector: 'edge[is_external]',
+        style: {
+            'line-style': 'dashed',
+            'line-color': '#c1a967',
+            'target-arrow-color': '#c1a967',
+        }
+    },
+    {
+        selector: 'edge[is_external_bridge]',
+        style: {
+            'line-style': 'dotted',
+            'line-color': '#f7c948',
+            'target-arrow-color': '#f7c948',
+            'width': 3,
         }
     },
     {
@@ -263,6 +294,10 @@ function runWaveFromNode(startNode, direction) {
 async function deleteGraphObject(ele) {
     const objectId = ele.data('id');
     const typeLabel = ele.isNode() ? 'node' : 'edge';
+    if (ele.data('is_external') || ele.data('is_external_bridge')) {
+        setStatus(`External ${typeLabel}s are read-only.`, 'warn');
+        return;
+    }
 
     try {
         const response = await fetch(tapdbUrl(`/api/object/${encodeURIComponent(objectId)}`), {
@@ -426,6 +461,10 @@ function initCytoscape(container, elements) {
         const node = evt.target;
         showNodeInfo(node.data());
 
+        if (node.data('is_external')) {
+            return;
+        }
+
         if (pendingLineageChildId) {
             const childId = pendingLineageChildId;
             const parentId = node.id();
@@ -500,6 +539,9 @@ function initCytoscape(container, elements) {
 
     // Double-click to navigate.
     cy.on('dbltap', 'node', function(evt) {
+        if (evt.target.data('is_external')) {
+            return;
+        }
         const euid = evt.target.data('id');
         window.location.href = '/object/' + euid;
     });
@@ -535,6 +577,61 @@ function topLevelRowValue(key, value) {
         return `<code>${escapeHtml(JSON.stringify(value))}</code>`;
     }
     return escapeHtml(String(value));
+}
+
+function currentDepth() {
+    const raw = document.getElementById('depth')?.value || '4';
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : 4;
+}
+
+function buildExternalGraphUrl(sourceEuid, refIndex) {
+    const params = new URLSearchParams({
+        source_euid: sourceEuid,
+        ref_index: String(refIndex),
+        depth: String(currentDepth()),
+    });
+    return `${tapdbUrl('/api/graph/external')}?${params.toString()}`;
+}
+
+function buildExternalObjectUrl(sourceEuid, refIndex, euid) {
+    const params = new URLSearchParams({
+        source_euid: sourceEuid,
+        ref_index: String(refIndex),
+        euid,
+    });
+    return `${tapdbUrl('/api/graph/external/object')}?${params.toString()}`;
+}
+
+function renderExternalRefs(refs, sourceEuid, allowMerge) {
+    if (!Array.isArray(refs) || refs.length === 0) {
+        return '';
+    }
+    const rows = refs.map((ref) => {
+        const openRemote = ref.href
+            ? `<a href="${escapeHtml(ref.href)}" class="btn" target="_blank" rel="noreferrer">Open Remote</a>`
+            : '';
+        const mergeButton = allowMerge
+            ? `<button class="btn" onclick="mergeExternalRef('${escapeHtml(sourceEuid)}', ${Number(ref.ref_index || 0)})"` +
+                `${ref.graph_expandable ? '' : ' disabled'}` +
+                `>Merge External Graph</button>`
+            : '';
+        const disabledReason = !ref.graph_expandable && ref.reason
+            ? `<div style="color: var(--text-muted); font-size: 0.8rem;">${escapeHtml(ref.reason)}</div>`
+            : '';
+        return `
+            <div style="border:1px solid var(--border-color); border-radius:6px; padding:0.65rem; margin-bottom:0.6rem;">
+                <div style="font-weight:600;">${escapeHtml(ref.label || ref.root_euid || 'External reference')}</div>
+                <div style="font-size:0.82rem; color:var(--text-muted); margin:0.25rem 0 0.5rem 0;">
+                    ${escapeHtml(ref.system || 'external')} :: ${escapeHtml(ref.root_euid || '-')}
+                    ${ref.tenant_id ? ` :: ${escapeHtml(ref.tenant_id)}` : ''}
+                </div>
+                <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">${openRemote}${mergeButton}</div>
+                ${disabledReason}
+            </div>
+        `;
+    }).join('');
+    return `<div class="details-section-title">External References</div>${rows}`;
 }
 
 function renderDetailsPanel({ euid, objectData, graphData, isNode }) {
@@ -579,10 +676,19 @@ function renderDetailsPanel({ euid, objectData, graphData, isNode }) {
     const jsonPayload = Object.prototype.hasOwnProperty.call(merged, 'json_addl')
         ? merged.json_addl
         : {};
+    const externalRefs = Array.isArray(merged.external_refs) ? merged.external_refs : [];
+    const canRenderExternalRefs = isNode && !(graphData && graphData.is_external);
+    const sourceEuid = graphData && graphData.external_source_euid ? graphData.external_source_euid : euid;
+    const externalRefSection = renderExternalRefs(externalRefs, sourceEuid, canRenderExternalRefs);
+    const canViewLocalDetail = !(graphData && graphData.is_external);
 
     const actions = `
         <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.8rem;">
-            <a href="${tapdbUrl(`/object/${encodeURIComponent(euid)}`)}" class="btn">View Details</a>
+            ${
+                canViewLocalDetail
+                    ? `<a href="${tapdbUrl(`/object/${encodeURIComponent(euid)}`)}" class="btn">View Details</a>`
+                    : ''
+            }
             ${
                 isNode
                     ? `<button onclick="centerOnNode('${escapeHtml(euid)}')" class="btn">Center on Node</button>`
@@ -597,6 +703,7 @@ function renderDetailsPanel({ euid, objectData, graphData, isNode }) {
         <div class="details-grid">${topLevelRows || '<span style="color: var(--text-muted);">No properties.</span>'}</div>
         <div class="details-section-title">Raw Object JSON</div>
         <pre class="json-block">${escapeHtml(prettyJson(rawObjectPayload))}</pre>
+        ${externalRefSection}
         <div class="details-section-title">JSON (json_addl)</div>
         <pre class="json-block">${escapeHtml(prettyJson(jsonPayload))}</pre>
         <div class="details-section-title">Graph Payload</div>
@@ -616,15 +723,79 @@ async function fetchObjectData(euid) {
     return response.json();
 }
 
+async function fetchExternalObjectData(sourceEuid, refIndex, euid) {
+    const response = await fetch(buildExternalObjectUrl(sourceEuid, refIndex, euid), {
+        headers: {
+            Accept: 'application/json',
+        },
+    });
+    if (!response.ok) {
+        let payload = {};
+        try {
+            payload = await response.json();
+        } catch (_err) {
+            payload = {};
+        }
+        throw new Error(payload.detail || `Failed to load external object details (${response.status})`);
+    }
+    return response.json();
+}
+
+async function mergeExternalRef(sourceEuid, refIndex) {
+    if (!cy) {
+        setStatus('Load a graph before merging an external reference.', 'warn');
+        return;
+    }
+
+    try {
+        const response = await fetch(buildExternalGraphUrl(sourceEuid, refIndex), {
+            headers: { Accept: 'application/json' },
+        });
+        const payload = await response.json();
+        if (!response.ok) {
+            throw new Error(payload.detail || `Failed to merge external graph (${response.status})`);
+        }
+
+        const elements = payload.elements || {};
+        const nodes = Array.isArray(elements.nodes) ? elements.nodes : [];
+        const edges = Array.isArray(elements.edges) ? elements.edges : [];
+        const existingIds = new Set(cy.elements().map((ele) => ele.id()));
+        const additions = [];
+        [...nodes, ...edges].forEach((element) => {
+            const id = element && element.data ? element.data.id : null;
+            if (!id || existingIds.has(id)) {
+                return;
+            }
+            additions.push(element);
+            existingIds.add(id);
+        });
+
+        if (additions.length === 0) {
+            setStatus('External graph already merged.', 'warn');
+            return;
+        }
+
+        cy.add(additions);
+        applyLayout();
+        refreshLegendFromCurrentGraph();
+        setStatus(`Merged external graph for ${sourceEuid}.`, 'ok');
+    } catch (error) {
+        console.error('Failed to merge external graph:', error);
+        setStatus(`External merge failed: ${error.message}`, 'error');
+    }
+}
+
 async function showNodeInfo(data) {
     const content = document.getElementById('node-info-content');
     if (content) {
         content.innerHTML = '<p style="color: var(--text-muted);">Loading node details...</p>';
     }
     try {
-        const objectData = await fetchObjectData(data.id);
+        const objectData = data.is_external
+            ? await fetchExternalObjectData(data.external_source_euid, data.source_ref_index, data.remote_euid || data.id)
+            : await fetchObjectData(data.id);
         renderDetailsPanel({
-            euid: data.id,
+            euid: data.is_external ? (data.remote_euid || data.id) : data.id,
             objectData,
             graphData: data,
             isNode: true,
@@ -653,9 +824,11 @@ async function showEdgeInfo(data) {
         content.innerHTML = '<p style="color: var(--text-muted);">Loading edge details...</p>';
     }
     try {
-        const objectData = await fetchObjectData(data.id);
+        const objectData = (data.is_external || data.is_external_bridge) && data.remote_euid
+            ? await fetchExternalObjectData(data.external_source_euid, data.source_ref_index, data.remote_euid)
+            : await fetchObjectData(data.id);
         renderDetailsPanel({
-            euid: data.id,
+            euid: (data.is_external || data.is_external_bridge) ? (data.remote_euid || data.id) : data.id,
             objectData,
             graphData: data,
             isNode: false,
@@ -745,6 +918,11 @@ async function loadGraph() {
         // Update URL without reload.
         const newUrl = tapdbUrl('/graph') + '?start_euid=' + encodeURIComponent(startEuid) + '&depth=' + depth;
         window.history.replaceState({}, '', newUrl);
+        if (pendingAutoMergeRef !== null && startEuid) {
+            const mergeRef = pendingAutoMergeRef;
+            pendingAutoMergeRef = null;
+            await mergeExternalRef(startEuid, mergeRef);
+        }
 
     } catch (error) {
         console.error('Error loading graph:', error);
@@ -760,18 +938,24 @@ function updateLegend(typesInGraph) {
         return;
     }
 
+    const staticItems = [
+        '<div class="legend-item"><div class="legend-color" style="background:#666"></div>Local</div>',
+        '<div class="legend-item"><div class="legend-color" style="background:#c1a967"></div>External</div>',
+        '<div class="legend-item"><div class="legend-color" style="background:#f7c948"></div>Bridge</div>',
+    ];
     if (Object.keys(typesInGraph).length === 0) {
-        legendContainer.innerHTML = '<span style="color: var(--text-muted); font-size: 0.85rem;">No nodes in graph</span>';
+        legendContainer.innerHTML = staticItems.join('');
         return;
     }
 
-    // Sort types alphabetically.
     const sortedTypes = Object.keys(typesInGraph).sort();
 
-    legendContainer.innerHTML = sortedTypes.map((type) => `
+    legendContainer.innerHTML = staticItems.join('') + sortedTypes.map((type) => `
         <div class="legend-item">
             <div class="legend-color" style="background:${typesInGraph[type]}"></div>
             ${type}
         </div>
     `).join('');
 }
+
+window.mergeExternalRef = mergeExternalRef;

--- a/admin/templates/graph.html
+++ b/admin/templates/graph.html
@@ -314,6 +314,11 @@
 {% endblock %}
 
 {% block scripts %}
+<script>
+    window.TAPDB_GRAPH_BOOTSTRAP = {
+        defaultMergeRef: {{ merge_ref | tojson }}
+    };
+</script>
 <script src="{{ tapdb_url(request, '/static/js/graph.js') }}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {

--- a/admin/templates/object_detail.html
+++ b/admin/templates/object_detail.html
@@ -42,6 +42,36 @@
 </div>
 {% endif %}
 
+{% if external_refs %}
+<div class="card">
+    <h2 class="card-title">External References</h2>
+    <table>
+        <thead>
+            <tr><th>Label</th><th>System</th><th>Root EUID</th><th>Tenant</th><th>Actions</th></tr>
+        </thead>
+        <tbody>
+            {% for ref in external_refs %}
+            <tr>
+                <td>{{ ref.label }}</td>
+                <td>{{ ref.system }}</td>
+                <td><code>{{ ref.root_euid }}</code></td>
+                <td>{{ ref.tenant_id or '-' }}</td>
+                <td style="display:flex; gap:0.5rem; flex-wrap:wrap;">
+                    {% if ref.href %}
+                    <a href="{{ ref.href }}" class="btn" target="_blank" rel="noreferrer">Open Remote</a>
+                    {% endif %}
+                    <a href="{{ tapdb_url(request, '/graph') }}?start_euid={{ obj.euid }}&depth=4&merge_ref={{ ref.ref_index }}" class="btn">Open In Graph</a>
+                    {% if not ref.graph_expandable %}
+                    <span style="color: var(--text-muted);">{{ ref.reason or 'Graph expansion unavailable' }}</span>
+                    {% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endif %}
+
 {% if obj_type == 'instance' %}
 <div class="card">
     <h2 class="card-title">Parent Relationships ({{ parent_lineages | length }})</h2>

--- a/tests/test_admin_routes_smoke.py
+++ b/tests/test_admin_routes_smoke.py
@@ -312,7 +312,7 @@ def route_client(monkeypatch: pytest.MonkeyPatch):
         "get_template",
         lambda name: _FakeTemplateRender(name, state),
     )
-    monkeypatch.setattr(admin_main, "get_style", lambda: {"skin_css": "x.css"})
+    monkeypatch.setattr(admin_main, "get_style", lambda *_args, **_kwargs: {"skin_css": "x.css"})
     monkeypatch.setattr(admin_main, "get_db", lambda: _FakeConn(state))
     monkeypatch.setattr(admin_main, "get_user_permissions", lambda _u: {"ok": True})
     monkeypatch.setattr(admin_main, "get_user_by_username", lambda _u: None)
@@ -584,6 +584,45 @@ def test_protected_html_and_api_routes(route_client, monkeypatch: pytest.MonkeyP
     resp = client.delete("/api/object/GT1")
     assert resp.status_code == 200
     assert state["templates"][0].is_deleted is True
+
+
+def test_api_object_detail_includes_external_refs(route_client, monkeypatch: pytest.MonkeyPatch):
+    client, state = route_client
+
+    async def _admin_auth_user(_request):
+        return _admin_user()
+
+    monkeypatch.setattr(auth_mod, "get_current_user", _admin_auth_user)
+    state["instances"][0].json_addl = {
+        "properties": {
+            "external_payload": {
+                "tapdb_graph": {
+                    "system": "atlas",
+                    "base_url": "https://atlas.local",
+                    "root_euid": "AT-PAT-1",
+                    "tenant_id": "atlas-tenant-1",
+                    "graph_data_path": "/api/graph/data",
+                    "object_detail_path_template": "/api/graph/object/{euid}",
+                    "auth_mode": "none",
+                }
+            }
+        }
+    }
+
+    resp = client.get("/api/object/GX11")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["external_refs"] == [
+        {
+            "label": "atlas:AT-PAT-1",
+            "system": "atlas",
+            "root_euid": "AT-PAT-1",
+            "tenant_id": "atlas-tenant-1",
+            "href": "https://atlas.local/api/graph/object/AT-PAT-1",
+            "graph_expandable": True,
+            "ref_index": 0,
+        }
+    ]
 
 
 def test_home_query_and_audit_panels_admin(


### PR DESCRIPTION
## Summary
- add shared external-graph reference resolution for TapDB admin objects
- surface external graph links on the admin object detail and graph pages
- extend the admin smoke coverage for the new graph affordances

## Testing
- pytest tests/test_admin_routes_smoke.py -q