### PR TITLE
chore: bump daylily-cognito[auth] to >=0.1.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ admin = [
     "jinja2",
     "python-multipart",
     "itsdangerous",
-    "daylily-cognito[auth]>=0.1.24",
+    "daylily-cognito[auth]>=0.1.26",
     # passlib 1.7.x is not compatible with bcrypt>=4 (bcrypt enforces 72-byte
     # password max and passlib's backend self-test uses a longer sentinel).
     # Pin to bcrypt<4 to keep admin auth usable.


### PR DESCRIPTION
Bumps daylily-cognito[auth] dependency from >=0.1.24 to >=0.1.26.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author