### PR TITLE
docs: clarify scm-based release versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,11 @@ jobs:
           pip install build
           pip install -e ".[dev,cli,aurora,admin]"
 
+      - name: Show SCM version context
+        run: |
+          git describe --tags --dirty --always
+          python -m setuptools_scm
+
       - name: Build wheel artifact
         run: python -m build --wheel
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,26 @@ Optional convenience wrapper:
 source tapdb_activate.sh
 ```
 
+## Release Versioning
+
+Package versions are derived from Git tags via `setuptools_scm`.
+
+- An exact tagged commit builds the exact release version.
+- Commits after the latest tag build the next inferred version with a `.devN`
+  suffix, where `N` is the commit count since that tag.
+- Local version metadata is disabled, so builds do not append Git hashes to the
+  published version string.
+
+Examples:
+
+- `git describe` = `0.2.5` -> build version `0.2.5`
+- `git describe` = `0.2.5-2-g1774465` -> build version `0.2.6.dev2`
+
+For release artifacts, run `git describe --tags --dirty --always` before
+`python -m build` and build from the exact release tag. If `HEAD` includes
+additional commits that should be released, create a new tag on that commit
+first.
+
 ## Quick Start
 
 Initialize a strict namespace and bootstrap a local stack:


### PR DESCRIPTION
## Summary
- document setuptools_scm release version behavior
- show SCM version context in CI before wheel builds

## Testing
- python -m setuptools_scm
- python -m build --wheel
