### PR TITLE
Add TapDB DAG object search

### DIFF
--- a/daylily_tapdb/services/__init__.py
+++ b/daylily_tapdb/services/__init__.py
@@ -15,6 +15,7 @@ from daylily_tapdb.services.graph_payloads import (
     build_object_detail_payload,
 )
 from daylily_tapdb.services.object_lookup import find_object_by_euid
+from daylily_tapdb.services.object_search import search_objects
 
 __all__ = [
     "ALLOWED_AUTH_MODES",
@@ -28,4 +29,5 @@ __all__ = [
     "get_external_ref_by_index",
     "namespace_external_graph",
     "resolve_external_graph_refs",
+    "search_objects",
 ]

--- a/daylily_tapdb/services/external_refs.py
+++ b/daylily_tapdb/services/external_refs.py
@@ -12,6 +12,12 @@ from urllib.request import urlopen
 from fastapi import Request
 
 ALLOWED_AUTH_MODES = {"none", "same_origin"}
+TYPED_EXTERNAL_IDENTIFIER_MARKERS = {
+    "external_identifier",
+    "external_id",
+    "external_reference",
+    "tapdb_external_identifier",
+}
 
 
 @dataclass(frozen=True)
@@ -73,8 +79,95 @@ def _compose_object_href(
     return urljoin(base_url.rstrip("/") + "/", relative.lstrip("/"))
 
 
+def _external_ref_from_item(raw: Any) -> ExternalGraphRef:
+    item = _as_dict(raw)
+    system = _clean(
+        item.get("system")
+        or item.get("target_system")
+        or item.get("service")
+        or item.get("service_id")
+    )
+    root_euid = _clean(
+        item.get("root_euid")
+        or item.get("target_euid")
+        or item.get("remote_euid")
+        or item.get("value")
+        or item.get("euid")
+    )
+    tenant_id = _clean(item.get("tenant_id")) or None
+    base_url = _clean(item.get("base_url")) or None
+    graph_data_path = _clean(item.get("graph_data_path")) or None
+    object_detail_path_template = (
+        _clean(item.get("object_detail_path_template")) or None
+    )
+    auth_mode = _clean(item.get("auth_mode")) or "none"
+    href = _clean(item.get("href")) or None
+    if not href and base_url and object_detail_path_template and root_euid:
+        href = _compose_object_href(
+            base_url=base_url,
+            object_detail_path_template=object_detail_path_template,
+            root_euid=root_euid,
+        )
+
+    graph_expandable = True
+    reason: str | None = None
+    missing: list[str] = []
+    if not system:
+        missing.append("system")
+    if not root_euid:
+        missing.append("root_euid")
+    if not base_url:
+        missing.append("base_url")
+    if not graph_data_path:
+        missing.append("graph_data_path")
+    if not object_detail_path_template:
+        missing.append("object_detail_path_template")
+    if auth_mode not in ALLOWED_AUTH_MODES:
+        missing.append("auth_mode")
+    if missing:
+        graph_expandable = False
+        reason = "Missing required graph metadata: " + ", ".join(missing)
+
+    label = _clean(item.get("label")) or (
+        f"{system}:{root_euid}" if system and root_euid else "external reference"
+    )
+    return ExternalGraphRef(
+        label=label,
+        system=system or "external",
+        root_euid=root_euid,
+        tenant_id=tenant_id,
+        href=href,
+        graph_expandable=graph_expandable,
+        reason=reason,
+        base_url=base_url,
+        graph_data_path=graph_data_path,
+        object_detail_path_template=object_detail_path_template,
+        auth_mode=auth_mode,
+    )
+
+
+def _typed_external_identifier_items(obj: Any, properties: dict[str, Any]) -> list[Any]:
+    raw = (
+        properties.get("tapdb_external_identifier")
+        or properties.get("external_identifier")
+        or properties.get("external_reference")
+    )
+    if isinstance(raw, list):
+        return list(raw)
+    if isinstance(raw, dict):
+        return [raw]
+    markers = {
+        _clean(getattr(obj, "category", None)).lower(),
+        _clean(getattr(obj, "type", None)).lower(),
+        _clean(getattr(obj, "subtype", None)).lower(),
+    }
+    if markers & TYPED_EXTERNAL_IDENTIFIER_MARKERS:
+        return [properties]
+    return []
+
+
 def resolve_external_graph_refs(obj: Any) -> list[ExternalGraphRef]:
-    """Parse explicit `external_payload.tapdb_graph` refs from object JSON."""
+    """Parse explicit external graph refs and typed external identifier objects."""
 
     json_addl = _as_dict(getattr(obj, "json_addl", None))
     properties = _as_dict(json_addl.get("properties"))
@@ -87,64 +180,17 @@ def resolve_external_graph_refs(obj: Any) -> list[ExternalGraphRef]:
         refs_raw = [tapdb_graph]
     else:
         refs_raw = []
+    refs_raw.extend(_typed_external_identifier_items(obj, properties))
 
     refs: list[ExternalGraphRef] = []
+    seen: set[tuple[str, str, str | None]] = set()
     for raw in refs_raw:
-        item = _as_dict(raw)
-        system = _clean(item.get("system"))
-        root_euid = _clean(item.get("root_euid"))
-        tenant_id = _clean(item.get("tenant_id")) or None
-        base_url = _clean(item.get("base_url")) or None
-        graph_data_path = _clean(item.get("graph_data_path")) or None
-        object_detail_path_template = (
-            _clean(item.get("object_detail_path_template")) or None
-        )
-        auth_mode = _clean(item.get("auth_mode")) or "none"
-        href = _clean(item.get("href")) or None
-        if not href and base_url and object_detail_path_template and root_euid:
-            href = _compose_object_href(
-                base_url=base_url,
-                object_detail_path_template=object_detail_path_template,
-                root_euid=root_euid,
-            )
-
-        graph_expandable = True
-        reason: str | None = None
-        missing: list[str] = []
-        if not system:
-            missing.append("system")
-        if not root_euid:
-            missing.append("root_euid")
-        if not base_url:
-            missing.append("base_url")
-        if not graph_data_path:
-            missing.append("graph_data_path")
-        if not object_detail_path_template:
-            missing.append("object_detail_path_template")
-        if auth_mode not in ALLOWED_AUTH_MODES:
-            missing.append("auth_mode")
-        if missing:
-            graph_expandable = False
-            reason = "Missing required graph metadata: " + ", ".join(missing)
-
-        label = _clean(item.get("label")) or (
-            f"{system}:{root_euid}" if system and root_euid else "external reference"
-        )
-        refs.append(
-            ExternalGraphRef(
-                label=label,
-                system=system or "external",
-                root_euid=root_euid,
-                tenant_id=tenant_id,
-                href=href,
-                graph_expandable=graph_expandable,
-                reason=reason,
-                base_url=base_url,
-                graph_data_path=graph_data_path,
-                object_detail_path_template=object_detail_path_template,
-                auth_mode=auth_mode,
-            )
-        )
+        ref = _external_ref_from_item(raw)
+        key = (ref.system, ref.root_euid, ref.tenant_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        refs.append(ref)
 
     refs.sort(
         key=lambda ref: (ref.system, ref.label, ref.root_euid, ref.tenant_id or "")

--- a/daylily_tapdb/services/graph_payloads.py
+++ b/daylily_tapdb/services/graph_payloads.py
@@ -78,6 +78,7 @@ def _node_payload(
             "subtype": getattr(obj, "subtype", None),
             "href": f"/object/{getattr(obj, 'euid', '')}",
             "color": _CATEGORY_COLORS.get(category, _CATEGORY_COLORS["generic"]),
+            "external_refs": external_ref_payloads(obj),
         }
     }
 

--- a/daylily_tapdb/services/object_search.py
+++ b/daylily_tapdb/services/object_search.py
@@ -1,0 +1,189 @@
+"""Reusable TapDB object search for DAG federation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from daylily_tapdb.models.instance import generic_instance
+from daylily_tapdb.models.lineage import generic_instance_lineage
+from daylily_tapdb.models.template import generic_template
+
+SEARCH_RECORD_TYPES = {"all", "template", "instance", "lineage"}
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _lower(value: Any) -> str:
+    return _clean(value).lower()
+
+
+def _iso(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        return value.isoformat()
+    except Exception:
+        return _clean(value) or None
+
+
+def _record_type(value: Any) -> str:
+    normalized = _lower(value) or "all"
+    return normalized if normalized in SEARCH_RECORD_TYPES else "all"
+
+
+def _matches_text(row: Any, q: str) -> bool:
+    if not q:
+        return True
+    haystack = " ".join(
+        _lower(getattr(row, name, None))
+        for name in (
+            "euid",
+            "name",
+            "category",
+            "type",
+            "subtype",
+            "version",
+            "bstatus",
+            "relationship_type",
+        )
+    )
+    return q in haystack
+
+
+def _matches_filters(
+    row: Any,
+    *,
+    q: str,
+    euid: str,
+    category: str,
+    type_name: str,
+    subtype: str,
+    tenant_id: str,
+    relationship_type: str,
+) -> bool:
+    if q and not _matches_text(row, q):
+        return False
+    if euid and _lower(getattr(row, "euid", None)) != euid:
+        return False
+    if category and _lower(getattr(row, "category", None)) != category:
+        return False
+    if type_name and _lower(getattr(row, "type", None)) != type_name:
+        return False
+    if subtype and _lower(getattr(row, "subtype", None)) != subtype:
+        return False
+    if tenant_id and _lower(getattr(row, "tenant_id", None)) != tenant_id:
+        return False
+    if (
+        relationship_type
+        and _lower(getattr(row, "relationship_type", None)) != relationship_type
+    ):
+        return False
+    return True
+
+
+def _to_search_result(
+    row: Any, *, record_type: str, service_name: str
+) -> dict[str, Any]:
+    euid = getattr(row, "euid", None)
+    name = getattr(row, "name", None)
+    return {
+        "system": service_name,
+        "service": service_name,
+        "record_type": record_type,
+        "kind": record_type,
+        "uid": getattr(row, "uid", None),
+        "euid": euid,
+        "name": name,
+        "display_label": name or euid,
+        "category": getattr(row, "category", None),
+        "type": getattr(row, "type", None),
+        "subtype": getattr(row, "subtype", None),
+        "version": getattr(row, "version", None),
+        "bstatus": getattr(row, "bstatus", None),
+        "tenant_id": _clean(getattr(row, "tenant_id", None)) or None,
+        "relationship_type": getattr(row, "relationship_type", None),
+        "href": f"/object/{euid or ''}",
+        "graph_href": f"/api/dag/data?start_euid={euid or ''}",
+        "created_dt": _iso(getattr(row, "created_dt", None)),
+        "modified_dt": _iso(getattr(row, "modified_dt", None)),
+    }
+
+
+def search_objects(
+    session: Any,
+    *,
+    service_name: str,
+    q: str = "",
+    euid: str = "",
+    record_type: str = "all",
+    category: str = "",
+    type_name: str = "",
+    subtype: str = "",
+    tenant_id: str = "",
+    relationship_type: str = "",
+    limit: int = 25,
+) -> dict[str, Any]:
+    """Search TapDB objects across templates, instances, and lineages."""
+
+    normalized_record_type = _record_type(record_type)
+    selected = (
+        ["template", "instance", "lineage"]
+        if normalized_record_type == "all"
+        else [normalized_record_type]
+    )
+    normalized_limit = max(1, min(100, int(limit or 25)))
+    filters = {
+        "q": _lower(q),
+        "euid": _lower(euid),
+        "record_type": normalized_record_type,
+        "category": _lower(category),
+        "type": _lower(type_name),
+        "subtype": _lower(subtype),
+        "tenant_id": _lower(tenant_id),
+        "relationship_type": _lower(relationship_type),
+        "limit": normalized_limit,
+    }
+    models = {
+        "template": generic_template,
+        "instance": generic_instance,
+        "lineage": generic_instance_lineage,
+    }
+
+    results: list[dict[str, Any]] = []
+    for kind in selected:
+        rows = session.query(models[kind]).filter_by(is_deleted=False).all()
+        for row in rows:
+            if _matches_filters(
+                row,
+                q=filters["q"],
+                euid=filters["euid"],
+                category=filters["category"],
+                type_name=filters["type"],
+                subtype=filters["subtype"],
+                tenant_id=filters["tenant_id"],
+                relationship_type=filters["relationship_type"],
+            ):
+                results.append(
+                    _to_search_result(row, record_type=kind, service_name=service_name)
+                )
+
+    results.sort(
+        key=lambda item: (
+            str(item.get("created_dt") or ""),
+            str(item.get("record_type") or ""),
+            str(item.get("euid") or ""),
+        ),
+        reverse=True,
+    )
+    trimmed = results[:normalized_limit]
+    return {
+        "items": trimmed,
+        "page": {
+            "limit": normalized_limit,
+            "total": len(results),
+            "next_cursor": None,
+        },
+        "filters": filters,
+    }

--- a/daylily_tapdb/web/dag.py
+++ b/daylily_tapdb/web/dag.py
@@ -18,6 +18,7 @@ from daylily_tapdb.services.graph_payloads import (
     build_object_detail_payload,
 )
 from daylily_tapdb.services.object_lookup import find_object_by_euid
+from daylily_tapdb.services.object_search import search_objects
 
 from . import runtime as dag_runtime
 
@@ -57,6 +58,11 @@ def build_dag_capability_advertisement(
                 "kind": "dag_native_graph",
             },
             {
+                "path": f"{normalized_base}/search",
+                "auth": auth,
+                "kind": "dag_object_search",
+            },
+            {
                 "path": f"{normalized_base}/external",
                 "auth": auth,
                 "kind": "dag_external_graph",
@@ -71,7 +77,12 @@ def build_dag_capability_advertisement(
         "capabilities": [
             "exact_lookup",
             "native_graph",
+            "object_search",
             "external_graph_expansion",
+        ],
+        "external_ref_models": [
+            "external_payload.tapdb_graph",
+            "typed_external_identifier",
         ],
         "contract_version": CONTRACT_VERSION,
     }
@@ -131,6 +142,39 @@ def create_tapdb_dag_router(
                     "depth": depth,
                     "owner_service": resolved_service_name,
                     "root_record_type": record_type,
+                    "contract_version": CONTRACT_VERSION,
+                }
+                return payload
+
+    @router.get("/api/dag/search")
+    async def dag_search(
+        q: str = "",
+        euid: str = "",
+        record_type: str = "all",
+        category: str = "",
+        type: str = "",
+        subtype: str = "",
+        tenant_id: str = "",
+        relationship_type: str = "",
+        limit: int = Query(25, ge=1, le=100),
+    ) -> dict[str, Any]:
+        with dag_runtime.get_db(resolved_config_path, resolved_env_name) as conn:
+            with conn.session_scope() as session:
+                payload = search_objects(
+                    session,
+                    service_name=resolved_service_name,
+                    q=q,
+                    euid=euid,
+                    record_type=record_type,
+                    category=category,
+                    type_name=type,
+                    subtype=subtype,
+                    tenant_id=tenant_id,
+                    relationship_type=relationship_type,
+                    limit=limit,
+                )
+                payload["meta"] = {
+                    "owner_service": resolved_service_name,
                     "contract_version": CONTRACT_VERSION,
                 }
                 return payload

--- a/docs/dag_spec.md
+++ b/docs/dag_spec.md
@@ -20,6 +20,7 @@ All TapDB-backed contributors should expose these routes:
 
 - `GET /api/dag/object/{euid}`
 - `GET /api/dag/data?start_euid=<euid>&depth=<n>`
+- `GET /api/dag/search?...filters`
 - `GET /api/dag/external?source_euid=<euid>&ref_index=<i>&depth=<n>`
 - `GET /api/dag/external/object?source_euid=<euid>&ref_index=<i>&euid=<remote_euid>`
 
@@ -106,6 +107,47 @@ Edge `data` must include at least:
 }
 ```
 
+Graph node `data` also includes `external_refs` when the object carries explicit
+TapDB graph refs or is a typed external identifier object.
+
+### `GET /api/dag/search`
+
+- Searches local TapDB objects for UI and aggregator entrypoints.
+- Supports filters for `q`, exact `euid`, `record_type`, `category`, `type`,
+  `subtype`, `tenant_id`, `relationship_type`, and `limit`.
+- Search results are candidates. Exact ownership still comes from
+  `/api/dag/object/{euid}` or an explicit `service_id + euid` request.
+
+Minimum payload shape:
+
+```json
+{
+  "items": [
+    {
+      "system": "bloom",
+      "service": "bloom",
+      "record_type": "instance",
+      "euid": "Z:BCN-33",
+      "display_label": "Specimen tube",
+      "category": "container",
+      "type": "tube",
+      "tenant_id": null,
+      "relationship_type": null,
+      "graph_href": "/api/dag/data?start_euid=Z:BCN-33"
+    }
+  ],
+  "page": {
+    "limit": 25,
+    "total": 1,
+    "next_cursor": null
+  },
+  "meta": {
+    "owner_service": "bloom",
+    "contract_version": "dag:v1"
+  }
+}
+```
+
 ### `GET /api/dag/external`
 
 - Expands one explicit external reference from a local object.
@@ -124,8 +166,10 @@ Edge `data` must include at least:
   local IDs.
 - A service can be perspective-local only. It does not need to be globally
   canonical to contribute.
-- Search endpoints can still exist for UI convenience, but they are not part of
-  owner resolution.
+- Search endpoints are for UI convenience and cross-service entrypoints. They
+  are not a substitute for exact ownership.
+- Typed external identifier objects are valid federation refs when their
+  metadata provides a `system`/`target_system` and `root_euid`/`target_euid`.
 
 ## Capability Advertising
 
@@ -137,6 +181,7 @@ Current canonical capability labels are:
 
 - `exact_lookup`
 - `native_graph`
+- `object_search`
 - `external_graph_expansion`
 
 ## Host Integration

--- a/tests/test_services_external_refs.py
+++ b/tests/test_services_external_refs.py
@@ -125,6 +125,39 @@ def test_external_ref_payloads_exposes_public_dicts():
     ]
 
 
+def test_typed_external_identifier_object_exposes_public_ref():
+    obj = SimpleNamespace(
+        category="external_identifier",
+        type="tapdb",
+        subtype="object",
+        json_addl={
+            "properties": {
+                "external_identifier": {
+                    "system": "bloom",
+                    "target_euid": "BL-1",
+                    "tenant_id": "tenant-2",
+                }
+            }
+        },
+    )
+
+    assert eg.external_ref_payloads(obj) == [
+        {
+            "label": "bloom:BL-1",
+            "system": "bloom",
+            "root_euid": "BL-1",
+            "tenant_id": "tenant-2",
+            "href": None,
+            "graph_expandable": False,
+            "ref_index": 0,
+            "reason": (
+                "Missing required graph metadata: base_url, graph_data_path, "
+                "object_detail_path_template"
+            ),
+        }
+    ]
+
+
 def test_resolve_external_graph_refs_marks_missing_metadata():
     obj = SimpleNamespace(
         json_addl={

--- a/tests/test_web_dag.py
+++ b/tests/test_web_dag.py
@@ -47,6 +47,9 @@ class _FakeQuery:
     def first(self):
         return self._rows[0] if self._rows else None
 
+    def all(self):
+        return list(self._rows)
+
 
 class _FakeSession:
     def __init__(self, rows_by_model):
@@ -170,10 +173,17 @@ def test_build_dag_capability_advertisement_has_canonical_paths() -> None:
     assert payload["capabilities"] == [
         "exact_lookup",
         "native_graph",
+        "object_search",
         "external_graph_expansion",
     ]
     assert payload["endpoints"][0]["path"] == "/api/dag/object/{euid}"
     assert payload["endpoints"][1]["path"] == "/api/dag/data"
+    assert payload["endpoints"][2]["path"] == "/api/dag/search"
+    assert payload["endpoints"][2]["kind"] == "dag_object_search"
+    assert payload["external_ref_models"] == [
+        "external_payload.tapdb_graph",
+        "typed_external_identifier",
+    ]
 
 
 def test_create_tapdb_dag_router_serves_exact_lookup_graph_and_external(
@@ -249,6 +259,20 @@ def test_create_tapdb_dag_router_serves_exact_lookup_graph_and_external(
     assert node_ids == {"GX1", "GX2"}
     assert graph_body["elements"]["edges"][0]["data"]["source"] == "GX2"
     assert graph_body["elements"]["edges"][0]["data"]["target"] == "GX1"
+    assert (
+        graph_body["elements"]["nodes"][0]["data"]["external_refs"][0]["root_euid"]
+        == "AT-1"
+    )
+
+    search_response = client.get(
+        "/api/dag/search",
+        params={"q": "root", "record_type": "instance", "category": "container"},
+    )
+    assert search_response.status_code == 200
+    search_body = search_response.json()
+    assert search_body["meta"]["owner_service"] == "dewey"
+    assert search_body["items"][0]["euid"] == "GX1"
+    assert search_body["items"][0]["record_type"] == "instance"
 
     external_graph_response = client.get(
         "/api/dag/external",


### PR DESCRIPTION
## Summary
- add reusable TapDB object search for DAG federation
- expose `/api/dag/search` and advertise the object-search capability
- include external graph refs on DAG node payloads and support typed external identifier refs

## Validation
- `source ./activate && python -m ruff check daylily_tapdb admin tests`
- `source ./activate && python -m pytest tests/test_services_external_refs.py tests/test_web_dag.py -q`
- `source ./activate && python -m pytest -q`