### PR TITLE
Add schema name to db-config init

### DIFF
--- a/daylily_tapdb/cli/__init__.py
+++ b/daylily_tapdb/cli/__init__.py
@@ -1137,6 +1137,7 @@ def build_app():
         env: list[str],
         db_port: list[str],
         ui_port: list[str],
+        schema_name: list[str],
         force: bool,
     ) -> tuple[Path, dict]:
         current = active_context_overrides()
@@ -1166,6 +1167,7 @@ def build_app():
 
         db_ports = _parse_env_port_pairs(db_port, flag="--db-port")
         ui_ports = _parse_env_port_pairs(ui_port, flag="--ui-port")
+        schema_names = _parse_env_text_pairs(schema_name, flag="--schema-name")
         domain_codes = _parse_env_text_pairs(domain_code, flag="--domain-code")
 
         root = existing if isinstance(existing, dict) else {}
@@ -1235,7 +1237,8 @@ def build_app():
                 ),
                 "schema_name": validate_postgres_identifier_component(
                     str(
-                        prior.get("schema_name")
+                        schema_names.get(env_name)
+                        or prior.get("schema_name")
                         or default_schema_name_for_database(database_name, env_name)
                     ),
                     field_name=f"environments.{env_name}.schema_name",
@@ -1326,6 +1329,7 @@ def build_app():
             env=[env_name],
             db_port=[f"{env_name}=5432"],
             ui_port=ui_port,
+            schema_name=[],
             force=False,
         )
         return initialized_path
@@ -1371,6 +1375,11 @@ def build_app():
             "--ui-port",
             help="Per-env UI port mapping (ENV=PORT, repeatable)",
         ),
+        schema_name: list[str] = typer.Option(
+            [],
+            "--schema-name",
+            help="Per-env PostgreSQL schema mapping (ENV=SCHEMA, repeatable)",
+        ),
         force: bool = typer.Option(
             False, "--force", help="Overwrite existing config metadata if needed"
         ),
@@ -1386,6 +1395,7 @@ def build_app():
             env=env,
             db_port=db_port,
             ui_port=ui_port,
+            schema_name=schema_name,
             force=force,
         )
         ccyo_out.success("TAPDB namespaced config initialized")

--- a/tests/test_cli_root_floor_lift.py
+++ b/tests/test_cli_root_floor_lift.py
@@ -720,7 +720,9 @@ def test_config_init_update_and_info_commands(
     init_payload = yaml.safe_load(init_path.read_text(encoding="utf-8"))
     assert init_payload["meta"]["client_id"] == "atlas"
     assert init_payload["environments"]["dev"]["ui_port"] == "8911"
-    assert init_payload["environments"]["dev"]["schema_name"] == "tapdb_atlas_unidbtst_dev"
+    assert (
+        init_payload["environments"]["dev"]["schema_name"] == "tapdb_atlas_unidbtst_dev"
+    )
     assert init_payload["environments"]["test"]["port"] == "5534"
     assert init_payload["environments"]["test"]["schema_name"] == "tapdb_app_test"
 

--- a/tests/test_cli_root_floor_lift.py
+++ b/tests/test_cli_root_floor_lift.py
@@ -712,13 +712,15 @@ def test_config_init_update_and_info_commands(
             "dev=8911",
             "--ui-port",
             "test=8912",
+            "--schema-name",
+            "dev=tapdb_atlas_unidbtst_dev",
         ],
     )
     assert result.exit_code == 0
     init_payload = yaml.safe_load(init_path.read_text(encoding="utf-8"))
     assert init_payload["meta"]["client_id"] == "atlas"
     assert init_payload["environments"]["dev"]["ui_port"] == "8911"
-    assert init_payload["environments"]["dev"]["schema_name"] == "tapdb_app_dev"
+    assert init_payload["environments"]["dev"]["schema_name"] == "tapdb_atlas_unidbtst_dev"
     assert init_payload["environments"]["test"]["port"] == "5534"
     assert init_payload["environments"]["test"]["schema_name"] == "tapdb_app_test"
 


### PR DESCRIPTION
## Summary
- add repeatable --schema-name ENV=SCHEMA to db-config init
- use the explicit schema when writing per-env config
- cover the explicit init schema path in CLI tests

## Tests
- source ./activate && python -m pytest tests/test_cli_root_floor_lift.py::test_config_init_update_and_info_commands -q
- source ./activate && python -m pytest tests/test_aurora_config.py -k 'schema_name or explicit_schema_name or unsafe_schema_name' -q
- source ./activate && tapdb db-config init --help