### PR TITLE
[codex] Add TapDB schema namespace support

### DIFF
--- a/admin/db_pool.py
+++ b/admin/db_pool.py
@@ -64,12 +64,35 @@ def _set_audit_username(session: Session, username: Optional[str]) -> None:
         logger.warning("Could not set session audit username: %s", exc)
 
 
+def _require_schema_name(cfg: dict[str, str], *, env_name: str) -> str:
+    schema_name = str(cfg.get("schema_name") or "").strip()
+    if not schema_name:
+        raise RuntimeError(
+            f"Config for env {env_name!r} is missing required field: schema_name"
+        )
+    return schema_name
+
+
+def _set_search_path(session: Session, schema_name: str) -> None:
+    """Set per-transaction PostgreSQL search_path for TAPDB queries."""
+    bind = getattr(session, "bind", None)
+    dialect = getattr(bind, "dialect", None)
+    dialect_name = str(getattr(dialect, "name", "") or "").strip().lower()
+    if dialect_name != "postgresql":
+        return
+    session.execute(
+        text("SELECT set_config('search_path', :schema_name, true)"),
+        {"schema_name": schema_name},
+    )
+
+
 @dataclass(frozen=True)
 class EngineBundle:
     env_name: str
     engine: Engine
     SessionFactory: sessionmaker
     cfg: dict[str, str]
+    schema_name: str
 
 
 class AdminDBConnection:
@@ -94,6 +117,7 @@ class AdminDBConnection:
         trans = session.begin()
         token = db_username_var.set(_audit_username_for_session(self.app_username))
         try:
+            _set_search_path(session, self._bundle.schema_name)
             _set_audit_username(session, self.app_username)
             yield session
             if commit:
@@ -181,6 +205,7 @@ def _attach_aurora_password_provider(
 
 
 def _build_engine_for_cfg(cfg: dict[str, str], *, env_name: str) -> Engine:
+    _require_schema_name(cfg, env_name=env_name)
     engine_type = (cfg.get("engine_type") or "local").strip().lower()
     echo_sql = _parse_bool(os.environ.get("ECHO_SQL"), default=False)
 
@@ -243,13 +268,18 @@ def get_engine_bundle(env_name: str) -> EngineBundle:
             return cached
 
         cfg = get_db_config_for_env(env)
+        schema_name = _require_schema_name(cfg, env_name=env)
         engine = _build_engine_for_cfg(cfg, env_name=env)
         from admin.db_metrics import maybe_install_engine_metrics
 
         maybe_install_engine_metrics(engine, env_name=env)
         SessionFactory = sessionmaker(bind=engine)
         bundle = EngineBundle(
-            env_name=env, engine=engine, SessionFactory=SessionFactory, cfg=cfg
+            env_name=env,
+            engine=engine,
+            SessionFactory=SessionFactory,
+            cfg=cfg,
+            schema_name=schema_name,
         )
         _bundles_by_env[env] = bundle
         return bundle

--- a/admin/main.py
+++ b/admin/main.py
@@ -388,6 +388,9 @@ def _empty_db_inventory_context(*, error: Optional[str] = None) -> dict:
     return {
         "db_inventory_error": error,
         "db_inventory_db_name": None,
+        "db_inventory_physical_db_name": None,
+        "db_inventory_active_schema_name": None,
+        "db_inventory_search_path": [],
         "db_inventory_schema_names": [],
         "db_inventory_counts": {
             "schemas": 0,
@@ -419,6 +422,19 @@ def load_db_inventory_context() -> dict:
             with conn.session_scope() as session:
                 db_name = session.execute(text("SELECT current_database()")).scalar()
                 ctx["db_inventory_db_name"] = str(db_name or "")
+                ctx["db_inventory_physical_db_name"] = str(db_name or "")
+                active_schema = str(
+                    session.execute(text("SELECT current_schema()")).scalar() or ""
+                ).strip()
+                if not active_schema:
+                    raise RuntimeError("Active PostgreSQL schema is not configured.")
+                ctx["db_inventory_active_schema_name"] = active_schema
+                search_path = session.execute(
+                    text("SELECT current_schemas(false) AS schema_names")
+                ).scalar()
+                ctx["db_inventory_search_path"] = [
+                    str(item) for item in (search_path or [])
+                ]
 
                 schema_filter = """
                     nspname NOT IN ('pg_catalog', 'information_schema')
@@ -427,10 +443,7 @@ def load_db_inventory_context() -> dict:
                     AND nspname NOT LIKE 'pg_toast_temp_%'
                 """
                 schemaname_filter = """
-                    schemaname NOT IN ('pg_catalog', 'information_schema')
-                    AND schemaname NOT LIKE 'pg_toast%'
-                    AND schemaname NOT LIKE 'pg_temp_%'
-                    AND schemaname NOT LIKE 'pg_toast_temp_%'
+                    schemaname = :schema_name
                 """
 
                 schema_rows = session.execute(
@@ -456,7 +469,8 @@ def load_db_inventory_context() -> dict:
                             WHERE {schemaname_filter}
                             ORDER BY schemaname, tablename
                             """
-                        )
+                        ),
+                        {"schema_name": active_schema},
                     ).mappings()
                 ]
                 views = [
@@ -469,7 +483,8 @@ def load_db_inventory_context() -> dict:
                             WHERE {schemaname_filter}
                             ORDER BY schemaname, viewname
                             """
-                        )
+                        ),
+                        {"schema_name": active_schema},
                     ).mappings()
                 ]
                 materialized_views = [
@@ -482,7 +497,8 @@ def load_db_inventory_context() -> dict:
                             WHERE {schemaname_filter}
                             ORDER BY schemaname, matviewname
                             """
-                        )
+                        ),
+                        {"schema_name": active_schema},
                     ).mappings()
                 ]
                 sequences = [
@@ -495,14 +511,15 @@ def load_db_inventory_context() -> dict:
                             WHERE {schemaname_filter}
                             ORDER BY schemaname, sequencename
                             """
-                        )
+                        ),
+                        {"schema_name": active_schema},
                     ).mappings()
                 ]
                 triggers = [
                     dict(row)
                     for row in session.execute(
                         text(
-                            f"""
+                            """
                             SELECT
                                 ns.nspname AS schema_name,
                                 cls.relname AS table_name,
@@ -511,27 +528,29 @@ def load_db_inventory_context() -> dict:
                             JOIN pg_class cls ON cls.oid = tg.tgrelid
                             JOIN pg_namespace ns ON ns.oid = cls.relnamespace
                             WHERE NOT tg.tgisinternal
-                              AND {schema_filter}
+                              AND ns.nspname = :schema_name
                             ORDER BY ns.nspname, cls.relname, tg.tgname
                             """
-                        )
+                        ),
+                        {"schema_name": active_schema},
                     ).mappings()
                 ]
                 functions = [
                     dict(row)
                     for row in session.execute(
                         text(
-                            f"""
+                            """
                             SELECT
                                 ns.nspname AS schema_name,
                                 p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ')'
                                     AS function_signature
                             FROM pg_proc p
                             JOIN pg_namespace ns ON ns.oid = p.pronamespace
-                            WHERE {schema_filter}
+                            WHERE ns.nspname = :schema_name
                             ORDER BY ns.nspname, function_signature
                             """
-                        )
+                        ),
+                        {"schema_name": active_schema},
                     ).mappings()
                 ]
                 indexes = [
@@ -547,7 +566,8 @@ def load_db_inventory_context() -> dict:
                             WHERE {schemaname_filter}
                             ORDER BY schemaname, tablename, indexname
                             """
-                        )
+                        ),
+                        {"schema_name": active_schema},
                     ).mappings()
                 ]
 

--- a/admin/templates/info.html
+++ b/admin/templates/info.html
@@ -88,11 +88,25 @@
     </p>
     {% else %}
     <p style="margin-bottom: 0.75rem;">
-        Connected runtime database:
-        <code>{{ db_inventory_db_name or "unknown" }}</code>
+        Physical database:
+        <code>{{ db_inventory_physical_db_name or db_inventory_db_name or "unknown" }}</code>
     </p>
     <p style="margin-bottom: 0.75rem;">
-        Schemas:
+        Active configured schema:
+        <code>{{ db_inventory_active_schema_name or "unknown" }}</code>
+    </p>
+    <p style="margin-bottom: 0.75rem;">
+        Search path:
+        {% if db_inventory_search_path %}
+        {% for schema_name in db_inventory_search_path %}
+        <code>{{ schema_name }}</code>{% if not loop.last %}, {% endif %}
+        {% endfor %}
+        {% else %}
+        <span style="color: var(--text-muted);">none</span>
+        {% endif %}
+    </p>
+    <p style="margin-bottom: 0.75rem;">
+        Non-system schemas:
         {% if db_inventory_schema_names %}
         {% for schema_name in db_inventory_schema_names %}
         <code>{{ schema_name }}</code>{% if not loop.last %}, {% endif %}

--- a/daylily_tapdb/cli/__init__.py
+++ b/daylily_tapdb/cli/__init__.py
@@ -26,7 +26,11 @@ from daylily_tapdb.cli.context import (
     resolve_context,
     set_cli_context,
 )
-from daylily_tapdb.cli.db_config import default_database_name_for_namespace
+from daylily_tapdb.cli.db_config import (
+    default_database_name_for_namespace,
+    default_schema_name_for_database,
+    validate_postgres_identifier_component,
+)
 from daylily_tapdb.cli.output import print_renderable
 from daylily_tapdb.cli.spec import spec
 from daylily_tapdb.governance import (
@@ -1229,6 +1233,13 @@ def build_app():
                     prior.get("database")
                     or default_database_name_for_namespace(database_name, env_name)
                 ),
+                "schema_name": validate_postgres_identifier_component(
+                    str(
+                        prior.get("schema_name")
+                        or default_schema_name_for_database(database_name, env_name)
+                    ),
+                    field_name=f"environments.{env_name}.schema_name",
+                ),
                 "cognito_user_pool_id": str(prior.get("cognito_user_pool_id") or ""),
                 "support_email": str(prior.get("support_email") or ""),
             }
@@ -1403,6 +1414,9 @@ def build_app():
         database: Optional[str] = typer.Option(
             None, "--database", help="Database name"
         ),
+        schema_name: Optional[str] = typer.Option(
+            None, "--schema-name", help="PostgreSQL schema name"
+        ),
         cognito_user_pool_id: Optional[str] = typer.Option(
             None, "--cognito-user-pool-id", help="Bound Cognito user pool ID"
         ),
@@ -1528,6 +1542,7 @@ def build_app():
             "user",
             "password",
             "database",
+            "schema_name",
             "cognito_user_pool_id",
             "cognito_app_client_id",
             "cognito_app_client_secret",
@@ -1598,6 +1613,11 @@ def build_app():
             updates["password"] = str(password)
         if database is not None:
             updates["database"] = str(database).strip()
+        if schema_name is not None:
+            updates["schema_name"] = validate_postgres_identifier_component(
+                schema_name,
+                field_name="schema_name",
+            )
         if cognito_user_pool_id is not None:
             updates["cognito_user_pool_id"] = str(cognito_user_pool_id).strip()
         if cognito_app_client_id is not None:

--- a/daylily_tapdb/cli/db.py
+++ b/daylily_tapdb/cli/db.py
@@ -293,6 +293,23 @@ def _get_db_config(env: Environment) -> dict:
     return get_db_config_for_env(env.value)
 
 
+def _configured_schema_name(env: Environment) -> Optional[str]:
+    cfg = _get_db_config(env)
+    raw_schema_name = cfg.get("schema_name")
+    if raw_schema_name is None:
+        return None
+    schema_name = str(raw_schema_name).strip()
+    return schema_name or None
+
+
+def _get_schema_name(env: Environment) -> str:
+    """Return the configured PostgreSQL schema name for TAPDB objects."""
+    schema_name = _configured_schema_name(env)
+    if schema_name is None:
+        raise ValueError("schema_name must be configured for TAPDB DB commands")
+    return schema_name
+
+
 def _get_connection_string(env: Environment, database: Optional[str] = None) -> str:
     """Build PostgreSQL connection string for display.
 
@@ -374,11 +391,23 @@ def _run_psql(
     """
     cfg = _get_db_config(env)
     db = database or cfg["database"]
+    schema_name = (
+        _configured_schema_name(env) if _uses_configured_database(database) else None
+    )
+    apply_search_path = schema_name is not None
 
     if cfg.get("engine_type") == "aurora":
         from daylily_tapdb.aurora.schema_deployer import AuroraSchemaDeployer
 
         iam_auth = cfg.get("iam_auth", "true").lower() in ("true", "1", "yes")
+        aurora_sql = sql
+        aurora_file = file
+        if apply_search_path:
+            if file:
+                aurora_sql = _read_file_with_schema_search_path(schema_name, file)
+                aurora_file = None
+            elif sql:
+                aurora_sql = _with_schema_search_path(schema_name, sql)
         return AuroraSchemaDeployer.run_psql(
             host=cfg["host"],
             port=int(cfg["port"]),
@@ -388,8 +417,8 @@ def _run_psql(
             iam_auth=iam_auth,
             secret_arn=cfg.get("secret_arn") or None,
             password=cfg.get("password") or None,
-            sql=sql,
-            file=file,
+            sql=aurora_sql,
+            file=aurora_file,
         )
 
     cmd = [
@@ -409,6 +438,9 @@ def _run_psql(
         "-v",
         "ON_ERROR_STOP=1",
     ]
+
+    if apply_search_path:
+        cmd.extend(["-c", _set_search_path_sql(schema_name)])
 
     if file:
         cmd.extend(["-f", str(file)])
@@ -441,6 +473,22 @@ def _quoted_sql_literal(value: str) -> str:
 
 def _quoted_sql_ident(value: str) -> str:
     return '"' + value.replace('"', '""') + '"'
+
+
+def _set_search_path_sql(schema_name: str) -> str:
+    return f"SET search_path TO {_quoted_sql_ident(schema_name)}"
+
+
+def _with_schema_search_path(schema_name: str, sql: str) -> str:
+    return f"{_set_search_path_sql(schema_name)};\n{sql}"
+
+
+def _read_file_with_schema_search_path(schema_name: str, file: Path) -> str:
+    return _with_schema_search_path(schema_name, file.read_text(encoding="utf-8"))
+
+
+def _uses_configured_database(database: Optional[str]) -> bool:
+    return database is None
 
 
 def _bootstrap_user_candidates(preferred_user: str) -> list[str]:
@@ -534,6 +582,7 @@ def _parse_single_int(output: str) -> int:
 
 def _get_table_counts(env: Environment) -> dict:
     """Get row counts for TAPDB tables."""
+    _get_schema_name(env)
     tables = [
         "generic_template",
         "generic_instance",
@@ -556,11 +605,13 @@ def _get_table_counts(env: Environment) -> dict:
 
 def _schema_exists(env: Environment) -> bool:
     """Check if TAPDB schema exists in database."""
+    schema_name = _get_schema_name(env)
     success, psql_out = _run_psql(
         env,
         sql=(
             "SELECT COUNT(*) FROM information_schema.tables"
-            " WHERE table_name = 'generic_template'"
+            f" WHERE table_schema = {_quoted_sql_literal(schema_name)}"
+            " AND table_name = 'generic_template'"
         ),
     )
     if not success:
@@ -571,6 +622,17 @@ def _schema_exists(env: Environment) -> bool:
         return False
 
 
+def _ensure_schema_exists(env: Environment) -> None:
+    """Create the configured PostgreSQL schema when it is absent."""
+    schema_name = _get_schema_name(env)
+    success, psql_out = _run_psql(
+        env,
+        sql=f"CREATE SCHEMA IF NOT EXISTS {_quoted_sql_ident(schema_name)}",
+    )
+    if not success:
+        raise RuntimeError(f"Failed to create schema {schema_name!r}: {psql_out}")
+
+
 def _run_schema_drift_check(
     env: Environment,
     *,
@@ -578,6 +640,7 @@ def _run_schema_drift_check(
 ) -> tuple[dict[str, Any], bool]:
     """Build drift payload for CLI output."""
     cfg = _get_db_config(env)
+    schema_name = _get_schema_name(env)
     schema_root = _find_schema_root(required_subpath=Path("tapdb_schema.sql"))
     asset_paths = schema_asset_files(schema_root)
     identity_prefixes = _required_identity_prefixes(env)
@@ -592,7 +655,7 @@ def _run_schema_drift_check(
         app_username="tapdb_schema_drift_check",
     ) as conn:
         with conn.session_scope(commit=False) as session:
-            live = load_live_schema_inventory(session)
+            live = load_live_schema_inventory(session, schema_name=schema_name)
 
     drift_result = diff_schema_inventory(
         expected,
@@ -777,6 +840,7 @@ def db_schema_apply(
     )
     ccyo_out.print_text(f"  Host:     {cfg['host']}:{cfg['port']}")
     ccyo_out.print_text(f"  Database: {cfg['database']}")
+    ccyo_out.print_text(f"  Schema:   {_get_schema_name(env)}")
     ccyo_out.print_text(f"  User:     {cfg['user']}")
     ccyo_out.print_text("")
 
@@ -789,6 +853,12 @@ def db_schema_apply(
         schema_file = _find_schema_file()
         ccyo_out.success(f"Schema file: {schema_file}")
     except FileNotFoundError as e:
+        ccyo_out.error(f"{e}")
+        raise typer.Exit(1)
+
+    try:
+        _ensure_schema_exists(env)
+    except RuntimeError as e:
         ccyo_out.error(f"{e}")
         raise typer.Exit(1)
 
@@ -853,6 +923,7 @@ def db_status(
         raise typer.Exit(1)
 
     ccyo_out.success(f"Database: {cfg['database']}")
+    ccyo_out.success(f"Schema: {_get_schema_name(env)}")
 
     # Check schema
     if not _schema_exists(env):
@@ -862,7 +933,7 @@ def db_status(
         )
         raise typer.Exit(1)
 
-    ccyo_out.success("Schema: installed")
+    ccyo_out.success("Schema objects: installed")
 
     # Get table counts
     counts = _get_table_counts(env)
@@ -919,7 +990,7 @@ def db_schema_drift_check(
                         "status": "error",
                         "env": env.value,
                         "database": cfg["database"],
-                        "schema_name": None,
+                        "schema_name": cfg["schema_name"],
                         "strict": strict,
                         "error": message,
                     },
@@ -942,7 +1013,7 @@ def db_schema_drift_check(
                         "status": "error",
                         "env": env.value,
                         "database": cfg["database"],
-                        "schema_name": None,
+                        "schema_name": cfg["schema_name"],
                         "strict": strict,
                         "error": message,
                     },
@@ -1026,6 +1097,7 @@ def db_nuke(
             f"[bold red]⚠️  DESTRUCTIVE OPERATION[/bold red]\n\n"
             f"Environment: [bold]{env.value.upper()}[/bold]\n"
             f"Database:    [bold]{cfg['database']}[/bold]\n"
+            f"Schema:      [bold]{_get_schema_name(env)}[/bold]\n"
             f"Host:        {cfg['host']}:{cfg['port']}\n"
             f"{aurora_warning}\n"
             f"[yellow]Data to be deleted:[/yellow]\n"

--- a/daylily_tapdb/cli/db_config.py
+++ b/daylily_tapdb/cli/db_config.py
@@ -48,6 +48,7 @@ DEFAULT_DB_MAX_OVERFLOW = 10
 DEFAULT_DB_POOL_TIMEOUT = 30
 DEFAULT_DB_POOL_RECYCLE = 1800
 _POSTGRES_IDENTIFIER_RE = re.compile(r"[^a-z0-9_]+")
+_SAFE_POSTGRES_IDENTIFIER_COMPONENT_RE = re.compile(r"[a-z_][a-z0-9_]{0,62}")
 
 
 def normalize_postgres_identifier_component(value: str) -> str:
@@ -72,6 +73,26 @@ def default_database_name_for_namespace(database_name: str, env_name: str) -> st
         f"{normalize_postgres_identifier_component(database_name)}_"
         f"{normalize_postgres_identifier_component(env_name)}"
     )
+
+
+def default_schema_name_for_database(database_name: str, env_name: str) -> str:
+    """Build the default schema name for a database namespace/env pair."""
+
+    return default_database_name_for_namespace(database_name, env_name)
+
+
+def validate_postgres_identifier_component(value: str, *, field_name: str) -> str:
+    """Validate an explicitly configured PostgreSQL identifier component."""
+
+    raw = str(value or "").strip()
+    if not raw:
+        raise RuntimeError(f"{field_name} is required")
+    if not _SAFE_POSTGRES_IDENTIFIER_COMPONENT_RE.fullmatch(raw):
+        raise RuntimeError(
+            f"{field_name} must be a safe PostgreSQL identifier component "
+            "([a-z_][a-z0-9_]{0,62})"
+        )
+    return raw
 
 
 def get_config_paths(
@@ -266,6 +287,13 @@ def get_db_config_for_env(
         return str(val)
 
     engine_type = (_file_str("engine_type") or "local").strip().lower()
+    try:
+        schema_name = validate_postgres_identifier_component(
+            _file_str("schema_name") or "",
+            field_name=f"environments.{env_key}.schema_name",
+        )
+    except RuntimeError as exc:
+        raise RuntimeError(f"Config {resolved_config_path}: {exc}") from exc
 
     cfg: dict[str, str] = {
         "engine_type": engine_type,
@@ -276,6 +304,7 @@ def get_db_config_for_env(
         "password": _file_str("password") or "",
         "secret_arn": _file_str("secret_arn") or "",
         "database": _file_str("database") or f"tapdb_{env_key}",
+        "schema_name": schema_name,
         "cognito_user_pool_id": _file_str("cognito_user_pool_id") or "",
         "cognito_app_client_id": _file_str("cognito_app_client_id") or "",
         "cognito_app_client_secret": _file_str("cognito_app_client_secret") or "",

--- a/daylily_tapdb/connection.py
+++ b/daylily_tapdb/connection.py
@@ -75,6 +75,7 @@ class TAPDBConnection:
         secret_arn: Optional[str] = None,
         domain_code: Optional[str] = None,
         owner_repo_name: Optional[str] = None,
+        schema_name: Optional[str] = None,
     ):
         """
         Initialize database connection.
@@ -99,6 +100,7 @@ class TAPDBConnection:
             secret_arn: Secrets Manager ARN for password (Aurora fallback).
             domain_code: Domain code for session scoping (1-4 chars). Required.
             owner_repo_name: Repo-name for session ownership scoping. Required.
+            schema_name: PostgreSQL schema to use as this session's search_path.
         """
         self.logger = logging.getLogger(__name__ + ".TAPDBConnection")
 
@@ -113,6 +115,7 @@ class TAPDBConnection:
             if owner_repo_name is not None
             else resolve_runtime_owner_repo_name()
         )
+        self.schema_name = (schema_name or "").strip() or None
         if not self.domain_code:
             raise ValueError(
                 "domain_code is required. Set MERIDIAN_DOMAIN_CODE env var or pass domain_code= param."
@@ -192,7 +195,7 @@ class TAPDBConnection:
         self,
         session: Session,
         statement: str,
-        params: Optional[dict[str, str]] = None,
+        params: Optional[dict[str, object]] = None,
         *,
         use_savepoint: bool,
         warning: str,
@@ -273,6 +276,20 @@ class TAPDBConnection:
             warning="Could not set session owner repo name",
         )
 
+    def _set_session_search_path(self, session: Session, *, local: bool) -> None:
+        """Set the PostgreSQL search_path for TAPDB runtime queries."""
+        if not self._is_postgresql_session(session):
+            return
+        if not self.schema_name:
+            raise ValueError("schema_name is required for PostgreSQL TAPDB sessions.")
+        self._execute_session_setting(
+            session,
+            "SELECT set_config('search_path', :schema_name, :is_local)",
+            {"schema_name": self.schema_name, "is_local": local},
+            use_savepoint=local,
+            warning="Could not set session search_path",
+        )
+
     def get_session(self) -> Session:
         """
         Get a new session.
@@ -285,6 +302,7 @@ class TAPDBConnection:
         """
         session = self._Session()
         self._set_session_timezone_utc(session, local=False)
+        self._set_session_search_path(session, local=False)
         self._set_session_domain_code(session, local=False)
         return session
 
@@ -309,6 +327,7 @@ class TAPDBConnection:
         try:
             # Must happen inside a transaction for SET LOCAL.
             self._set_session_timezone_utc(session, local=True)
+            self._set_session_search_path(session, local=True)
             self._set_session_domain_code(session, local=True)
             self._set_session_username(session)
             yield session

--- a/daylily_tapdb/schema_inventory.py
+++ b/daylily_tapdb/schema_inventory.py
@@ -227,7 +227,14 @@ def load_live_schema_inventory(
 ) -> TapdbSchemaInventory:
     """Inspect the deployed TAPDB schema from PostgreSQL catalogs."""
 
-    resolved_schema = schema_name or discover_tapdb_schema_name(session)
+    if schema_name is None:
+        resolved_schema = discover_tapdb_schema_name(session)
+    else:
+        resolved_schema = str(schema_name).strip()
+        if not resolved_schema:
+            raise SchemaDriftOperationalError(
+                "Explicit TAPDB schema name must not be empty."
+            )
     inventory = TapdbSchemaInventory(schema_name=resolved_schema)
     if not resolved_schema:
         return inventory

--- a/daylily_tapdb/services/external_refs.py
+++ b/daylily_tapdb/services/external_refs.py
@@ -35,6 +35,8 @@ class ExternalGraphRef:
     graph_data_path: str | None
     object_detail_path_template: str | None
     auth_mode: str
+    relationship_type: str | None = None
+    source_field: str | None = None
 
     def to_public_dict(self, *, ref_index: int) -> dict[str, Any]:
         payload = {
@@ -46,6 +48,10 @@ class ExternalGraphRef:
             "graph_expandable": self.graph_expandable,
             "ref_index": ref_index,
         }
+        if self.relationship_type:
+            payload["relationship_type"] = self.relationship_type
+        if self.source_field:
+            payload["source_field"] = self.source_field
         if self.reason:
             payload["reason"] = self.reason
         return payload
@@ -101,6 +107,8 @@ def _external_ref_from_item(raw: Any) -> ExternalGraphRef:
         _clean(item.get("object_detail_path_template")) or None
     )
     auth_mode = _clean(item.get("auth_mode")) or "none"
+    relationship_type = _clean(item.get("relationship_type")) or None
+    source_field = _clean(item.get("source_field")) or None
     href = _clean(item.get("href")) or None
     if not href and base_url and object_detail_path_template and root_euid:
         href = _compose_object_href(
@@ -143,6 +151,8 @@ def _external_ref_from_item(raw: Any) -> ExternalGraphRef:
         graph_data_path=graph_data_path,
         object_detail_path_template=object_detail_path_template,
         auth_mode=auth_mode,
+        relationship_type=relationship_type,
+        source_field=source_field,
     )
 
 
@@ -328,21 +338,20 @@ def namespace_external_graph(
         namespaced_edges.append({"data": edge_data})
 
     bridge_id = f"bridge::{source_euid}::{ref.system}::{ref.tenant_id or 'global'}::{ref.root_euid}"
-    namespaced_edges.append(
-        {
-            "data": {
-                "id": bridge_id,
-                "source": source_euid,
-                "target": namespaced_id(ref.root_euid),
-                "relationship_type": "external_reference",
-                "is_external_bridge": True,
-                "external_system": ref.system,
-                "external_tenant_id": ref.tenant_id,
-                "source_ref_index": ref_index,
-                "external_source_euid": source_euid,
-            }
-        }
-    )
+    bridge_data = {
+        "id": bridge_id,
+        "source": source_euid,
+        "target": namespaced_id(ref.root_euid),
+        "relationship_type": ref.relationship_type or "external_reference",
+        "is_external_bridge": True,
+        "external_system": ref.system,
+        "external_tenant_id": ref.tenant_id,
+        "source_ref_index": ref_index,
+        "external_source_euid": source_euid,
+    }
+    if ref.source_field:
+        bridge_data["source_field"] = ref.source_field
+    namespaced_edges.append({"data": bridge_data})
 
     return {
         "elements": {"nodes": namespaced_nodes, "edges": namespaced_edges},

--- a/daylily_tapdb/services/graph_payloads.py
+++ b/daylily_tapdb/services/graph_payloads.py
@@ -23,6 +23,31 @@ _CATEGORY_COLORS = {
     "generic": "#888888",
 }
 
+_GRAPH_PRESENTATION_FIELDS = (
+    "role",
+    "expected_fanout_max",
+    "collapse_by_default",
+    "fanout_reason",
+)
+
+
+def _isoformat_attr(obj: Any, attr: str) -> str | None:
+    value = getattr(obj, attr, None)
+    return value.isoformat() if value is not None else None
+
+
+def _graph_presentation_payload(obj: Any) -> dict[str, Any]:
+    json_addl = getattr(obj, "json_addl", None)
+    if not isinstance(json_addl, dict):
+        return {}
+    properties = json_addl.get("properties")
+    if not isinstance(properties, dict):
+        return {}
+    graph = properties.get("graph")
+    if not isinstance(graph, dict):
+        return {}
+    return {key: graph[key] for key in _GRAPH_PRESENTATION_FIELDS if key in graph}
+
 
 def build_object_detail_payload(
     obj: Any,
@@ -47,11 +72,8 @@ def build_object_detail_payload(
         "bstatus": getattr(obj, "bstatus", None),
         "json_addl": json_addl,
         "href": f"/object/{getattr(obj, 'euid', '')}",
-        "created_dt": (
-            getattr(obj, "created_dt", None).isoformat()
-            if getattr(obj, "created_dt", None) is not None
-            else None
-        ),
+        "created_dt": _isoformat_attr(obj, "created_dt"),
+        "modified_dt": _isoformat_attr(obj, "modified_dt"),
         "external_refs": external_ref_payloads(obj),
     }
 
@@ -65,22 +87,24 @@ def _node_payload(
     category = (
         str(getattr(obj, "category", "") or "generic").strip().lower() or "generic"
     )
-    return {
-        "data": {
-            "id": getattr(obj, "euid", None),
-            "euid": getattr(obj, "euid", None),
-            "display_label": getattr(obj, "name", None) or getattr(obj, "euid", None),
-            "name": getattr(obj, "name", None) or getattr(obj, "euid", None),
-            "system": service_name,
-            "record_type": record_type,
-            "category": getattr(obj, "category", None),
-            "type": getattr(obj, "type", None),
-            "subtype": getattr(obj, "subtype", None),
-            "href": f"/object/{getattr(obj, 'euid', '')}",
-            "color": _CATEGORY_COLORS.get(category, _CATEGORY_COLORS["generic"]),
-            "external_refs": external_ref_payloads(obj),
-        }
+    data = {
+        "id": getattr(obj, "euid", None),
+        "euid": getattr(obj, "euid", None),
+        "display_label": getattr(obj, "name", None) or getattr(obj, "euid", None),
+        "name": getattr(obj, "name", None) or getattr(obj, "euid", None),
+        "system": service_name,
+        "record_type": record_type,
+        "category": getattr(obj, "category", None),
+        "type": getattr(obj, "type", None),
+        "subtype": getattr(obj, "subtype", None),
+        "href": f"/object/{getattr(obj, 'euid', '')}",
+        "color": _CATEGORY_COLORS.get(category, _CATEGORY_COLORS["generic"]),
+        "created_dt": _isoformat_attr(obj, "created_dt"),
+        "modified_dt": _isoformat_attr(obj, "modified_dt"),
+        "external_refs": external_ref_payloads(obj),
     }
+    data.update(_graph_presentation_payload(obj))
+    return {"data": data}
 
 
 def _lineage_edge_payload(lineage: Any, *, service_name: str) -> dict[str, Any] | None:

--- a/daylily_tapdb/web/runtime.py
+++ b/daylily_tapdb/web/runtime.py
@@ -48,6 +48,28 @@ def _set_audit_username(session: Session, username: Optional[str]) -> None:
         logger.warning("Could not set session audit username: %s", exc)
 
 
+def _require_schema_name(cfg: dict[str, str], *, env_name: str) -> str:
+    schema_name = str(cfg.get("schema_name") or "").strip()
+    if not schema_name:
+        raise RuntimeError(
+            f"Config for env {env_name!r} is missing required field: schema_name"
+        )
+    return schema_name
+
+
+def _set_search_path(session: Session, schema_name: str) -> None:
+    """Set per-transaction PostgreSQL search_path for runtime queries."""
+    bind = getattr(session, "bind", None)
+    dialect = getattr(bind, "dialect", None)
+    dialect_name = str(getattr(dialect, "name", "") or "").strip().lower()
+    if dialect_name != "postgresql":
+        return
+    session.execute(
+        text("SELECT set_config('search_path', :schema_name, true)"),
+        {"schema_name": schema_name},
+    )
+
+
 @dataclass(frozen=True)
 class RuntimeBundle:
     config_path: str
@@ -55,6 +77,7 @@ class RuntimeBundle:
     engine: Engine
     SessionFactory: sessionmaker
     cfg: dict[str, str]
+    schema_name: str
 
 
 class RuntimeDBConnection:
@@ -75,6 +98,7 @@ class RuntimeDBConnection:
         session = self._bundle.SessionFactory()
         trans = session.begin()
         try:
+            _set_search_path(session, self._bundle.schema_name)
             _set_audit_username(session, self.app_username)
             yield session
             if commit:
@@ -162,6 +186,7 @@ def _build_engine_for_cfg(
     config_path: str,
     env_name: str,
 ) -> Engine:
+    _require_schema_name(cfg, env_name=env_name)
     engine_type = (cfg.get("engine_type") or "local").strip().lower()
     echo_sql = _parse_bool(os.environ.get("ECHO_SQL"), default=False)
 
@@ -233,6 +258,7 @@ def get_db(config_path: str, env_name: str) -> RuntimeDBConnection:
         raise RuntimeError("TapDB env name is required.")
 
     cfg = get_db_config_for_env(env, config_path=config_path)
+    schema_name = _require_schema_name(cfg, env_name=env)
     resolved_config_path = str(cfg.get("config_path") or str(config_path)).strip()
     key = (resolved_config_path, env)
 
@@ -250,6 +276,7 @@ def get_db(config_path: str, env_name: str) -> RuntimeDBConnection:
                 engine=engine,
                 SessionFactory=sessionmaker(bind=engine),
                 cfg=cfg,
+                schema_name=schema_name,
             )
             _bundles[key] = bundle
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "rich",
     "uuid6>=2024.1.12",
     "cli-core-yo==2.1.1",
-    "meridian-euid>=0.4.1,<0.4.3",
+    "meridian-euid==0.4.5",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,6 +215,7 @@ def pg_instance(tmp_path_factory):
                 "user": user,
                 "password": "",
                 "database": database,
+                "schema_name": "tapdb_testdb_dev",
             },
         },
     }
@@ -239,6 +240,7 @@ def pg_instance(tmp_path_factory):
         "config_dir": cfg_dir,
         "user": user,
         "database": database,
+        "schema_name": "tapdb_testdb_dev",
         "dsn": dsn,
         "base": base,
     }

--- a/tests/test_admin_cognito.py
+++ b/tests/test_admin_cognito.py
@@ -69,6 +69,7 @@ def test_resolve_tapdb_pool_config_from_tapdb_yaml(
         "    domain_code: Z\n"
         "    user: test\n"
         "    database: tapdb_dev\n"
+        "    schema_name: tapdb_tapdb_dev\n"
         "    cognito_user_pool_id: us-east-1_TESTPOOL\n"
         "    cognito_app_client_id: client123\n"
         "    cognito_client_name: tapdb\n"
@@ -110,7 +111,8 @@ def test_resolve_tapdb_pool_config_requires_pool_id(
         "    ui_port: 8911\n"
         "    domain_code: Z\n"
         "    user: test\n"
-        "    database: tapdb_dev\n",
+        "    database: tapdb_dev\n"
+        "    schema_name: tapdb_tapdb_dev\n",
     )
 
     set_cli_context(config_path=cfg_path, env_name="dev")
@@ -141,6 +143,7 @@ def test_resolve_tapdb_pool_config_requires_client_id(
         "    domain_code: Z\n"
         "    user: test\n"
         "    database: tapdb_dev\n"
+        "    schema_name: tapdb_tapdb_dev\n"
         "    cognito_user_pool_id: us-east-1_TESTPOOL\n"
         "    cognito_client_name: tapdb\n"
         "    cognito_region: us-east-1\n",
@@ -174,6 +177,7 @@ def test_resolve_tapdb_pool_config_requires_tapdb_client_name(
         "    domain_code: Z\n"
         "    user: test\n"
         "    database: tapdb_dev\n"
+        "    schema_name: tapdb_tapdb_dev\n"
         "    cognito_user_pool_id: us-east-1_TESTPOOL\n"
         "    cognito_app_client_id: client123\n"
         "    cognito_client_name: wrong-client\n"

--- a/tests/test_admin_db_connection.py
+++ b/tests/test_admin_db_connection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from sqlalchemy import create_engine as sa_create_engine
 
 import admin.auth as auth_mod
@@ -35,6 +36,7 @@ def test_admin_get_db_reuses_single_engine_bundle(monkeypatch):
             "user": "tapdb_admin",
             "password": "",
             "database": "tapdb_dev",
+            "schema_name": "tapdb_dev",
         },
     )
 
@@ -52,6 +54,76 @@ def test_admin_get_db_reuses_single_engine_bundle(monkeypatch):
     _ = main_mod.get_db()
 
     assert calls["count"] == 1
+
+
+def test_admin_get_engine_bundle_requires_schema_name(monkeypatch):
+    pool_mod._clear_engine_cache_for_tests()
+    monkeypatch.setattr(
+        pool_mod,
+        "get_db_config_for_env",
+        lambda _env: {
+            "engine_type": "local",
+            "host": "localhost",
+            "port": "5533",
+            "user": "tapdb_admin",
+            "password": "",
+            "database": "tapdb_dev",
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="schema_name"):
+        pool_mod.get_engine_bundle("dev")
+
+
+def test_admin_session_scope_sets_search_path(monkeypatch):
+    pool_mod._clear_engine_cache_for_tests()
+
+    class _Trans:
+        def commit(self):
+            return None
+
+        def rollback(self):
+            return None
+
+    class _Session:
+        def __init__(self):
+            self.bind = type(
+                "Bind", (), {"dialect": type("Dialect", (), {"name": "postgresql"})()}
+            )()
+            self.statements = []
+
+        def begin(self):
+            return _Trans()
+
+        def execute(self, stmt, params=None):
+            self.statements.append((str(stmt), params or {}))
+
+        def close(self):
+            return None
+
+    session = _Session()
+    bundle = pool_mod.EngineBundle(
+        env_name="dev",
+        engine=sa_create_engine("sqlite:///:memory:"),
+        SessionFactory=lambda: session,
+        cfg={"schema_name": "tapdb_dev"},
+        schema_name="tapdb_dev",
+    )
+    conn = pool_mod.AdminDBConnection(bundle)
+    monkeypatch.setattr(
+        "admin.db_metrics.db_username_var",
+        type(
+            "Var",
+            (),
+            {"set": lambda self, value: value, "reset": lambda self, token: None},
+        )(),
+    )
+
+    with conn.session_scope(commit=False):
+        pass
+
+    assert "set_config('search_path'" in session.statements[0][0]
+    assert session.statements[0][1]["schema_name"] == "tapdb_dev"
 
 
 def test_attach_aurora_password_provider_refreshes_iam_token(monkeypatch):

--- a/tests/test_admin_db_metrics.py
+++ b/tests/test_admin_db_metrics.py
@@ -76,7 +76,8 @@ def _write_config(path: Path, *, queue_max: int) -> Path:
         "    domain_code: Z\n"
         "    user: tapdb\n"
         "    password: ''\n"
-        "    database: tapdb_dev\n",
+        "    database: tapdb_dev\n"
+        "    schema_name: tapdb_beta_dev\n",
         encoding="utf-8",
     )
     return path

--- a/tests/test_admin_main_coverage.py
+++ b/tests/test_admin_main_coverage.py
@@ -687,6 +687,8 @@ def test_main_load_db_inventory_context_covers_success_and_error(monkeypatch):
     rows = iter(
         [
             SimpleNamespace(scalar=lambda: "tapdb_dev"),
+            SimpleNamespace(scalar=lambda: "public"),
+            SimpleNamespace(scalar=lambda: ["public"]),
             _InventoryMappings([{"schema_name": "public"}, {"schema_name": "app_ns"}]),
             _InventoryMappings(
                 [{"schema_name": "public", "table_name": "generic_instance"}]
@@ -728,7 +730,7 @@ def test_main_load_db_inventory_context_covers_success_and_error(monkeypatch):
     )
 
     class _InventorySession:
-        def execute(self, _stmt):
+        def execute(self, _stmt, _params=None):
             return next(rows)
 
     class _InventoryConn:
@@ -745,6 +747,9 @@ def test_main_load_db_inventory_context_covers_success_and_error(monkeypatch):
     monkeypatch.setattr(admin_main, "get_db", lambda: _InventoryConn())
     ctx = admin_main.load_db_inventory_context()
     assert ctx["db_inventory_db_name"] == "tapdb_dev"
+    assert ctx["db_inventory_physical_db_name"] == "tapdb_dev"
+    assert ctx["db_inventory_active_schema_name"] == "public"
+    assert ctx["db_inventory_search_path"] == ["public"]
     assert ctx["db_inventory_counts"]["schemas"] == 2
     assert ctx["db_inventory_tables"]
 

--- a/tests/test_admin_support_coverage.py
+++ b/tests/test_admin_support_coverage.py
@@ -4,6 +4,7 @@ import base64
 import json
 import re
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -15,6 +16,7 @@ import admin.auth as auth_mod
 import admin.db_metrics as metrics_mod
 import admin.db_pool as pool_mod
 import admin.domain_access as domain_mod
+import admin.main as admin_main
 
 
 def _signed_cookie(secret: str, payload: dict) -> str:
@@ -241,6 +243,78 @@ def test_db_metrics_writer_cache_and_engine_metrics_callbacks(monkeypatch):
 
     metrics_mod.stop_all_writers()
     assert writer1.stopped == 1
+
+
+def test_admin_inventory_context_scopes_objects_to_active_schema(monkeypatch):
+    class _Mappings:
+        def __init__(self, rows):
+            self._rows = list(rows)
+
+        def mappings(self):
+            return self
+
+        def __iter__(self):
+            return iter(self._rows)
+
+    rows = iter(
+        [
+            SimpleNamespace(scalar=lambda: "tapdb_physical_dev"),
+            SimpleNamespace(scalar=lambda: "tapdb_active"),
+            SimpleNamespace(scalar=lambda: ["tapdb_active"]),
+            _Mappings(
+                [
+                    {"schema_name": "tapdb_active"},
+                    {"schema_name": "tapdb_old"},
+                ]
+            ),
+            _Mappings(
+                [{"schema_name": "tapdb_active", "table_name": "generic_template"}]
+            ),
+            _Mappings([]),
+            _Mappings([]),
+            _Mappings(
+                [{"schema_name": "tapdb_active", "sequence_name": "gx_instance_seq"}]
+            ),
+            _Mappings([]),
+            _Mappings(
+                [
+                    {
+                        "schema_name": "tapdb_active",
+                        "function_signature": "set_generic_template_euid()",
+                    }
+                ]
+            ),
+            _Mappings([]),
+        ]
+    )
+
+    class _Session:
+        def execute(self, _stmt, _params=None):
+            return next(rows)
+
+    class _Conn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        @contextmanager
+        def session_scope(self):
+            yield _Session()
+
+    monkeypatch.setattr(admin_main, "get_db", lambda: _Conn())
+    ctx = admin_main.load_db_inventory_context()
+
+    assert ctx["db_inventory_physical_db_name"] == "tapdb_physical_dev"
+    assert ctx["db_inventory_active_schema_name"] == "tapdb_active"
+    assert ctx["db_inventory_search_path"] == ["tapdb_active"]
+    assert ctx["db_inventory_schema_names"] == ["tapdb_active", "tapdb_old"]
+    assert ctx["db_inventory_counts"]["schemas"] == 2
+    assert ctx["db_inventory_counts"]["tables"] == 1
+    assert ctx["db_inventory_tables"] == [
+        {"schema_name": "tapdb_active", "table_name": "generic_template"}
+    ]
 
 
 def test_auth_helpers_cover_disabled_and_shared_auth(monkeypatch):
@@ -478,6 +552,7 @@ def test_db_pool_helpers_cover_engine_build_session_scope_and_dispose(
         engine=sa_create_engine("sqlite://"),
         SessionFactory=lambda: session,
         cfg={},
+        schema_name="tapdb_unit",
     )
     conn = pool_mod.AdminDBConnection(bundle)
     conn.app_username = "admin"
@@ -572,6 +647,7 @@ def test_db_pool_helpers_cover_engine_build_session_scope_and_dispose(
             "host": "db.local",
             "port": "5432",
             "database": "tapdb_dev",
+            "schema_name": "tapdb_dev",
             "user": "tapdb",
             "password": "secret",
             "region": "us-west-2",
@@ -590,6 +666,7 @@ def test_db_pool_helpers_cover_engine_build_session_scope_and_dispose(
             "host": "localhost",
             "port": "5432",
             "database": "tapdb_dev",
+            "schema_name": "tapdb_dev",
             "user": "tapdb",
             "password": "",
         },
@@ -617,6 +694,7 @@ def test_db_pool_helpers_cover_engine_build_session_scope_and_dispose(
         engine=bad_engine,
         SessionFactory=lambda: None,
         cfg={},
+        schema_name="tapdb_unit",
     )
     caplog.clear()
     pool_mod.dispose_all_engines()

--- a/tests/test_aurora_config.py
+++ b/tests/test_aurora_config.py
@@ -147,6 +147,7 @@ def _yaml_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             user: daylily
             password: ""
             database: tapdb_dev
+            schema_name: tapdb_dbx_dev
           aurora_dev:
             engine_type: aurora
             host: my-cluster.us-west-2.rds.amazonaws.com
@@ -155,6 +156,7 @@ def _yaml_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             user: tapdb_admin
             password: ""
             database: tapdb_dev
+            schema_name: tapdb_dbx_aurora_dev
             region: us-west-2
             cluster_identifier: my-cluster
             iam_auth: true
@@ -175,6 +177,7 @@ class TestGetDbConfigEngineType:
 
         cfg = get_db_config_for_env("dev")
         assert cfg["engine_type"] == "local"
+        assert cfg["schema_name"] == "tapdb_dbx_dev"
 
     @pytest.mark.usefixtures("_yaml_config")
     def test_aurora_env_has_engine_type_aurora(self):
@@ -182,6 +185,7 @@ class TestGetDbConfigEngineType:
 
         cfg = get_db_config_for_env("aurora_dev")
         assert cfg["engine_type"] == "aurora"
+        assert cfg["schema_name"] == "tapdb_dbx_aurora_dev"
 
     @pytest.mark.usefixtures("_yaml_config")
     def test_aurora_env_has_aurora_fields(self):
@@ -253,6 +257,7 @@ class TestGetDbConfigEngineType:
                 user: daylily
                 password: ""
                 database: tapdb_dev
+                schema_name: tapdb_dbx_dev
             """).format(
                 domain_registry=domain_registry,
                 prefix_registry=prefix_registry,
@@ -307,6 +312,7 @@ class TestGetDbConfigEngineType:
                 user: daylily
                 password: ""
                 database: tapdb_dev
+                schema_name: tapdb_dbx_dev
                 unix_socket_dir: /tmp/from-config
             """).format(
                 domain_registry=domain_registry,
@@ -357,3 +363,67 @@ class TestDatabaseNameNormalization:
             default_database_name_for_namespace("auruse1-daylily-tapdb", "dev")
             == "tapdb_auruse1_daylily_tapdb_dev"
         )
+
+    def test_default_schema_name_for_database_normalizes_hyphens(self):
+        from daylily_tapdb.cli.db_config import default_schema_name_for_database
+
+        assert (
+            default_schema_name_for_database("auruse1-daylily-tapdb", "dev")
+            == "tapdb_auruse1_daylily_tapdb_dev"
+        )
+
+    @pytest.mark.parametrize(
+        "schema_name",
+        ["tapdb_app_dev", "_tapdb_app_dev", "tapdb_app_123"],
+    )
+    def test_validate_postgres_identifier_component_accepts_safe_values(
+        self, schema_name: str
+    ):
+        from daylily_tapdb.cli.db_config import validate_postgres_identifier_component
+
+        assert (
+            validate_postgres_identifier_component(
+                schema_name,
+                field_name="schema_name",
+            )
+            == schema_name
+        )
+
+    @pytest.mark.parametrize(
+        "schema_name",
+        ["", "TapDB_App", "tapdb-app", "1tapdb", "tapdb.app", "a" * 64],
+    )
+    def test_validate_postgres_identifier_component_rejects_unsafe_values(
+        self, schema_name: str
+    ):
+        from daylily_tapdb.cli.db_config import validate_postgres_identifier_component
+
+        with pytest.raises(RuntimeError, match="schema_name"):
+            validate_postgres_identifier_component(
+                schema_name,
+                field_name="schema_name",
+            )
+
+    def test_get_db_config_requires_explicit_schema_name(self, _yaml_config: Path):
+        import yaml
+
+        from daylily_tapdb.cli.db_config import get_db_config_for_env
+
+        payload = yaml.safe_load(_yaml_config.read_text(encoding="utf-8"))
+        del payload["environments"]["dev"]["schema_name"]
+        _yaml_config.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="environments.dev.schema_name"):
+            get_db_config_for_env("dev")
+
+    def test_get_db_config_rejects_unsafe_schema_name(self, _yaml_config: Path):
+        import yaml
+
+        from daylily_tapdb.cli.db_config import get_db_config_for_env
+
+        payload = yaml.safe_load(_yaml_config.read_text(encoding="utf-8"))
+        payload["environments"]["dev"]["schema_name"] = "tapdb-dev"
+        _yaml_config.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="environments.dev.schema_name"):
+            get_db_config_for_env("dev")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,6 +108,7 @@ def _isolate_cli_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         "    user: test\n"
         '    password: ""\n'
         "    database: tapdb_dev\n"
+        "    schema_name: tapdb_testdb_dev\n"
         "  test:\n"
         "    engine_type: local\n"
         "    host: localhost\n"
@@ -117,6 +118,7 @@ def _isolate_cli_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         "    user: test\n"
         '    password: ""\n'
         "    database: tapdb_test\n"
+        "    schema_name: tapdb_testdb_test\n"
         "  prod:\n"
         "    engine_type: local\n"
         "    host: localhost\n"
@@ -125,7 +127,8 @@ def _isolate_cli_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         "    domain_code: Z\n"
         "    user: test\n"
         '    password: ""\n'
-        "    database: tapdb_prod\n",
+        "    database: tapdb_prod\n"
+        "    schema_name: tapdb_testdb_prod\n",
         encoding="utf-8",
     )
     os.chmod(cfg_path, 0o600)
@@ -427,7 +430,8 @@ class TestCLICognito:
             "    ui_port: 8911\n"
             "    domain_code: Z\n"
             "    user: test\n"
-            "    database: tapdb_dev\n",
+            "    database: tapdb_dev\n"
+            "    schema_name: tapdb_testdb_dev\n",
             encoding="utf-8",
         )
         result = runner.invoke(
@@ -832,6 +836,7 @@ class TestCLICognito:
                 "user": "test",
                 "password": "",
                 "database": "tapdb_dev",
+                "schema_name": "tapdb_testdb_dev",
                 "domain_code": "Z",
                 "owner_repo_name": "daylily-tapdb",
             },
@@ -1065,6 +1070,7 @@ class TestCLIBootstrap:
                             "user": "test",
                             "password": "",
                             "database": "tapdb_auruse1_daylily_tapdb_dev",
+                            "schema_name": "tapdb_auruse1_daylily_tapdb_dev",
                         }
                     },
                 },
@@ -1163,6 +1169,7 @@ class TestCLIBootstrap:
                             "user": "test",
                             "password": "",
                             "database": "tapdb_auruse1_daylily_tapdb_dev",
+                            "schema_name": "tapdb_auruse1_daylily_tapdb_dev",
                         }
                     },
                 },

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -74,7 +74,8 @@ def _isolate_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         "    domain_code: Z\n"
         "    user: test\n"
         '    password: ""\n'
-        "    database: tapdb_dev\n",
+        "    database: tapdb_dev\n"
+        "    schema_name: tapdb_testdb_dev\n",
         encoding="utf-8",
     )
     os.chmod(cfg_path, 0o600)

--- a/tests/test_cli_db_floor_lift.py
+++ b/tests/test_cli_db_floor_lift.py
@@ -15,6 +15,7 @@ def _base_cfg(**overrides):
         "host": "localhost",
         "port": "5533",
         "database": "tapdb_dev",
+        "schema_name": "tapdb_app",
         "user": "tapdb",
         "password": "",
         "domain_code": "Z",
@@ -125,9 +126,11 @@ def test_db_sequence_baseline_and_run_psql_branches(
         db_mod, "_get_db_config", lambda _env: _base_cfg(password="secret")
     )
     captured_envs: list[dict[str, str]] = []
+    captured_cmds: list[list[str]] = []
 
     def _fake_run(cmd, capture_output=True, text=True, env=None):
         _ = (cmd, capture_output, text)
+        captured_cmds.append(cmd)
         captured_envs.append(env)
         return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
 
@@ -135,6 +138,8 @@ def test_db_sequence_baseline_and_run_psql_branches(
     ok, out = real_run_psql(db_mod.Environment.dev, sql="SELECT 1")
     assert ok is True
     assert captured_envs[-1]["PGPASSWORD"] == "secret"
+    assert "-c" in captured_cmds[-1]
+    assert 'SET search_path TO "tapdb_app"' in captured_cmds[-1]
 
     monkeypatch.setattr(
         db_mod.subprocess,
@@ -190,6 +195,18 @@ def test_db_role_counts_schema_and_drift_helpers(
     assert counts["generic_template"] == "?"
     assert counts["generic_instance"] is None
 
+    schema_sqls: list[str] = []
+    monkeypatch.setattr(
+        db_mod,
+        "_run_psql",
+        lambda _env, sql=None, **_kwargs: (
+            schema_sqls.append(sql or ""),
+            (True, ""),
+        )[1],
+    )
+    db_mod._ensure_schema_exists(db_mod.Environment.dev)
+    assert 'CREATE SCHEMA IF NOT EXISTS "tapdb_app"' in schema_sqls[-1]
+
     monkeypatch.setattr(db_mod, "_run_psql", lambda *_args, **_kwargs: (False, "boom"))
     assert db_mod._schema_exists(db_mod.Environment.dev) is False
     monkeypatch.setattr(
@@ -218,10 +235,16 @@ def test_db_role_counts_schema_and_drift_helpers(
             "seq": dynamic_sequence_name,
         },
     )
+    live_inventory_calls: list[str | None] = []
+
+    def _fake_load_live_schema_inventory(session, schema_name=None):
+        live_inventory_calls.append(schema_name)
+        return {"live": True, "session": session, "schema_name": schema_name}
+
     monkeypatch.setattr(
         db_mod,
         "load_live_schema_inventory",
-        lambda session: {"live": True, "session": session},
+        _fake_load_live_schema_inventory,
     )
 
     class _Result:
@@ -266,6 +289,8 @@ def test_db_role_counts_schema_and_drift_helpers(
     assert has_drift is True
     assert payload["counts"]["expected"]["count"] == 1
     assert payload["counts"]["missing"]["count"] == 1
+    assert payload["schema_name"] == "public"
+    assert live_inventory_calls == ["tapdb_app"]
 
 
 def test_db_callback_create_and_delete_branches(
@@ -413,6 +438,10 @@ def test_db_schema_apply_status_and_drift_command_branches(
 
     monkeypatch.setattr(db_mod, "_find_schema_file", lambda: schema_file)
     monkeypatch.setattr(db_mod, "_schema_exists", lambda _env: True)
+    ensure_schema_calls: list[db_mod.Environment] = []
+    monkeypatch.setattr(
+        db_mod, "_ensure_schema_exists", lambda env: ensure_schema_calls.append(env)
+    )
     monkeypatch.setattr(
         db_mod, "_run_psql", lambda *_args, **_kwargs: (False, "schema apply failed")
     )
@@ -422,6 +451,7 @@ def test_db_schema_apply_status_and_drift_command_branches(
         db_mod.db_schema_apply(db_mod.Environment.dev, reinitialize=False)
     assert exc.value.exit_code == 1
     assert log_calls[-1][1] == "SCHEMA_APPLY_FAILED"
+    assert ensure_schema_calls == [db_mod.Environment.dev]
 
     monkeypatch.setattr(db_mod, "_run_psql", lambda *_args, **_kwargs: (True, ""))
     monkeypatch.setattr(

--- a/tests/test_cli_floor_lift_part1.py
+++ b/tests/test_cli_floor_lift_part1.py
@@ -288,6 +288,7 @@ def test_runtime_db_connection_context_manager_commit_and_rollback(
         engine=object(),
         SessionFactory=_factory,
         cfg={},
+        schema_name="tapdb_dev",
     )
     conn = runtime_mod.RuntimeDBConnection(bundle)
     conn.app_username = "alice"
@@ -357,6 +358,7 @@ def test_runtime_build_engine_for_cfg_local_and_aurora(
             "host": "localhost",
             "port": "5432",
             "database": "tapdb_dev",
+            "schema_name": "tapdb_dev",
             "user": "tapdb",
             "password": "",
         },
@@ -369,6 +371,7 @@ def test_runtime_build_engine_for_cfg_local_and_aurora(
             "host": "aurora.local",
             "port": "6432",
             "database": "tapdb_prod",
+            "schema_name": "tapdb_prod",
             "user": "tapdb",
             "password": "",
             "iam_auth": "yes",
@@ -418,6 +421,7 @@ def test_runtime_clear_cache_logs_dispose_errors(
         engine=_Engine(),
         SessionFactory=lambda: None,
         cfg={},
+        schema_name="tapdb_dev",
     )
     runtime_mod._bundles[("/tmp/tapdb-config.yaml", "dev")] = bundle
 

--- a/tests/test_cli_helper_units.py
+++ b/tests/test_cli_helper_units.py
@@ -113,6 +113,7 @@ def test_db_schema_apply_reapplies_when_schema_table_already_exists(
             "host": "localhost",
             "port": "5432",
             "database": "tapdb_dev",
+            "schema_name": "tapdb_app",
             "user": "tapdb",
         },
     )
@@ -136,7 +137,10 @@ def test_db_schema_apply_reapplies_when_schema_table_already_exists(
 
     db_mod.db_schema_apply(db_mod.Environment.dev)
 
-    assert psql_calls == [(None, schema_file, None)]
+    assert psql_calls == [
+        ('CREATE SCHEMA IF NOT EXISTS "tapdb_app"', None, None),
+        (None, schema_file, None),
+    ]
     assert sync_calls == [db_mod.Environment.dev]
     assert baseline_calls == [db_mod.Environment.dev]
     assert log_calls == [("dev", "SCHEMA_APPLY", f"Schema applied from {schema_file}")]

--- a/tests/test_cli_root_floor_lift.py
+++ b/tests/test_cli_root_floor_lift.py
@@ -103,6 +103,7 @@ def cli_namespace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         "    user: tapdb\n"
         "    password: ''\n"
         "    database: tapdb_dev\n"
+        "    schema_name: tapdb_testdb_dev\n"
         "  prod:\n"
         "    engine_type: local\n"
         "    host: localhost\n"
@@ -111,7 +112,8 @@ def cli_namespace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         "    domain_code: Z\n"
         "    user: tapdb\n"
         "    password: ''\n"
-        "    database: tapdb_prod\n",
+        "    database: tapdb_prod\n"
+        "    schema_name: tapdb_testdb_prod\n",
         encoding="utf-8",
     )
     os.chmod(cfg_path, stat.S_IRUSR | stat.S_IWUSR)
@@ -716,7 +718,9 @@ def test_config_init_update_and_info_commands(
     init_payload = yaml.safe_load(init_path.read_text(encoding="utf-8"))
     assert init_payload["meta"]["client_id"] == "atlas"
     assert init_payload["environments"]["dev"]["ui_port"] == "8911"
+    assert init_payload["environments"]["dev"]["schema_name"] == "tapdb_app_dev"
     assert init_payload["environments"]["test"]["port"] == "5534"
+    assert init_payload["environments"]["test"]["schema_name"] == "tapdb_app_test"
 
     clear_cli_context()
     set_cli_context(config_path=init_path)
@@ -827,6 +831,8 @@ def test_config_init_update_and_info_commands(
             "dev",
             "--host",
             "db.internal",
+            "--schema-name",
+            "tapdb_testdb_dev_next",
             "--port",
             "6543",
             "--ui-port",
@@ -867,6 +873,7 @@ def test_config_init_update_and_info_commands(
     assert result.exit_code == 0
     updated = yaml.safe_load(cli_namespace.read_text(encoding="utf-8"))
     assert updated["environments"]["dev"]["host"] == "db.internal"
+    assert updated["environments"]["dev"]["schema_name"] == "tapdb_testdb_dev_next"
     assert (
         updated["admin"]["footer"]["repo_url"]
         == "https://github.com/example/tapdb-core"
@@ -899,6 +906,7 @@ def test_config_init_update_and_info_commands(
             "user": "tapdb",
             "password": "secret",
             "database": f"tapdb_{env_name}",
+            "schema_name": f"tapdb_testdb_{env_name}",
         },
     )
     result = runner.invoke(fresh_app, ["info", "--check-all-envs", "--json"])

--- a/tests/test_connection_unit.py
+++ b/tests/test_connection_unit.py
@@ -67,6 +67,7 @@ def test_set_session_domain_code_executes_for_postgresql(monkeypatch):
         db_url="sqlite:///:memory:",
         domain_code="Z",
         owner_repo_name="daylily-tapdb",
+        schema_name="tapdb_unit",
     )
 
     stmts: list[str] = []
@@ -133,7 +134,11 @@ def test_session_scope_commit_true_commits(monkeypatch):
         m, "create_engine", lambda *a, **k: types.SimpleNamespace(dispose=lambda: None)
     )
     monkeypatch.setattr(m, "sessionmaker", lambda bind: lambda: None)
-    conn = m.TAPDBConnection(db_url="sqlite:///:memory:", app_username="pytest")
+    conn = m.TAPDBConnection(
+        db_url="sqlite:///:memory:",
+        app_username="pytest",
+        schema_name="tapdb_unit",
+    )
 
     class Trans:
         def __init__(self):
@@ -186,7 +191,11 @@ def test_session_scope_commit_false_rolls_back(monkeypatch):
         m, "create_engine", lambda *a, **k: types.SimpleNamespace(dispose=lambda: None)
     )
     monkeypatch.setattr(m, "sessionmaker", lambda bind: lambda: None)
-    conn = m.TAPDBConnection(db_url="sqlite:///:memory:", app_username="pytest")
+    conn = m.TAPDBConnection(
+        db_url="sqlite:///:memory:",
+        app_username="pytest",
+        schema_name="tapdb_unit",
+    )
 
     class Trans:
         def __init__(self):
@@ -235,7 +244,11 @@ def test_session_scope_exception_rolls_back_and_reraises(monkeypatch):
         m, "create_engine", lambda *a, **k: types.SimpleNamespace(dispose=lambda: None)
     )
     monkeypatch.setattr(m, "sessionmaker", lambda bind: lambda: None)
-    conn = m.TAPDBConnection(db_url="sqlite:///:memory:", app_username="pytest")
+    conn = m.TAPDBConnection(
+        db_url="sqlite:///:memory:",
+        app_username="pytest",
+        schema_name="tapdb_unit",
+    )
 
     class Trans:
         def __init__(self):
@@ -358,6 +371,53 @@ def test_set_session_timezone_utc_is_noop_for_postgresql(monkeypatch):
     assert calls["execute"] == 0
 
 
+def test_set_session_search_path_executes_for_postgresql(monkeypatch):
+    from daylily_tapdb import connection as m
+
+    monkeypatch.setattr(
+        m, "create_engine", lambda *a, **k: types.SimpleNamespace(dispose=lambda: None)
+    )
+    monkeypatch.setattr(m, "sessionmaker", lambda bind: lambda: None)
+    conn = m.TAPDBConnection(db_url="sqlite:///:memory:", schema_name="tapdb_unit")
+
+    calls = []
+
+    class Sess:
+        def __init__(self):
+            self.bind = types.SimpleNamespace(
+                dialect=types.SimpleNamespace(name="postgresql")
+            )
+
+        def begin_nested(self):
+            return types.SimpleNamespace(commit=lambda: None, rollback=lambda: None)
+
+        def execute(self, stmt, params=None):
+            calls.append((str(stmt), params))
+
+    conn._set_session_search_path(Sess(), local=True)
+    assert "set_config('search_path'" in calls[0][0]
+    assert calls[0][1]["schema_name"] == "tapdb_unit"
+
+
+def test_set_session_search_path_requires_schema_for_postgresql(monkeypatch):
+    from daylily_tapdb import connection as m
+
+    monkeypatch.setattr(
+        m, "create_engine", lambda *a, **k: types.SimpleNamespace(dispose=lambda: None)
+    )
+    monkeypatch.setattr(m, "sessionmaker", lambda bind: lambda: None)
+    conn = m.TAPDBConnection(db_url="sqlite:///:memory:")
+
+    class Sess:
+        def __init__(self):
+            self.bind = types.SimpleNamespace(
+                dialect=types.SimpleNamespace(name="postgresql")
+            )
+
+    with pytest.raises(ValueError, match="schema_name is required"):
+        conn._set_session_search_path(Sess(), local=True)
+
+
 def test_session_scope_domain_setup_failure_does_not_abort_outer_transaction(
     monkeypatch,
 ):
@@ -367,7 +427,11 @@ def test_session_scope_domain_setup_failure_does_not_abort_outer_transaction(
         m, "create_engine", lambda *a, **k: types.SimpleNamespace(dispose=lambda: None)
     )
     monkeypatch.setattr(m, "sessionmaker", lambda bind: lambda: None)
-    conn = m.TAPDBConnection(db_url="sqlite:///:memory:", app_username="pytest")
+    conn = m.TAPDBConnection(
+        db_url="sqlite:///:memory:",
+        app_username="pytest",
+        schema_name="tapdb_unit",
+    )
 
     class Trans:
         def __init__(self):

--- a/tests/test_db_safety.py
+++ b/tests/test_db_safety.py
@@ -171,7 +171,11 @@ def test_db_migrate_idempotent_when_all_migrations_already_applied(
     migrations_dir.mkdir(parents=True)
     (migrations_dir / "001_test.sql").write_text("SELECT 1;\n")
 
-    monkeypatch.setattr(m, "_get_db_config", lambda env: {"database": "tapdb"})
+    monkeypatch.setattr(
+        m,
+        "_get_db_config",
+        lambda env: {"database": "tapdb", "schema_name": "tapdb_app"},
+    )
     monkeypatch.setattr(m, "_check_db_exists", lambda env, db: True)
     monkeypatch.setattr(m, "_schema_exists", lambda env: True)
 
@@ -208,7 +212,11 @@ def test_db_migrate_uses_installed_data_migrations(tmp_path, monkeypatch):
     migration_file.write_text("SELECT 1;\n")
 
     monkeypatch.setattr(m.sysconfig, "get_paths", lambda: {"data": str(data_root)})
-    monkeypatch.setattr(m, "_get_db_config", lambda env: {"database": "tapdb"})
+    monkeypatch.setattr(
+        m,
+        "_get_db_config",
+        lambda env: {"database": "tapdb", "schema_name": "tapdb_app"},
+    )
     monkeypatch.setattr(m, "_check_db_exists", lambda env, db: True)
     monkeypatch.setattr(m, "_schema_exists", lambda env: True)
 
@@ -239,6 +247,7 @@ def test_db_nuke_drops_outbox_and_inbox_tables_before_scope_functions(monkeypatc
             "host": "localhost",
             "port": "5533",
             "engine_type": "local",
+            "schema_name": "tapdb_dev",
         },
     )
     monkeypatch.setattr(m, "_check_db_exists", lambda _env, _db: True)

--- a/tests/test_explicit_context.py
+++ b/tests/test_explicit_context.py
@@ -84,6 +84,7 @@ def _write_config(path: Path) -> Path:
         "    user: tapdb\n"
         "    password: filepw\n"
         "    database: tapdb_dev\n"
+        "    schema_name: tapdb_beta_dev\n"
         "  test:\n"
         "    engine_type: local\n"
         "    host: localhost\n"
@@ -92,7 +93,8 @@ def _write_config(path: Path) -> Path:
         "    domain_code: Z\n"
         "    user: tapdb\n"
         "    password: ''\n"
-        "    database: tapdb_test\n",
+        "    database: tapdb_test\n"
+        "    schema_name: tapdb_beta_test\n",
         encoding="utf-8",
     )
     os.chmod(path, 0o600)
@@ -140,6 +142,7 @@ def test_get_db_config_for_env_ignores_ambient_env_fallbacks(
     assert cfg["host"] == "localhost"
     assert cfg["port"] == "5533"
     assert cfg["password"] == "filepw"
+    assert cfg["schema_name"] == "tapdb_beta_dev"
     assert cfg["config_path"] == str(cfg_path)
 
 

--- a/tests/test_pg_integration.py
+++ b/tests/test_pg_integration.py
@@ -75,9 +75,10 @@ class TestSchemaApply:
                 conn.execute(
                     text(
                         "SELECT tablename FROM pg_tables "
-                        "WHERE schemaname = 'public' "
+                        "WHERE schemaname = :schema_name "
                         "ORDER BY tablename"
-                    )
+                    ),
+                    {"schema_name": pg_instance["schema_name"]},
                 )
                 .scalars()
                 .all()
@@ -137,7 +138,7 @@ class TestConnectionModule:
         from daylily_tapdb.connection import TAPDBConnection
 
         info = pg_instance
-        conn_obj = TAPDBConnection(db_url=info["dsn"])
+        conn_obj = TAPDBConnection(db_url=info["dsn"], schema_name=info["schema_name"])
         with conn_obj as c:
             with c.session_scope(commit=False) as session:
                 val = session.execute(text("SELECT current_database()")).scalar()
@@ -147,7 +148,10 @@ class TestConnectionModule:
         """Verify commit path works with SET LOCAL for audit logging."""
         from daylily_tapdb.connection import TAPDBConnection
 
-        conn_obj = TAPDBConnection(db_url=pg_instance["dsn"])
+        conn_obj = TAPDBConnection(
+            db_url=pg_instance["dsn"],
+            schema_name=pg_instance["schema_name"],
+        )
         with conn_obj as c:
             with c.session_scope(commit=True) as session:
                 session.execute(text("SELECT 1"))
@@ -199,7 +203,12 @@ class TestDbCommands:
 
 class TestORMOperations:
     def _engine(self, pg_instance):
-        return create_engine(pg_instance["dsn"])
+        return create_engine(
+            pg_instance["dsn"],
+            connect_args={
+                "options": f"-csearch_path={pg_instance['schema_name']}",
+            },
+        )
 
     def test_query_templates(self, pg_instance):
         """Verify seeded templates are queryable."""
@@ -252,8 +261,9 @@ class TestORMOperations:
                 conn.execute(
                     text(
                         "SELECT sequencename FROM pg_sequences "
-                        "WHERE schemaname = 'public'"
-                    )
+                        "WHERE schemaname = :schema_name"
+                    ),
+                    {"schema_name": pg_instance["schema_name"]},
                 )
                 .scalars()
                 .all()

--- a/tests/test_runtime_utils_coverage.py
+++ b/tests/test_runtime_utils_coverage.py
@@ -510,6 +510,7 @@ def test_runtime_db_connection_session_scope_commit_and_rollback():
         engine=create_engine("sqlite://"),
         SessionFactory=lambda: session,
         cfg={},
+        schema_name="tapdb_unit",
     )
     conn = runtime_mod.RuntimeDBConnection(bundle)
     conn.app_username = "tester"
@@ -529,6 +530,7 @@ def test_runtime_db_connection_session_scope_commit_and_rollback():
             engine=create_engine("sqlite://"),
             SessionFactory=lambda: session,
             cfg={},
+            schema_name="tapdb_unit",
         )
     )
     with conn.session_scope(commit=True):
@@ -544,12 +546,54 @@ def test_runtime_db_connection_session_scope_commit_and_rollback():
             engine=create_engine("sqlite://"),
             SessionFactory=lambda: session,
             cfg={},
+            schema_name="tapdb_unit",
         )
     )
     with pytest.raises(RuntimeError, match="boom"):
         with conn.session_scope(commit=True):
             raise RuntimeError("boom")
     assert session.trans.rollbacks == 1
+
+
+def test_runtime_db_connection_session_scope_sets_search_path():
+    class _Trans:
+        def commit(self):
+            return None
+
+        def rollback(self):
+            return None
+
+    class _Session:
+        def __init__(self):
+            self.bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+            self.statements = []
+
+        def begin(self):
+            return _Trans()
+
+        def execute(self, stmt, params=None):
+            self.statements.append((str(stmt), params or {}))
+
+        def close(self):
+            return None
+
+    session = _Session()
+    conn = runtime_mod.RuntimeDBConnection(
+        runtime_mod.RuntimeBundle(
+            config_path="/tmp/tapdb.yaml",
+            env_name="dev",
+            engine=create_engine("sqlite://"),
+            SessionFactory=lambda: session,
+            cfg={"schema_name": "tapdb_dev"},
+            schema_name="tapdb_dev",
+        )
+    )
+
+    with conn.session_scope(commit=False):
+        pass
+
+    assert "set_config('search_path'" in session.statements[0][0]
+    assert session.statements[0][1]["schema_name"] == "tapdb_dev"
 
 
 def test_runtime_engine_helpers_cover_auth_modes_and_cache(monkeypatch):
@@ -658,6 +702,7 @@ def test_runtime_engine_helpers_cover_auth_modes_and_cache(monkeypatch):
             "host": "localhost",
             "port": "5432",
             "database": "tapdb_dev",
+            "schema_name": "tapdb_dev",
             "user": "tapdb",
             "password": "",
         },
@@ -679,6 +724,23 @@ def test_runtime_engine_helpers_cover_auth_modes_and_cache(monkeypatch):
 
     with pytest.raises(RuntimeError, match="env name is required"):
         runtime_mod.get_db("/tmp/tapdb.yaml", "")
+
+    monkeypatch.setattr(
+        runtime_mod,
+        "get_db_config_for_env",
+        lambda env, config_path: {
+            "config_path": "/resolved/tapdb.yaml",
+            "engine_type": "local",
+            "host": "localhost",
+            "port": "5432",
+            "database": "tapdb_dev",
+            "user": "tapdb",
+            "password": "",
+        },
+    )
+    runtime_mod._clear_runtime_cache_for_tests()
+    with pytest.raises(RuntimeError, match="schema_name"):
+        runtime_mod.get_db("/tmp/tapdb.yaml", "dev")
 
 
 @pytest.mark.anyio

--- a/tests/test_schema_inventory.py
+++ b/tests/test_schema_inventory.py
@@ -4,10 +4,12 @@ import random
 import time
 from pathlib import Path
 
+import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
 from daylily_tapdb.schema_inventory import (
+    SchemaDriftOperationalError,
     TapdbSchemaInventory,
     build_expected_schema_inventory,
     diff_schema_inventory,
@@ -158,3 +160,34 @@ def test_live_inventory_and_diff_against_real_postgres(pytestconfig):
     finally:
         engine.dispose()
         _drop_schema(dsn, schema_name)
+
+
+def test_explicit_live_inventory_schema_bypasses_multi_schema_discovery(
+    pytestconfig,
+):
+    dsn = resolve_tapdb_test_dsn(pytestconfig)
+
+    schema_sql_path = _repo_schema_root() / "tapdb_schema.sql"
+    suffix = f"{int(time.time())}_{random.randint(1, 1_000_000)}"
+    first_schema = f"tapdb_drift_a_{suffix}"
+    second_schema = f"tapdb_drift_b_{suffix}"
+    _install_schema(dsn, first_schema, schema_sql_path)
+    _install_schema(dsn, second_schema, schema_sql_path)
+
+    engine = create_engine(dsn)
+    try:
+        with Session(engine) as session:
+            explicit = load_live_schema_inventory(session, schema_name=second_schema)
+        assert explicit.schema_name == second_schema
+        assert "generic_template" in explicit.tables
+
+        with Session(engine) as session:
+            with pytest.raises(
+                SchemaDriftOperationalError,
+                match="Multiple TAPDB schemas detected",
+            ):
+                load_live_schema_inventory(session)
+    finally:
+        engine.dispose()
+        _drop_schema(dsn, first_schema)
+        _drop_schema(dsn, second_schema)

--- a/tests/test_schema_name_isolation.py
+++ b/tests/test_schema_name_isolation.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from sqlalchemy import func, select
+
+from daylily_tapdb.cli.db_config import get_db_config_for_env
+from daylily_tapdb.connection import TAPDBConnection
+from daylily_tapdb.models.template import generic_template
+from tests.test_integration import (
+    _drop_schema,
+    _install_schema,
+    _seed_identity_prefixes,
+    _seed_templates,
+)
+
+
+def _write_tapdb_config(
+    *,
+    path: Path,
+    pg_instance: dict,
+    database_name: str,
+    schema_name: str,
+) -> Path:
+    source_config = yaml.safe_load(
+        Path(pg_instance["config_path"]).read_text(encoding="utf-8")
+    )
+    meta = dict(source_config["meta"])
+    meta["database_name"] = database_name
+    payload = {
+        "meta": meta,
+        "environments": {
+            "dev": {
+                "engine_type": "local",
+                "host": "localhost",
+                "port": pg_instance["port"],
+                "ui_port": 18911,
+                "domain_code": "Z",
+                "user": pg_instance["user"],
+                "password": "",
+                "database": pg_instance["database"],
+                "schema_name": schema_name,
+            },
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+    path.chmod(0o600)
+    return path
+
+
+def _seed_marker_template(
+    *, dsn: str, schema_name: str, prefix: str, marker: str
+) -> None:
+    with TAPDBConnection(
+        db_url=dsn,
+        app_username="pytest",
+        domain_code="T",
+        owner_repo_name="daylily-tapdb",
+        schema_name=schema_name,
+    ) as conn:
+        with conn.session_scope(commit=True) as session:
+            _seed_identity_prefixes(session, prefix=prefix)
+            _seed_templates(
+                session,
+                [
+                    {
+                        "name": f"{marker} Schema Marker",
+                        "polymorphic_discriminator": "generic_template",
+                        "category": "schema",
+                        "type": "isolation",
+                        "subtype": marker.lower(),
+                        "version": "1.0",
+                        "instance_prefix": prefix,
+                        "is_singleton": False,
+                        "bstatus": "active",
+                        "json_addl": {"marker": marker},
+                    }
+                ],
+            )
+
+
+def _template_names(*, dsn: str, schema_name: str) -> set[str]:
+    with TAPDBConnection(
+        db_url=dsn,
+        app_username="pytest",
+        domain_code="T",
+        owner_repo_name="daylily-tapdb",
+        schema_name=schema_name,
+    ) as conn:
+        with conn.session_scope(commit=False) as session:
+            return set(session.scalars(select(generic_template.name)).all())
+
+
+def test_two_configured_schemas_share_one_physical_database_without_cross_reads(
+    pg_instance,
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    schema_sql_path = repo_root / "schema" / "tapdb_schema.sql"
+    schema_a = "tapdb_atlas_dayfly5_dev"
+    schema_b = "tapdb_bloom_dayfly5_dev"
+    config_a = _write_tapdb_config(
+        path=tmp_path / "alpha" / "tapdb-config.yaml",
+        pg_instance=pg_instance,
+        database_name="atlas-dayfly5",
+        schema_name=schema_a,
+    )
+    config_b = _write_tapdb_config(
+        path=tmp_path / "beta" / "tapdb-config.yaml",
+        pg_instance=pg_instance,
+        database_name="bloom-dayfly5",
+        schema_name=schema_b,
+    )
+
+    cfg_a = get_db_config_for_env("dev", config_path=config_a)
+    cfg_b = get_db_config_for_env("dev", config_path=config_b)
+    assert cfg_a["database"] == cfg_b["database"] == pg_instance["database"]
+    assert cfg_a["schema_name"] == schema_a
+    assert cfg_b["schema_name"] == schema_b
+
+    try:
+        _install_schema(pg_instance["dsn"], schema_a, schema_sql_path)
+        _install_schema(pg_instance["dsn"], schema_b, schema_sql_path)
+        _seed_marker_template(
+            dsn=pg_instance["dsn"], schema_name=schema_a, prefix="AX", marker="Alpha"
+        )
+        _seed_marker_template(
+            dsn=pg_instance["dsn"], schema_name=schema_b, prefix="BT", marker="Beta"
+        )
+
+        names_a = _template_names(dsn=pg_instance["dsn"], schema_name=schema_a)
+        names_b = _template_names(dsn=pg_instance["dsn"], schema_name=schema_b)
+
+        assert "Alpha Schema Marker" in names_a
+        assert "Beta Schema Marker" not in names_a
+        assert "Beta Schema Marker" in names_b
+        assert "Alpha Schema Marker" not in names_b
+
+        with TAPDBConnection(
+            db_url=pg_instance["dsn"],
+            app_username="pytest",
+            domain_code="T",
+            owner_repo_name="daylily-tapdb",
+            schema_name=schema_a,
+        ) as conn_a:
+            with conn_a.session_scope(commit=False) as session_a:
+                count_a = session_a.scalar(
+                    select(func.count()).select_from(generic_template)
+                )
+        with TAPDBConnection(
+            db_url=pg_instance["dsn"],
+            app_username="pytest",
+            domain_code="T",
+            owner_repo_name="daylily-tapdb",
+            schema_name=schema_b,
+        ) as conn_b:
+            with conn_b.session_scope(commit=False) as session_b:
+                count_b = session_b.scalar(
+                    select(func.count()).select_from(generic_template)
+                )
+
+        assert count_a == len(names_a)
+        assert count_b == len(names_b)
+    finally:
+        _drop_schema(pg_instance["dsn"], schema_a)
+        _drop_schema(pg_instance["dsn"], schema_b)

--- a/tests/test_services_external_refs.py
+++ b/tests/test_services_external_refs.py
@@ -15,6 +15,8 @@ def _ref(
     graph_expandable: bool = True,
     graph_data_path: str = "/api/graph/data",
     object_detail_path_template: str = "/api/object/{euid}",
+    relationship_type: str | None = None,
+    source_field: str | None = None,
     tenant_id: str | None = "tenant-1",
 ) -> eg.ExternalGraphRef:
     return eg.ExternalGraphRef(
@@ -29,6 +31,8 @@ def _ref(
         graph_data_path=graph_data_path,
         object_detail_path_template=object_detail_path_template,
         auth_mode=auth_mode,
+        relationship_type=relationship_type,
+        source_field=source_field,
     )
 
 
@@ -99,14 +103,19 @@ def test_external_ref_payloads_exposes_public_dicts():
         json_addl={
             "properties": {
                 "external_payload": {
-                    "tapdb_graph": {
-                        "system": "atlas",
-                        "root_euid": "A-1",
-                        "base_url": "https://atlas.local",
-                        "graph_data_path": "/api/graph/data",
-                        "object_detail_path_template": "/api/object/{euid}",
-                        "auth_mode": "none",
-                    }
+                    "tapdb_graph": [
+                        {
+                            "system": "atlas",
+                            "root_euid": "A-1",
+                            "base_url": "https://atlas.local",
+                            "graph_data_path": "/api/graph/data",
+                            "object_detail_path_template": "/api/object/{euid}",
+                            "auth_mode": "none",
+                            "label": "Atlas source object",
+                            "relationship_type": "derived_from",
+                            "source_field": "properties.atlas_euid",
+                        }
+                    ]
                 }
             }
         }
@@ -114,13 +123,15 @@ def test_external_ref_payloads_exposes_public_dicts():
 
     assert eg.external_ref_payloads(obj) == [
         {
-            "label": "atlas:A-1",
+            "label": "Atlas source object",
             "system": "atlas",
             "root_euid": "A-1",
             "tenant_id": None,
             "href": "https://atlas.local/api/object/A-1",
             "graph_expandable": True,
             "ref_index": 0,
+            "relationship_type": "derived_from",
+            "source_field": "properties.atlas_euid",
         }
     ]
 
@@ -267,7 +278,11 @@ def test_namespace_external_graph_namespaces_nodes_edges_and_bridge():
             ],
         }
     }
-    ref = _ref(tenant_id="tenant-1")
+    ref = _ref(
+        relationship_type="derived_from",
+        source_field="properties.atlas_euid",
+        tenant_id="tenant-1",
+    )
 
     out = eg.namespace_external_graph(
         payload,
@@ -287,5 +302,7 @@ def test_namespace_external_graph_namespaces_nodes_edges_and_bridge():
     assert edges[0]["data"]["target"] == "ext::atlas::tenant-1::R-2"
     assert edges[1]["data"]["is_external_bridge"] is True
     assert edges[1]["data"]["source"] == "TGX-10"
+    assert edges[1]["data"]["relationship_type"] == "derived_from"
+    assert edges[1]["data"]["source_field"] == "properties.atlas_euid"
     assert out["meta"]["node_count"] == 1
     assert out["meta"]["edge_count"] == 2

--- a/tests/test_services_graph_payloads.py
+++ b/tests/test_services_graph_payloads.py
@@ -35,8 +35,20 @@ def _build_instance_graph():
         subtype="sample",
         version="1.0",
         bstatus="active",
-        json_addl={"properties": {"external_payload": {"tapdb_graph": []}}},
+        json_addl={
+            "properties": {
+                "external_payload": {"tapdb_graph": []},
+                "graph": {
+                    "role": "root",
+                    "expected_fanout_max": 12,
+                    "collapse_by_default": True,
+                    "fanout_reason": "one source object can have many outputs",
+                    "unsafe_layout": "left",
+                },
+            }
+        },
         created_dt=datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        modified_dt=datetime(2024, 1, 3, 4, 5, 6, tzinfo=timezone.utc),
         is_deleted=False,
     )
     child = SimpleNamespace(
@@ -50,6 +62,7 @@ def _build_instance_graph():
         bstatus="active",
         json_addl={},
         created_dt=None,
+        modified_dt=None,
         is_deleted=False,
     )
     lineage = SimpleNamespace(
@@ -87,11 +100,15 @@ def test_build_object_detail_payload_includes_external_refs_and_iso_dates() -> N
                         "graph_data_path": "/api/graph/data",
                         "object_detail_path_template": "/api/object/{euid}",
                         "auth_mode": "none",
+                        "label": "Atlas patient record",
+                        "relationship_type": "represents",
+                        "source_field": "properties.patient_id",
                     }
                 }
             }
         },
         created_dt=datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        modified_dt=datetime(2024, 1, 3, 4, 5, 6, tzinfo=timezone.utc),
     )
 
     payload = build_object_detail_payload(
@@ -104,15 +121,18 @@ def test_build_object_detail_payload_includes_external_refs_and_iso_dates() -> N
     assert payload["system"] == "dewey"
     assert payload["display_label"] == "Root Tube"
     assert payload["created_dt"] == "2024-01-02T03:04:05+00:00"
+    assert payload["modified_dt"] == "2024-01-03T04:05:06+00:00"
     assert payload["external_refs"] == [
         {
-            "label": "atlas:AT-1",
+            "label": "Atlas patient record",
             "system": "atlas",
             "root_euid": "AT-1",
             "tenant_id": None,
             "href": "https://atlas.local/api/object/AT-1",
             "graph_expandable": True,
             "ref_index": 0,
+            "relationship_type": "represents",
+            "source_field": "properties.patient_id",
         }
     ]
 
@@ -131,7 +151,26 @@ def test_build_graph_payload_returns_instance_graph_and_singletons() -> None:
     assert node_ids == {"GX1", "GX2"}
     assert payload["elements"]["edges"][0]["data"]["source"] == "GX2"
     assert payload["elements"]["edges"][0]["data"]["target"] == "GX1"
-    assert payload["elements"]["nodes"][0]["data"]["color"] == "#8B00FF"
+    root_node = next(
+        node["data"]
+        for node in payload["elements"]["nodes"]
+        if node["data"]["id"] == "GX1"
+    )
+    child_node = next(
+        node["data"]
+        for node in payload["elements"]["nodes"]
+        if node["data"]["id"] == "GX2"
+    )
+    assert root_node["color"] == "#8B00FF"
+    assert root_node["created_dt"] == "2024-01-02T03:04:05+00:00"
+    assert root_node["modified_dt"] == "2024-01-03T04:05:06+00:00"
+    assert child_node["created_dt"] is None
+    assert child_node["modified_dt"] is None
+    assert root_node["role"] == "root"
+    assert root_node["expected_fanout_max"] == 12
+    assert root_node["collapse_by_default"] is True
+    assert root_node["fanout_reason"] == "one source object can have many outputs"
+    assert "unsafe_layout" not in root_node
 
     lineage_only = build_graph_payload(
         child.child_of_lineages._items[0],

--- a/tests/test_web_dag.py
+++ b/tests/test_web_dag.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 from fastapi import FastAPI
@@ -90,6 +91,13 @@ def _build_fake_runtime_connection():
         json_addl={
             "properties": {
                 "color": "blue",
+                "graph": {
+                    "role": "source",
+                    "expected_fanout_max": 8,
+                    "collapse_by_default": False,
+                    "fanout_reason": "root specimen source",
+                    "debug": "do not expose",
+                },
                 "external_payload": {
                     "tapdb_graph": {
                         "system": "atlas",
@@ -103,7 +111,8 @@ def _build_fake_runtime_connection():
                 },
             }
         },
-        created_dt=None,
+        created_dt=datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        modified_dt=datetime(2024, 1, 3, 4, 5, 6, tzinfo=timezone.utc),
         is_deleted=False,
     )
     child = SimpleNamespace(
@@ -117,6 +126,7 @@ def _build_fake_runtime_connection():
         bstatus="active",
         json_addl={},
         created_dt=None,
+        modified_dt=None,
         is_deleted=False,
     )
     template = SimpleNamespace(
@@ -130,6 +140,7 @@ def _build_fake_runtime_connection():
         bstatus="active",
         json_addl={},
         created_dt=None,
+        modified_dt=None,
         is_deleted=False,
     )
     lineage = SimpleNamespace(
@@ -259,6 +270,18 @@ def test_create_tapdb_dag_router_serves_exact_lookup_graph_and_external(
     assert node_ids == {"GX1", "GX2"}
     assert graph_body["elements"]["edges"][0]["data"]["source"] == "GX2"
     assert graph_body["elements"]["edges"][0]["data"]["target"] == "GX1"
+    root_node = next(
+        node["data"]
+        for node in graph_body["elements"]["nodes"]
+        if node["data"]["id"] == "GX1"
+    )
+    assert root_node["created_dt"] == "2024-01-02T03:04:05+00:00"
+    assert root_node["modified_dt"] == "2024-01-03T04:05:06+00:00"
+    assert root_node["role"] == "source"
+    assert root_node["expected_fanout_max"] == 8
+    assert root_node["collapse_by_default"] is False
+    assert root_node["fanout_reason"] == "root specimen source"
+    assert "debug" not in root_node
     assert (
         graph_body["elements"]["nodes"][0]["data"]["external_refs"][0]["root_euid"]
         == "AT-1"


### PR DESCRIPTION
## Summary
- add explicit TapDB `schema_name` config support and validation
- target schema apply/migrate/status/inventory/admin/runtime connections at the configured schema
- set SQLAlchemy runtime search paths for service isolation
- add multi-schema isolation coverage for two service schemas in one physical PostgreSQL database
- pin `meridian-euid==0.4.5`

## Validation
- `.venv/bin/python -m pytest tests/test_aurora_config.py tests/test_explicit_context.py tests/test_cli_root_floor_lift.py tests/test_cli_db_floor_lift.py tests/test_cli_helper_units.py tests/test_connection_unit.py tests/test_admin_db_connection.py tests/test_runtime_utils_coverage.py tests/test_admin_support_coverage.py tests/test_coverage_boost.py tests/test_schema_inventory.py tests/test_admin_main_coverage.py tests/test_schema_name_isolation.py -q` -> `182 passed, 2 skipped`
- `.venv/bin/ruff check admin/db_pool.py admin/main.py daylily_tapdb/cli/__init__.py daylily_tapdb/cli/db.py daylily_tapdb/cli/db_config.py daylily_tapdb/connection.py daylily_tapdb/schema_inventory.py daylily_tapdb/web/runtime.py tests/test_admin_db_connection.py tests/test_admin_main_coverage.py tests/test_admin_support_coverage.py tests/test_aurora_config.py tests/test_cli_db_floor_lift.py tests/test_cli_helper_units.py tests/test_cli_root_floor_lift.py tests/test_connection_unit.py tests/test_explicit_context.py tests/test_runtime_utils_coverage.py tests/test_schema_inventory.py tests/test_schema_name_isolation.py` -> passed

## Notes
This PR includes the existing `6.0.10` DAG provenance commit that was already on the source branch, plus the schema namespace commit.