### PR TITLE
Update Cognito dependency pin to 2.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ admin = [
     "jinja2",
     "python-multipart",
     "itsdangerous",
-    "daylily-auth-cognito==2.1.4",
+    "daylily-auth-cognito==2.1.5",
     # passlib 1.7.x is not compatible with bcrypt>=4 (bcrypt enforces 72-byte
     # password max and passlib's backend self-test uses a longer sentinel).
     # Pin to bcrypt<4 to keep admin auth usable.

--- a/tests/test_activation_metadata.py
+++ b/tests/test_activation_metadata.py
@@ -17,7 +17,7 @@ def test_pyproject_pins_published_cli_core_yo() -> None:
 
     assert "cli-core-yo==2.1.1" in dependencies
     assert "cli-core-yo==2.1.1" in dev_dependencies
-    assert "daylily-auth-cognito==2.1.4" in admin_dependencies
+    assert "daylily-auth-cognito==2.1.5" in admin_dependencies
     assert all("daylily-cognito" not in dependency for dependency in admin_dependencies)
 
 


### PR DESCRIPTION
## Summary
- update the admin extra to daylily-auth-cognito==2.1.5
- update activation metadata coverage to assert the fixed Cognito release

## Validation
- ruff check daylily_tapdb/ admin/ tests/
- ruff format --check daylily_tapdb/ admin/ tests/
- bandit -c pyproject.toml -r daylily_tapdb/ admin/
- python -m pytest tests/ -q --deselect tests/test_admin_routes_smoke.py