### PR TITLE
[codex] Update CLI and Cognito dependency pins

### DIFF
--- a/activate
+++ b/activate
@@ -207,7 +207,7 @@ if [ ! -x "${_tapdb_tapdb}" ] || ! _tapdb_distribution_is_editable_from_repo "${
     fi
 fi
 
-_tapdb_cli_core_yo_version="2.1.0"
+_tapdb_cli_core_yo_version="2.1.1"
 if ! _tapdb_distribution_is_published "cli-core-yo" "${_tapdb_cli_core_yo_version}"; then
     if [ "${_tapdb_smoke}" = "1" ]; then
         printf "${_tapdb_yellow}⚠${_tapdb_reset} cli-core-yo must be installed as published %s.\n" "${_tapdb_cli_core_yo_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,13 +32,13 @@ dependencies = [
     "typer",
     "rich",
     "uuid6>=2024.1.12",
-    "cli-core-yo==2.1.0",
+    "cli-core-yo==2.1.1",
     "meridian-euid>=0.4.1,<0.4.3",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "cli-core-yo==2.1.0",
+    "cli-core-yo==2.1.1",
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "black>=23.0",
@@ -77,7 +77,7 @@ admin = [
     "jinja2",
     "python-multipart",
     "itsdangerous",
-    "daylily-auth-cognito==2.1.1",
+    "daylily-auth-cognito==2.1.4",
     # passlib 1.7.x is not compatible with bcrypt>=4 (bcrypt enforces 72-byte
     # password max and passlib's backend self-test uses a longer sentinel).
     # Pin to bcrypt<4 to keep admin auth usable.

--- a/tests/test_activation_metadata.py
+++ b/tests/test_activation_metadata.py
@@ -15,9 +15,9 @@ def test_pyproject_pins_published_cli_core_yo() -> None:
     dev_dependencies = data["project"]["optional-dependencies"]["dev"]
     admin_dependencies = data["project"]["optional-dependencies"]["admin"]
 
-    assert "cli-core-yo==2.1.0" in dependencies
-    assert "cli-core-yo==2.1.0" in dev_dependencies
-    assert "daylily-auth-cognito==2.1.1" in admin_dependencies
+    assert "cli-core-yo==2.1.1" in dependencies
+    assert "cli-core-yo==2.1.1" in dev_dependencies
+    assert "daylily-auth-cognito==2.1.4" in admin_dependencies
     assert all("daylily-cognito" not in dependency for dependency in admin_dependencies)
 
 
@@ -31,6 +31,6 @@ def test_activate_uses_published_cli_core_yo_metadata_check() -> None:
     assert "_tapdb_module_is_from_repo" not in text
     assert "--smoke" in text
     assert 'python -m pip install -e ".[cli,admin,aurora,dev]"' in text
-    assert '_tapdb_cli_core_yo_version="2.1.0"' in text
+    assert '_tapdb_cli_core_yo_version="2.1.1"' in text
     assert "cli-core-yo==${_tapdb_cli_core_yo_version}" in text
     assert "cli-core-yo is not installed as published" in text


### PR DESCRIPTION
## Summary

Updates TapDB dependency pins to:

- `cli-core-yo==2.1.1`
- `daylily-auth-cognito==2.1.4`

Also updates the activation metadata tests so the dependency contract stays explicit.

## Validation

- `python -m pytest tests/test_activation_metadata.py -q`
- `ruff check daylily_tapdb/ admin/ tests/`
- `ruff format --check daylily_tapdb/ admin/ tests/`
- `bandit -c pyproject.toml -r daylily_tapdb/ admin/`
- `source ./activate && python -m pytest tests/ -q --deselect tests/test_admin_routes_smoke.py`

Local full-suite result: `772 passed, 15 skipped, 15 deselected`.