### PR TITLE
Use daylily-auth-cognito in TapDB auth surfaces

### DIFF
--- a/AI_DIRECTIVE.md
+++ b/AI_DIRECTIVE.md
@@ -81,7 +81,7 @@ Use these functional groups only:
 
 6. `tapdb cognito`
 - Cognito lifecycle and validation flows.
-- Integrates TAPDB config with `daylily-cognito` (`daycog`) config files.
+- Integrates TAPDB config with `daylily-auth-cognito` (`daycog`) config files.
 
 ## Bootstrap-First Workflow
 Preferred setup path:
@@ -221,10 +221,8 @@ Agent requirements:
 TAPDB config stores only the pool reference per environment:
 - `environments.<env>.cognito_user_pool_id`
 
-All Cognito app/client/domain auth context is managed in daycog files under:
-- `~/.config/daycog/<pool>.<region>.env`
-- `~/.config/daycog/<pool>.<region>.<app>.env`
-- `~/.config/daycog/default.env`
+All Cognito app/client/domain auth context is managed in the Daycog flat config file:
+- `~/.config/daycog/config.yaml`
 
 Operational requirements:
 1. Use app client name `tapdb` for TAPDB UI.

--- a/admin/auth.py
+++ b/admin/auth.py
@@ -225,7 +225,7 @@ def get_user_by_uid(user_uid: int | str) -> Optional[dict]:
 
 
 def authenticate_with_cognito(username_or_email: str, password: str) -> dict:
-    """Authenticate against Cognito using daylily-cognito."""
+    """Authenticate against Cognito using daylily-auth-cognito."""
     auth = get_cognito_auth()
     return auth.authenticate(email=username_or_email, password=password)
 

--- a/daylily_tapdb/cli/cognito.py
+++ b/daylily_tapdb/cli/cognito.py
@@ -1,6 +1,6 @@
 """TAPDB Cognito integration commands.
 
-Operational lifecycle is delegated to the daylily-cognito CLI (`daycog`).
+Operational lifecycle is delegated to the daylily-auth-cognito CLI (`daycog`).
 TAPDB stores only Cognito pool ID in tapdb config.
 """
 

--- a/docs/runtime-and-cli.md
+++ b/docs/runtime-and-cli.md
@@ -68,7 +68,7 @@ That split is deliberate:
 - `db` manages database lifecycle, schema, migrations, backup, and data seeding.
 - `ui` manages the admin server process.
 - `bootstrap` is the one-command orchestration path.
-- `cognito` is the TAPDB-side bridge to `daylily-cognito`.
+- `cognito` is the TAPDB-side bridge to `daylily-auth-cognito`.
 - `aurora` is optional cloud infrastructure support.
 
 ## Local Lifecycle

--- a/docs/specs_and_plans/tapdb_core_refactor_spec_for_codex.md
+++ b/docs/specs_and_plans/tapdb_core_refactor_spec_for_codex.md
@@ -128,7 +128,7 @@ Keep `admin` as a separate optional extra, but make it conceptually sit on top o
 
 - `admin`
   - includes `fastapi` and admin-specific dependencies
-  - includes `uvicorn`, `jinja2`, `python-multipart`, `itsdangerous`, `daylily-cognito[auth]`, password/auth deps, etc.
+  - includes `uvicorn`, `jinja2`, `python-multipart`, `itsdangerous`, `daylily-auth-cognito`, password/auth deps, etc.
 
 ### Packaging rules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ admin = [
     "jinja2",
     "python-multipart",
     "itsdangerous",
-    "daylily-cognito[auth]>=1.2.0",
+    "daylily-auth-cognito==2.0.1",
     # passlib 1.7.x is not compatible with bcrypt>=4 (bcrypt enforces 72-byte
     # password max and passlib's backend self-test uses a longer sentinel).
     # Pin to bcrypt<4 to keep admin auth usable.


### PR DESCRIPTION
Summary:\n- replace the legacy daylily-cognito dependency in TapDB's admin/auth surfaces\n- align active docs with the current daycog flat config model\n\nValidation:\n- source ./activate && python -m pytest tests/test_cli_cognito_floor_lift.py -q