### PR TITLE
Remove TapDB environment target toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,16 +56,16 @@ source ./activate
 Always use `tapdb` CLI commands for database operations. Never run raw SQL or shell scripts.
 
 ```bash
-tapdb --config <path> --env <name> bootstrap local         # Full local setup
-tapdb --config <path> --env <name> db schema apply <env>   # Apply schema
-tapdb --config <path> --env <name> db schema migrate <env> # Run migrations
-tapdb --config <path> --env <name> db data seed <env>      # Seed templates
+tapdb --config <path> bootstrap local       # Full local setup
+tapdb --config <path> db schema apply       # Apply schema
+tapdb --config <path> db schema migrate     # Run migrations
+tapdb --config <path> db data seed          # Seed templates
 ```
 
 Use explicit TapDB context for runtime commands:
 
 ```bash
-tapdb --config <path> --env <name> ...
+tapdb --config <path> ...
 ```
 
 ## No Circumvention Policy
@@ -78,15 +78,14 @@ tapdb --config <path> --env <name> ...
 ## Testing
 
 ```bash
-# Run all tests (deselect known-broken smoke tests)
-python -m pytest tests/ -q --deselect tests/test_admin_routes_smoke.py
+# Run all tests
+python -m pytest tests/ -q
 
 # Run specific test file
 python -m pytest tests/test_models.py -q
 ```
 
-- **Known pre-existing failures**: `tests/test_admin_routes_smoke.py` (TypeError in route mocks — not a regression).
-- All other tests must pass before merging.
+- All tests must pass before merging.
 
 ## Branch Discipline
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ source ./activate
 The canonical operational form for runtime commands is:
 
 ```bash
-tapdb --config <path> --env <name> ...
+tapdb --config <path> ...
 ```
 
 Smoke the installed CLI surface first:
@@ -59,23 +59,25 @@ For a fuller local bootstrap, use the namespaced config flow and then bring up t
 
 ```bash
 tapdb --config ~/.config/tapdb/<client-id>/<database-name>/tapdb-config.yaml \
-  db-config init \
+  config init \
   --client-id <client-id> \
   --database-name <database-name> \
   --owner-repo-name <repo-name> \
-  --env dev \
-  --domain-code dev=<domain-code> \
+  --domain-code <domain-code> \
   --domain-registry-path /abs/path/to/domain_code_registry.json \
   --prefix-ownership-registry-path /abs/path/to/prefix_ownership_registry.json \
-  --db-port dev=5533 \
-  --ui-port dev=8911
+  --engine-type local \
+  --host localhost \
+  --port 5533 \
+  --ui-port 8911 \
+  --user tapdb \
+  --database tapdb_<client-id>_<database-name> \
+  --schema-name tapdb_<client-id>_<database-name>
 
 tapdb --config ~/.config/tapdb/<client-id>/<database-name>/tapdb-config.yaml \
-  --env dev \
   bootstrap local --no-gui
 
 tapdb --config ~/.config/tapdb/<client-id>/<database-name>/tapdb-config.yaml \
-  --env dev \
   --json info
 ```
 

--- a/admin/auth.py
+++ b/admin/auth.py
@@ -16,8 +16,7 @@ from itsdangerous import BadSignature
 
 from admin.cognito import get_cognito_auth
 from admin.db_pool import get_db_connection
-from daylily_tapdb.cli.context import active_env_name
-from daylily_tapdb.cli.db_config import get_admin_settings_for_env
+from daylily_tapdb.cli.db_config import get_admin_settings
 from daylily_tapdb.user_store import (
     create_or_get,
     get_by_login_or_email,
@@ -34,8 +33,7 @@ SESSION_MAX_AGE = 86400  # 24 hours
 
 
 def _admin_settings() -> dict[str, Any]:
-    env_name = active_env_name("dev").strip().lower()
-    return get_admin_settings_for_env(env_name)
+    return get_admin_settings()
 
 
 def _auth_disabled() -> bool:
@@ -164,9 +162,8 @@ def _tapdb_url(request: Request, path: str) -> str:
 
 
 def get_db():
-    """Get a DB connection using the active explicit TapDB env."""
-    env = active_env_name("dev").lower()
-    return get_db_connection(env)
+    """Get a DB connection using the active explicit TapDB target."""
+    return get_db_connection()
 
 
 def get_user_by_username(username: str) -> Optional[dict]:

--- a/admin/cognito.py
+++ b/admin/cognito.py
@@ -8,8 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 from daylily_tapdb.cli.cognito import REQUIRED_COGNITO_CLIENT_NAME
-from daylily_tapdb.cli.context import active_env_name
-from daylily_tapdb.cli.db_config import get_db_config_for_env
+from daylily_tapdb.cli.db_config import get_db_config
 
 
 @dataclass(frozen=True)
@@ -29,14 +28,14 @@ class TapdbPoolConfig:
 
 
 def resolve_tapdb_pool_config(env_name: Optional[str] = None) -> TapdbPoolConfig:
-    """Resolve TAPDB Cognito runtime config for an environment."""
-    env_key = (env_name or active_env_name("dev")).strip().lower()
-    cfg = get_db_config_for_env(env_key)
+    """Resolve TAPDB Cognito runtime config for the explicit target."""
+    _ = env_name
+    cfg = get_db_config()
     pool_id = (cfg.get("cognito_user_pool_id") or "").strip()
     if not pool_id:
         raise RuntimeError(
-            f"TAPDB Cognito is not configured for env '{env_key}'. "
-            f"Set environments.{env_key}.cognito_user_pool_id in tapdb config."
+            "TAPDB Cognito is not configured for the explicit target. "
+            "Set target.cognito_user_pool_id in tapdb config."
         )
 
     app_client_id = (cfg.get("cognito_app_client_id") or "").strip()
@@ -51,13 +50,13 @@ def resolve_tapdb_pool_config(env_name: Optional[str] = None) -> TapdbPoolConfig
         )
     if not app_client_id:
         raise RuntimeError(
-            f"TAPDB Cognito app client is not configured for env '{env_key}'. "
-            f"Set environments.{env_key}.cognito_app_client_id in tapdb config."
+            "TAPDB Cognito app client is not configured for the explicit target. "
+            "Set target.cognito_app_client_id in tapdb config."
         )
     if not region:
         raise RuntimeError(
-            f"TAPDB Cognito region is not configured for env '{env_key}'. "
-            f"Set environments.{env_key}.cognito_region in tapdb config."
+            "TAPDB Cognito region is not configured for the explicit target. "
+            "Set target.cognito_region in tapdb config."
         )
 
     return TapdbPoolConfig(

--- a/admin/db_metrics.py
+++ b/admin/db_metrics.py
@@ -26,8 +26,8 @@ from typing import Iterable, Optional
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 
-from daylily_tapdb.cli.context import active_env_name, resolve_context
-from daylily_tapdb.cli.db_config import get_admin_settings_for_env
+from daylily_tapdb.cli.context import resolve_context
+from daylily_tapdb.cli.db_config import get_admin_settings
 
 # Request attribution (set by middleware and session_scope).
 request_path_var: ContextVar[str] = ContextVar("tapdb_request_path", default="")
@@ -60,8 +60,7 @@ def _parse_bool(value: object, *, default: bool) -> bool:
 
 
 def _admin_settings() -> dict[str, object]:
-    env_name = active_env_name("dev").strip().lower()
-    return get_admin_settings_for_env(env_name)
+    return get_admin_settings()
 
 
 def metrics_enabled() -> bool:
@@ -111,9 +110,9 @@ def _extract_table_hint(statement: str, op: str) -> str:
 
 
 def _metrics_root_dir(env_name: str) -> Path:
-    env = (env_name or "dev").strip().lower()
-    ctx = resolve_context(require_keys=True, env_name=env)
-    return ctx.runtime_dir(env) / "metrics"
+    _ = env_name
+    ctx = resolve_context(require_keys=True)
+    return ctx.runtime_dir() / "metrics"
 
 
 def two_week_period_start_utc(now_utc: datetime) -> datetime:
@@ -166,7 +165,7 @@ class MetricsRow:
 
 class TSVMetricsWriter:
     def __init__(self, env_name: str):
-        self._env_name = (env_name or "dev").strip().lower()
+        self._env_name = "target"
         settings = _admin_settings()
         self._queue_max = int(settings.get("metrics_queue_max") or 20000)
         self._flush_secs = float(settings.get("metrics_flush_seconds") or 1.0)
@@ -227,7 +226,7 @@ _writers_by_env: dict[str, TSVMetricsWriter] = {}
 def _get_writer(env_name: str) -> Optional[TSVMetricsWriter]:
     if not metrics_enabled():
         return None
-    env = (env_name or "dev").strip().lower()
+    env = "target"
     with _writer_lock:
         writer = _writers_by_env.get(env)
         if writer is None:
@@ -237,7 +236,8 @@ def _get_writer(env_name: str) -> Optional[TSVMetricsWriter]:
 
 
 def get_dropped_count(env_name: str) -> int:
-    env = (env_name or "dev").strip().lower()
+    _ = env_name
+    env = "target"
     with _writer_lock:
         writer = _writers_by_env.get(env)
     return writer.dropped_count() if writer else 0
@@ -456,7 +456,7 @@ def summarize_metrics(rows: Iterable[dict]) -> dict:
 
 
 def build_metrics_page_context(env_name: str, *, limit: int = 5000) -> dict:
-    env = (env_name or "dev").strip().lower()
+    env = "target"
     clamped = max(1, min(int(limit), 20000))
     now = datetime.now(timezone.utc)
     period_start = two_week_period_start_utc(now)

--- a/admin/db_pool.py
+++ b/admin/db_pool.py
@@ -26,15 +26,16 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from daylily_tapdb.aurora.connection import AuroraConnectionBuilder
 from daylily_tapdb.cli.db_config import (
-    get_admin_settings_for_env,
-    get_db_config_for_env,
+    get_admin_settings,
+    get_db_config,
 )
 
 logger = logging.getLogger(__name__)
 
 
 def _admin_settings(env_name: str) -> dict[str, object]:
-    return get_admin_settings_for_env(env_name)
+    _ = env_name
+    return get_admin_settings()
 
 
 def _parse_bool(value: object, *, default: bool) -> bool:
@@ -68,7 +69,7 @@ def _require_schema_name(cfg: dict[str, str], *, env_name: str) -> str:
     schema_name = str(cfg.get("schema_name") or "").strip()
     if not schema_name:
         raise RuntimeError(
-            f"Config for env {env_name!r} is missing required field: schema_name"
+            "Config for explicit TapDB target is missing required field: schema_name"
         )
     return schema_name
 
@@ -259,15 +260,16 @@ def _build_engine_for_cfg(cfg: dict[str, str], *, env_name: str) -> Engine:
     return _create_engine(url, echo_sql=echo_sql, env_name=env_name)
 
 
-def get_engine_bundle(env_name: str) -> EngineBundle:
-    """Return (and cache) the shared engine bundle for an env."""
-    env = (env_name or "dev").strip().lower()
+def get_engine_bundle(env_name: str = "target") -> EngineBundle:
+    """Return (and cache) the shared engine bundle for the explicit target."""
+    _ = env_name
+    env = "target"
     with _engine_lock:
         cached = _bundles_by_env.get(env)
         if cached is not None:
             return cached
 
-        cfg = get_db_config_for_env(env)
+        cfg = get_db_config()
         schema_name = _require_schema_name(cfg, env_name=env)
         engine = _build_engine_for_cfg(cfg, env_name=env)
         from admin.db_metrics import maybe_install_engine_metrics
@@ -285,8 +287,9 @@ def get_engine_bundle(env_name: str) -> EngineBundle:
         return bundle
 
 
-def get_db_connection(env_name: str) -> AdminDBConnection:
+def get_db_connection(env_name: str = "target") -> AdminDBConnection:
     """Create a per-request AdminDBConnection backed by the cached Engine."""
+    _ = env_name
     return AdminDBConnection(get_engine_bundle(env_name))
 
 

--- a/admin/main.py
+++ b/admin/main.py
@@ -60,11 +60,10 @@ from admin.domain_access import (
     validate_allowed_origins,
 )
 from daylily_tapdb import InstanceFactory, TemplateManager, __version__
-from daylily_tapdb.cli.context import active_env_name
 from daylily_tapdb.cli.db_config import (
-    get_admin_settings_for_env,
+    get_admin_settings,
     get_config_path,
-    get_db_config_for_env,
+    get_db_config,
 )
 from daylily_tapdb.models.audit import audit_log
 from daylily_tapdb.models.instance import generic_instance
@@ -100,12 +99,12 @@ templates = Environment(
 )
 
 
-def _active_tapdb_env() -> str:
-    return active_env_name("dev").lower()
+def _active_tapdb_target() -> str:
+    return "target"
 
 
-APP_ENV = _active_tapdb_env()
-IS_PROD = APP_ENV == "prod"
+APP_ENV = _active_tapdb_target()
+IS_PROD = False
 DEFAULT_SUPPORT_EMAIL = "support@daylilyinformatics.com"
 DEFAULT_GITHUB_REPO_URL = "https://github.com/Daylily-Informatics/tapdb-core"
 _RESERVED_TEMPLATE_COORDS = {("generic", "actor", "system_user")}
@@ -137,7 +136,7 @@ def _default_admin_settings() -> dict[str, Any]:
 
 def _load_admin_settings() -> dict[str, Any]:
     try:
-        return get_admin_settings_for_env(APP_ENV)
+        return get_admin_settings()
     except Exception as exc:
         logger.warning("Could not resolve TAPDB admin settings from config: %s", exc)
         return _default_admin_settings()
@@ -340,10 +339,9 @@ def get_db():
     """Get database connection.
 
     Uses the canonical config loader from daylily_tapdb.cli.db_config.
-    The active env comes from explicit TapDB CLI/app context and defaults to 'dev'.
+    The active target comes from explicit TapDB CLI/app context.
     """
-    env = _active_tapdb_env()
-    return get_db_connection(env)
+    return get_db_connection()
 
 
 def get_style(request: Optional[Request] = None) -> Dict[str, str]:
@@ -379,7 +377,7 @@ templates.globals["is_reserved_template"] = _is_reserved_template
 
 def load_db_metrics_context(*, limit: int = 5000) -> dict:
     """Load DB metrics data for the admin metrics page (test-friendly wrapper)."""
-    env = _active_tapdb_env()
+    env = _active_tapdb_target()
     return build_metrics_page_context(env, limit=limit)
 
 
@@ -867,7 +865,7 @@ async def oauth_login(
     if user:
         return RedirectResponse(tapdb_url(request, "/"), status_code=302)
 
-    env_name = _active_tapdb_env()
+    env_name = _active_tapdb_target()
     try:
         runtime = _resolve_cognito_oauth_runtime(env_name)
     except Exception as exc:
@@ -906,7 +904,7 @@ async def oauth_callback(
     error_description: Optional[str] = None,
 ):
     """Handle Cognito Hosted UI OAuth callback."""
-    env_name = _active_tapdb_env()
+    env_name = _active_tapdb_target()
     if error:
         details = error_description or error
         content = templates.get_template("login.html").render(
@@ -1395,8 +1393,8 @@ async def info_page(request: Request):
     """Runtime info page with DB and Cognito connection details."""
     user = request.state.user
     permissions = get_user_permissions(user)
-    env = _active_tapdb_env()
-    cfg = get_db_config_for_env(env)
+    env = _active_tapdb_target()
+    cfg = get_db_config()
     is_admin = str(user.get("role") or "").strip().lower() == "admin"
 
     inventory_ctx = _empty_db_inventory_context()
@@ -1410,7 +1408,7 @@ async def info_page(request: Request):
     )
 
     db_rows: List[tuple[str, str]] = [
-        ("environment", env),
+        ("target", env),
         ("config_path", str(get_config_path())),
         ("runtime_database_name", runtime_db_name),
     ]

--- a/daylily_tapdb/__init__.py
+++ b/daylily_tapdb/__init__.py
@@ -6,11 +6,10 @@ with PostgreSQL and SQLAlchemy.
 
 Example:
     from daylily_tapdb import TAPDBConnection, TemplateManager, InstanceFactory
-    from daylily_tapdb.cli.db_config import get_db_config_for_env
+    from daylily_tapdb.cli.db_config import get_db_config
 
-    # Connect using an explicit TapDB config + env (recommended)
-    cfg = get_db_config_for_env(
-        "dev",
+    # Connect using an explicit TapDB target config.
+    cfg = get_db_config(
         config_path="~/.config/tapdb/tapdb/tapdb/tapdb-config.yaml",
     )
     db = TAPDBConnection(

--- a/daylily_tapdb/cli/__init__.py
+++ b/daylily_tapdb/cli/__init__.py
@@ -21,16 +21,11 @@ from daylily_tapdb.cli._registry_v2 import help_text, policy_for_command
 from daylily_tapdb.cli.context import (
     TapdbContext,
     active_context_overrides,
-    active_env_name,
     clear_cli_context,
     resolve_context,
     set_cli_context,
 )
-from daylily_tapdb.cli.db_config import (
-    default_database_name_for_namespace,
-    default_schema_name_for_database,
-    validate_postgres_identifier_component,
-)
+from daylily_tapdb.cli.db_config import validate_postgres_identifier_component
 from daylily_tapdb.cli.output import print_renderable
 from daylily_tapdb.cli.spec import spec
 from daylily_tapdb.governance import (
@@ -47,20 +42,13 @@ PID_FILE = Path.home() / ".tapdb" / "ui.pid"
 LOG_FILE = Path.home() / ".tapdb" / "ui.log"
 
 
-def _active_env_name() -> str:
-    return active_env_name("dev").strip().lower()
+def _require_context() -> TapdbContext:
+    return resolve_context(require_keys=True)
 
 
-def _require_context(*, env_name: Optional[str] = None) -> TapdbContext:
-    return resolve_context(
-        require_keys=True,
-        env_name=env_name if env_name is not None else _active_env_name(),
-    )
-
-
-def _ui_runtime_paths(env_name: Optional[str] = None) -> tuple[Path, Path, Path]:
-    ctx = _require_context(env_name=env_name)
-    ui_dir = ctx.ui_dir(env_name or _active_env_name())
+def _ui_runtime_paths() -> tuple[Path, Path, Path]:
+    ctx = _require_context()
+    ui_dir = ctx.ui_dir()
     return (
         ui_dir / "ui.pid",
         ui_dir / "ui.log",
@@ -69,20 +57,18 @@ def _ui_runtime_paths(env_name: Optional[str] = None) -> tuple[Path, Path, Path]
 
 
 def _resolve_tls_paths(
-    env_name: Optional[str] = None,
     *,
     cert_file: Optional[Path] = None,
     key_file: Optional[Path] = None,
 ) -> tuple[Path, Path]:
     """Resolve TLS cert/key paths from CLI overrides, config, or runtime defaults."""
-    from daylily_tapdb.cli.db_config import get_admin_settings_for_env
+    from daylily_tapdb.cli.db_config import get_admin_settings
 
-    pid_file, _, certs_dir = _ui_runtime_paths(env_name)
+    pid_file, _, certs_dir = _ui_runtime_paths()
     _ = pid_file  # path access validates context + env
     default_cert = certs_dir / "localhost.crt"
     default_key = certs_dir / "localhost.key"
-    resolved_env = env_name or _active_env_name()
-    admin_settings = get_admin_settings_for_env(resolved_env)
+    admin_settings = get_admin_settings()
     if cert_file is not None:
         cert = cert_file.expanduser()
     elif admin_settings.get("tls_cert_path"):
@@ -102,13 +88,11 @@ def _resolve_tls_paths(
 def _ensure_tls_certificates(
     host: str,
     *,
-    env_name: Optional[str] = None,
     cert_file: Optional[Path] = None,
     key_file: Optional[Path] = None,
 ) -> tuple[Path, Path]:
     """Ensure TLS cert/key exist for HTTPS UI startup."""
     cert_path, key_path = _resolve_tls_paths(
-        env_name,
         cert_file=cert_file,
         key_file=key_file,
     )
@@ -299,11 +283,6 @@ def build_app():
             readable=False,
             help="Explicit TapDB config file path for this invocation.",
         ),
-        env_name: Optional[str] = typer.Option(
-            None,
-            "--env",
-            help="Explicit TapDB environment name for this invocation.",
-        ),
     ):
         """Legacy direct-invocation context bridge for tests and embedding."""
         if ctx.resilient_parsing:
@@ -324,9 +303,6 @@ def build_app():
                 if database_name is not None
                 else prior_context.get("database_name")
             ),
-            env_name=env_name
-            if env_name is not None
-            else prior_context.get("env_name"),
             config_path=(
                 config_path
                 if config_path is not None
@@ -379,7 +355,7 @@ def build_app():
             None,
             "--port",
             "-p",
-            help="Port to run the server on (defaults to environments.<env>.ui_port)",
+            help="Port to run the server on (defaults to target.ui_port)",
         ),
         host: str = typer.Option(
             DEFAULT_UI_HOST, "--host", "-h", help="Host to bind to"
@@ -400,22 +376,20 @@ def build_app():
         ),
     ):
         """Start the TAPDB Admin UI server."""
-        from daylily_tapdb.cli.db_config import get_config_path, get_db_config_for_env
+        from daylily_tapdb.cli.db_config import get_config_path, get_db_config
 
-        env_name = _active_env_name()
-        pid_file, log_file, _ = _ui_runtime_paths(env_name)
+        pid_file, log_file, _ = _ui_runtime_paths()
         pid_file.parent.mkdir(parents=True, exist_ok=True)
         log_file.parent.mkdir(parents=True, exist_ok=True)
 
-        cfg = get_db_config_for_env(env_name)
+        cfg = get_db_config()
         configured_port = int(str(cfg.get("ui_port") or DEFAULT_UI_PORT))
         if port is None:
             port = configured_port
         elif port != configured_port:
             ccyo_out.error("UI port override is not allowed in strict mode.")
             ccyo_out.print_text(
-                f"  Configured ui_port for env {env_name}: "
-                f"[cyan]{configured_port}[/cyan]"
+                f"  Configured target.ui_port: [cyan]{configured_port}[/cyan]"
             )
             raise typer.Exit(1)
 
@@ -439,18 +413,16 @@ def build_app():
 
         if not _port_is_available(host, port):
             ccyo_out.error(f"{_port_conflict_details(port)}")
-            ns = _require_context(env_name=env_name).namespace_slug()
+            ns = _require_context().namespace_slug()
             ccyo_out.print_text(f"  Namespace: [dim]{ns}[/dim]")
             ccyo_out.print_text(
-                "  Update environments."
-                f"{env_name}.ui_port in the namespaced config to a free port."
+                "  Update target.ui_port in the namespaced config to a free port."
             )
             raise typer.Exit(1)
 
         try:
             cert_path, key_path = _ensure_tls_certificates(
                 host,
-                env_name=env_name,
                 cert_file=ssl_certfile,
                 key_file=ssl_keyfile,
             )
@@ -465,8 +437,6 @@ def build_app():
             "daylily_tapdb.cli.admin_server",
             "--config",
             str(effective_config_path),
-            "--env",
-            env_name,
             "--host",
             host,
             "--port",
@@ -525,7 +495,6 @@ def build_app():
         ),
     ):
         """Install mkcert local CA and generate localhost TLS certs for the UI."""
-        env_name = _active_env_name()
         mkcert = shutil.which("mkcert")
         if not mkcert:
             ccyo_out.error("mkcert is required for trusted local HTTPS certs.")
@@ -534,7 +503,7 @@ def build_app():
             )
             raise typer.Exit(1)
 
-        default_cert, default_key = _resolve_tls_paths(env_name)
+        default_cert, default_key = _resolve_tls_paths()
         cert_path = (cert_file or default_cert).expanduser()
         key_path = (key_file or default_key).expanduser()
         cert_path.parent.mkdir(parents=True, exist_ok=True)
@@ -574,14 +543,13 @@ def build_app():
         ccyo_out.print_text(f"   Cert: [dim]{cert_path}[/dim]")
         ccyo_out.print_text(f"   Key:  [dim]{key_path}[/dim]")
         ccyo_out.print_text(
-            "   Restart UI: [cyan]tapdb --config <path> --env <name> ui restart[/cyan]"
+            "   Restart UI: [cyan]tapdb --config <path> ui restart[/cyan]"
         )
 
     @ui_app.command("stop")
     def ui_stop():
         """Stop the TAPDB Admin UI server."""
-        env_name = _active_env_name()
-        pid_file, _, _ = _ui_runtime_paths(env_name)
+        pid_file, _, _ = _ui_runtime_paths()
         pid = _get_pid(pid_file)
         if not pid:
             ccyo_out.warning("No UI server running")
@@ -610,8 +578,7 @@ def build_app():
     @ui_app.command("status")
     def ui_status():
         """Check the status of the TAPDB Admin UI server."""
-        env_name = _active_env_name()
-        pid_file, log_file, _ = _ui_runtime_paths(env_name)
+        pid_file, log_file, _ = _ui_runtime_paths()
         pid = _get_pid(pid_file)
         if pid:
             ccyo_out.success(f"UI server is running (PID {pid})")
@@ -631,8 +598,7 @@ def build_app():
         lines: int = typer.Option(50, "--lines", "-n", help="Number of lines to show"),
     ):
         """View TAPDB Admin UI server logs (tails by default, Ctrl+C to stop)."""
-        env_name = _active_env_name()
-        _, log_file, _ = _ui_runtime_paths(env_name)
+        _, log_file, _ = _ui_runtime_paths()
         if not log_file.exists():
             ccyo_out.warning("No log file found. Start the server first.")
             return
@@ -674,28 +640,15 @@ def build_app():
         )
 
     def _resolve_bootstrap_env() -> DbEnvironment:
-        raw = str(active_context_overrides().get("env_name") or "").strip().lower()
-        if not raw:
-            ccyo_out.error("TapDB bootstrap requires an explicit --env value.")
-            ccyo_out.print_text(
-                "  Example: [cyan]tapdb --config <path> --env dev bootstrap local[/cyan]"
-            )
-            raise typer.Exit(1)
-        try:
-            return DbEnvironment(raw)
-        except ValueError:
-            ccyo_out.error(f"Unsupported TapDB env '{raw}'")
-            ccyo_out.print_text("  Supported values: dev, test, prod")
-            raise typer.Exit(1)
+        return DbEnvironment.target
 
     def _maybe_start_ui_after_bootstrap(no_gui: bool) -> None:
-        from daylily_tapdb.cli.db_config import get_db_config_for_env
+        from daylily_tapdb.cli.db_config import get_db_config
 
         if no_gui:
             ccyo_out.print_text("  UI start skipped (--no-gui)")
             return
-        env_name = _active_env_name()
-        cfg = get_db_config_for_env(env_name)
+        cfg = get_db_config()
         ui_port = int(str(cfg.get("ui_port") or DEFAULT_UI_PORT))
         try:
             ui_start(
@@ -710,8 +663,7 @@ def build_app():
             ccyo_out.error(f"DB is ready, but UI start failed: {e}")
             ccyo_out.print_text(
                 "  Recover with: "
-                f"[cyan]tapdb --config <path> --env {env_name} "
-                f"ui start --background --port {ui_port}[/cyan]"
+                f"[cyan]tapdb --config <path> ui start --background --port {ui_port}[/cyan]"
             )
 
     @bootstrap_app.command("local")
@@ -728,31 +680,25 @@ def build_app():
         insecure_dev_defaults: bool = typer.Option(
             False,
             "--insecure-dev-defaults",
-            help="DEV ONLY: create default admin user (tapdb_admin/passw0rd)",
+            help="LOCAL/SHARED ONLY: create default admin user (tapdb_admin/passw0rd)",
         ),
     ):
         """Bootstrap local TAPDB runtime, database, schema, and seed data."""
-        from daylily_tapdb.cli.db_config import get_db_config_for_env
+        from daylily_tapdb.cli.db_config import get_db_config
 
         env = _resolve_bootstrap_env()
-        cfg = get_db_config_for_env(env.value)
+        cfg = get_db_config()
         if cfg.get("engine_type") == "aurora":
             ccyo_out.error("Active target is Aurora; use bootstrap aurora")
             raise typer.Exit(1)
 
         ccyo_out.print_text(
-            f"\n[bold cyan]━━━ Bootstrap Local ({env.value}) ━━━[/bold cyan]"
+            "\n[bold cyan]━━━ Bootstrap Local (explicit target) ━━━[/bold cyan]"
         )
 
-        if env in (DbEnvironment.dev, DbEnvironment.test):
-            ccyo_out.print_text(
-                "\n[bold]Step 1/6: Ensure local PostgreSQL runtime[/bold]"
-            )
-            pg_init(env=env, force=False)
-            pg_start_local(env=env, port=None)
-        else:
-            ccyo_out.print_text("\n[bold]Step 1/6: Local runtime management[/bold]")
-            ccyo_out.print_text("  Skipping local runtime management for prod target")
+        ccyo_out.print_text("\n[bold]Step 1/6: Ensure local PostgreSQL runtime[/bold]")
+        pg_init(force=False)
+        pg_start_local(port=None)
 
         ccyo_out.print_text("\n[bold]Step 2/6: Ensure database exists[/bold]")
         create_database(env=env, owner=None)
@@ -815,62 +761,25 @@ def build_app():
         insecure_dev_defaults: bool = typer.Option(
             False,
             "--insecure-dev-defaults",
-            help="DEV ONLY: create default admin user (tapdb_admin/passw0rd)",
-        ),
-        owner_repo_name: Optional[str] = typer.Option(
-            None,
-            "--owner-repo-name",
-            help="Repo-name token used for Meridian prefix ownership validation when bootstrap creates config",
-        ),
-        domain_code: list[str] = typer.Option(
-            [],
-            "--domain-code",
-            help="Per-env domain code mapping (ENV=CODE, repeatable) when bootstrap creates config",
-        ),
-        ui_port: list[str] = typer.Option(
-            [],
-            "--ui-port",
-            help="Per-env UI port mapping (ENV=PORT, repeatable) when bootstrap creates config",
-        ),
-        domain_registry_path: str = typer.Option(
-            str(DEFAULT_DOMAIN_REGISTRY_PATH),
-            "--domain-registry-path",
-            help="Path to the shared Meridian domain registry JSON",
-        ),
-        prefix_ownership_registry_path: str = typer.Option(
-            str(DEFAULT_PREFIX_OWNERSHIP_REGISTRY_PATH),
-            "--prefix-ownership-registry-path",
-            help="Path to the shared Meridian prefix ownership registry JSON",
+            help="LOCAL/SHARED ONLY: create default admin user (tapdb_admin/passw0rd)",
         ),
     ):
         """Bootstrap Aurora TAPDB stack (infra + DB + schema + seed + optional UI)."""
         from daylily_tapdb.aurora.config import AuroraConfig
         from daylily_tapdb.aurora.stack_manager import AuroraStackManager
-        from daylily_tapdb.cli.aurora import (
-            _ensure_boto3,
-            _resolve_ingress_cidr,
-            _stack_name_for_env,
-            _update_config_file,
-        )
+        from daylily_tapdb.cli.aurora import _ensure_boto3, _resolve_ingress_cidr
 
         _ensure_boto3()
         env = _resolve_bootstrap_env()
-        stack_name = _stack_name_for_env(cluster)
+        stack_name = cluster
 
         ccyo_out.print_text(
-            f"\n[bold cyan]━━━ Bootstrap Aurora ({env.value} -> {cluster})"
+            f"\n[bold cyan]━━━ Bootstrap Aurora (explicit target -> {cluster})"
             " ━━━[/bold cyan]"
         )
 
-        ccyo_out.print_text("\n[bold]Step 1/8: Ensure TapDB config[/bold]")
-        config_path = _ensure_bootstrap_config_for_aurora(
-            env_name=env.value,
-            owner_repo_name=owner_repo_name,
-            domain_code=domain_code,
-            ui_port=ui_port,
-            domain_registry_path=domain_registry_path,
-            prefix_ownership_registry_path=prefix_ownership_registry_path,
-        )
+        ccyo_out.print_text("\n[bold]Step 1/8: Verify explicit TapDB config[/bold]")
+        config_path = _ensure_bootstrap_config_for_aurora()
         ccyo_out.success(f"  Config ready: {config_path}")
 
         ccyo_out.print_text("\n[bold]Step 2/8: Ensure Aurora cluster[/bold]")
@@ -919,14 +828,46 @@ def build_app():
             ccyo_out.error(f"Aurora endpoint not available for {stack_name}")
             raise typer.Exit(1)
 
-        ccyo_out.print_text("\n[bold]Step 3/8: Update TAPDB target config[/bold]")
-        _update_config_file(
-            env.value,
-            endpoint,
-            port,
-            region,
-            cluster_identifier=cluster,
-            secret_arn=outputs.get("SecretArn"),
+        ccyo_out.print_text("\n[bold]Step 3/8: TAPDB target config[/bold]")
+        config_update(
+            engine_type="aurora",
+            host=endpoint,
+            port=int(port),
+            ui_port=None,
+            user=None,
+            password=None,
+            database=None,
+            schema_name=None,
+            cognito_user_pool_id=None,
+            cognito_app_client_id=None,
+            cognito_app_client_secret=None,
+            cognito_client_name=None,
+            cognito_region=None,
+            cognito_domain=None,
+            cognito_callback_url=None,
+            cognito_logout_url=None,
+            domain_code=None,
+            owner_repo_name=None,
+            domain_registry_path=None,
+            prefix_ownership_registry_path=None,
+            support_email=None,
+            admin_repo_url=None,
+            admin_session_secret=None,
+            admin_auth_mode=None,
+            admin_disabled_user_email=None,
+            admin_disabled_user_role=None,
+            admin_shared_host_session_secret=None,
+            admin_shared_host_session_cookie=None,
+            admin_shared_host_session_max_age_seconds=None,
+            admin_allowed_origin=[],
+            admin_tls_cert_path=None,
+            admin_tls_key_path=None,
+            admin_metrics_enabled=None,
+            admin_metrics_queue_max=None,
+            admin_metrics_flush_seconds=None,
+            clear=[],
+            safety_tier="production",
+            destructive_operations="blocked",
         )
 
         ccyo_out.print_text("\n[bold]Step 4/8: Ensure database exists[/bold]")
@@ -979,102 +920,6 @@ def build_app():
             path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
         os.chmod(path, 0o600)
 
-    def _parse_env_port_pairs(values: list[str], *, flag: str) -> dict[str, int]:
-        parsed: dict[str, int] = {}
-        for raw in values:
-            text = str(raw).strip()
-            if not text:
-                continue
-            if "=" not in text:
-                raise RuntimeError(f"{flag} must be provided as ENV=PORT (got {raw!r})")
-            env_name, port_s = text.split("=", 1)
-            env_name = env_name.strip().lower()
-            port_s = port_s.strip()
-            if not env_name:
-                raise RuntimeError(f"{flag} missing environment in {raw!r}")
-            if not port_s.isdigit():
-                raise RuntimeError(f"{flag} has invalid port in {raw!r}")
-            port = int(port_s)
-            if port < 1 or port > 65535:
-                raise RuntimeError(f"{flag} port out of range in {raw!r}")
-            parsed[env_name] = port
-        return parsed
-
-    def _resolve_required_port(
-        *,
-        env_name: str,
-        field: str,
-        explicit_map: dict[str, int],
-        existing_env_cfg: dict,
-    ) -> int:
-        if env_name in explicit_map:
-            return explicit_map[env_name]
-
-        existing_raw = str(existing_env_cfg.get(field) or "").strip()
-        if existing_raw.isdigit():
-            return int(existing_raw)
-
-        if sys.stdin.isatty():
-            while True:
-                entered = typer.prompt(f"Enter {field} for {env_name}")
-                if entered.strip().isdigit():
-                    value = int(entered.strip())
-                    if 1 <= value <= 65535:
-                        return value
-                ccyo_out.error(f"Invalid {field} for {env_name}")
-
-        raise RuntimeError(
-            f"Missing required {field} for env {env_name}. "
-            f"Set via --db-port {env_name}=<port> or --ui-port {env_name}=<port>."
-        )
-
-    def _parse_env_text_pairs(values: list[str], *, flag: str) -> dict[str, str]:
-        parsed: dict[str, str] = {}
-        for raw in values:
-            text = str(raw).strip()
-            if not text:
-                continue
-            if "=" not in text:
-                raise RuntimeError(
-                    f"{flag} must be provided as ENV=VALUE (got {raw!r})"
-                )
-            env_name, value = text.split("=", 1)
-            env_name = env_name.strip().lower()
-            value = value.strip()
-            if not env_name:
-                raise RuntimeError(f"{flag} missing environment in {raw!r}")
-            if not value:
-                raise RuntimeError(f"{flag} missing value in {raw!r}")
-            parsed[env_name] = value
-        return parsed
-
-    def _resolve_required_text(
-        *,
-        env_name: str,
-        field: str,
-        explicit_map: dict[str, str],
-        existing_env_cfg: dict,
-        flag: str,
-    ) -> str:
-        if env_name in explicit_map:
-            return explicit_map[env_name]
-
-        existing_raw = str(existing_env_cfg.get(field) or "").strip()
-        if existing_raw:
-            return existing_raw
-
-        if sys.stdin.isatty():
-            while True:
-                entered = typer.prompt(f"Enter {field} for {env_name}")
-                if entered.strip():
-                    return entered.strip()
-                ccyo_out.error(f"Invalid {field} for {env_name}")
-
-        raise RuntimeError(
-            f"Missing required {field} for env {env_name}. "
-            f"Set via {flag} {env_name}=<value>."
-        )
-
     def _require_explicit_config_flag() -> Path:
         config_path = active_context_overrides().get("config_path")
         if not config_path:
@@ -1082,7 +927,9 @@ def build_app():
                 "TapDB config commands require --config. "
                 "Example: tapdb --config ~/.config/tapdb/atlas/app/tapdb-config.yaml "
                 "config init --client-id atlas --database-name app "
-                "--owner-repo-name lsmc-atlas --domain-code dev=Z"
+                "--owner-repo-name lsmc-atlas --domain-code Z "
+                "--engine-type local --host localhost --port 5533 --ui-port 8911 "
+                "--database tapdb_atlas --schema-name tapdb_atlas"
             )
         return Path(config_path)
 
@@ -1131,13 +978,19 @@ def build_app():
         client_id: str,
         database_name: str,
         owner_repo_name: str,
-        domain_code: list[str],
+        domain_code: str,
         domain_registry_path: str,
         prefix_ownership_registry_path: str,
-        env: list[str],
-        db_port: list[str],
-        ui_port: list[str],
-        schema_name: list[str],
+        engine_type: str,
+        host: str,
+        port: int,
+        ui_port: int,
+        user: str,
+        password: str,
+        database: str,
+        schema_name: str,
+        safety_tier: str,
+        destructive_operations: str,
         force: bool,
     ) -> tuple[Path, dict]:
         current = active_context_overrides()
@@ -1148,9 +1001,6 @@ def build_app():
         )
         config_path = _require_explicit_config_flag()
 
-        env_names = sorted({e.strip().lower() for e in env if str(e).strip()})
-        if not env_names:
-            raise RuntimeError("At least one --env must be provided")
         normalized_owner_repo_name = normalize_owner_repo_name(owner_repo_name)
 
         existing = _read_yaml_or_json_file(config_path)
@@ -1165,14 +1015,36 @@ def build_app():
                     "Use --force to overwrite."
                 )
 
-        db_ports = _parse_env_port_pairs(db_port, flag="--db-port")
-        ui_ports = _parse_env_port_pairs(ui_port, flag="--ui-port")
-        schema_names = _parse_env_text_pairs(schema_name, flag="--schema-name")
-        domain_codes = _parse_env_text_pairs(domain_code, flag="--domain-code")
+        normalized_engine_type = str(engine_type or "").strip().lower()
+        if normalized_engine_type not in {"local", "aurora"}:
+            raise RuntimeError("--engine-type must be local or aurora")
+        normalized_safety_tier = str(safety_tier or "").strip().lower()
+        if normalized_safety_tier not in {"local", "shared", "production"}:
+            raise RuntimeError("--safety-tier must be local, shared, or production")
+        normalized_destructive_operations = (
+            str(destructive_operations or "").strip().lower()
+        )
+        if normalized_destructive_operations not in {
+            "blocked",
+            "confirm_required",
+            "allowed",
+        }:
+            raise RuntimeError(
+                "--destructive-operations must be blocked, confirm_required, or allowed"
+            )
+        normalized_schema_name = validate_postgres_identifier_component(
+            schema_name, field_name="target.schema_name"
+        )
+        normalized_database = validate_postgres_identifier_component(
+            database, field_name="target.database"
+        )
+        normalized_domain_code = str(domain_code or "").strip().upper()
+        if not normalized_domain_code:
+            raise RuntimeError("--domain-code is required")
 
         root = existing if isinstance(existing, dict) else {}
         root["meta"] = {
-            "config_version": 3,
+            "config_version": 4,
             "client_id": client_id,
             "database_name": database_name,
             "owner_repo_name": normalized_owner_repo_name,
@@ -1200,139 +1072,42 @@ def build_app():
                     merged_admin[key] = value
             root["admin"] = merged_admin
 
-        envs = root.setdefault("environments", {})
-        for env_name in env_names:
-            prior = envs.get(env_name, {}) or {}
-            resolved_db_port = _resolve_required_port(
-                env_name=env_name,
-                field="port",
-                explicit_map=db_ports,
-                existing_env_cfg=prior,
-            )
-            resolved_ui_port = _resolve_required_port(
-                env_name=env_name,
-                field="ui_port",
-                explicit_map=ui_ports,
-                existing_env_cfg=prior,
-            )
-            resolved_domain_code = _resolve_required_text(
-                env_name=env_name,
-                field="domain_code",
-                explicit_map=domain_codes,
-                existing_env_cfg=prior,
-                flag="--domain-code",
-            )
-            envs[env_name] = {
-                **prior,
-                "engine_type": str(prior.get("engine_type") or "local"),
-                "host": "localhost",
-                "port": str(resolved_db_port),
-                "ui_port": str(resolved_ui_port),
-                "domain_code": resolved_domain_code,
-                "user": str(prior.get("user") or os.environ.get("USER", "postgres")),
-                "password": str(prior.get("password") or ""),
-                "database": str(
-                    prior.get("database")
-                    or default_database_name_for_namespace(database_name, env_name)
-                ),
-                "schema_name": validate_postgres_identifier_component(
-                    str(
-                        schema_names.get(env_name)
-                        or prior.get("schema_name")
-                        or default_schema_name_for_database(database_name, env_name)
-                    ),
-                    field_name=f"environments.{env_name}.schema_name",
-                ),
-                "cognito_user_pool_id": str(prior.get("cognito_user_pool_id") or ""),
-                "support_email": str(prior.get("support_email") or ""),
-            }
+        prior_target = (
+            root.get("target") if isinstance(root.get("target"), dict) else {}
+        )
+        root["target"] = {
+            **prior_target,
+            "engine_type": normalized_engine_type,
+            "host": str(host).strip(),
+            "port": str(port),
+            "ui_port": str(ui_port),
+            "domain_code": normalized_domain_code,
+            "user": str(user).strip(),
+            "password": str(password),
+            "database": normalized_database,
+            "schema_name": normalized_schema_name,
+            "cognito_user_pool_id": str(prior_target.get("cognito_user_pool_id") or ""),
+            "support_email": str(prior_target.get("support_email") or ""),
+        }
+        root["safety"] = {
+            "safety_tier": normalized_safety_tier,
+            "destructive_operations": normalized_destructive_operations,
+        }
+        root.pop("environments", None)
 
         _write_yaml_or_json_file(config_path, root)
         return config_path, root
 
-    def _ensure_bootstrap_config_for_aurora(
-        *,
-        env_name: str,
-        owner_repo_name: Optional[str],
-        domain_code: list[str],
-        ui_port: list[str],
-        domain_registry_path: str,
-        prefix_ownership_registry_path: str,
-    ) -> Path:
+    def _ensure_bootstrap_config_for_aurora() -> Path:
         config_path = _require_explicit_config_flag()
         root = _read_yaml_or_json_file(config_path)
-        envs = root.get("environments") if isinstance(root, dict) else None
-        if (
-            config_path.exists()
-            and isinstance(envs, dict)
-            and isinstance(envs.get(env_name), dict)
-        ):
+        target = root.get("target") if isinstance(root, dict) else None
+        if config_path.exists() and isinstance(target, dict) and target:
             return config_path
-
-        current = active_context_overrides()
-        client_id = str(current.get("client_id") or "").strip()
-        database_name = str(current.get("database_name") or "").strip()
-        if not client_id or not database_name:
-            raise RuntimeError(
-                "Aurora bootstrap needs --client-id and --database-name when the "
-                "TapDB config is missing or the target env is not configured."
-            )
-
-        meta = root.get("meta") if isinstance(root, dict) else None
-        resolved_owner_repo_name = str(owner_repo_name or "").strip()
-        if not resolved_owner_repo_name and isinstance(meta, dict):
-            resolved_owner_repo_name = str(meta.get("owner_repo_name") or "").strip()
-        if not resolved_owner_repo_name:
-            raise RuntimeError(
-                "Aurora bootstrap needs --owner-repo-name when it must create or "
-                "extend the TapDB config."
-            )
-
-        parsed_domain_codes = _parse_env_text_pairs(domain_code, flag="--domain-code")
-        parsed_ui_ports = _parse_env_port_pairs(ui_port, flag="--ui-port")
-        if not isinstance(envs, dict) or env_name not in envs:
-            if env_name not in parsed_domain_codes:
-                raise RuntimeError(
-                    "Aurora bootstrap needs --domain-code "
-                    f"{env_name}=<code> when it must create or extend the TapDB config."
-                )
-            if env_name not in parsed_ui_ports:
-                raise RuntimeError(
-                    "Aurora bootstrap needs --ui-port "
-                    f"{env_name}=<port> when it must create or extend the TapDB config."
-                )
-
-        resolved_domain_registry_path = domain_registry_path
-        resolved_prefix_registry_path = prefix_ownership_registry_path
-        if isinstance(meta, dict):
-            if (
-                not resolved_domain_registry_path
-                or resolved_domain_registry_path == str(DEFAULT_DOMAIN_REGISTRY_PATH)
-            ) and str(meta.get("domain_registry_path") or "").strip():
-                resolved_domain_registry_path = str(meta["domain_registry_path"])
-            if (
-                not resolved_prefix_registry_path
-                or resolved_prefix_registry_path
-                == str(DEFAULT_PREFIX_OWNERSHIP_REGISTRY_PATH)
-            ) and str(meta.get("prefix_ownership_registry_path") or "").strip():
-                resolved_prefix_registry_path = str(
-                    meta["prefix_ownership_registry_path"]
-                )
-
-        initialized_path, _ = _initialize_namespaced_config(
-            client_id=client_id,
-            database_name=database_name,
-            owner_repo_name=resolved_owner_repo_name,
-            domain_code=domain_code,
-            domain_registry_path=resolved_domain_registry_path,
-            prefix_ownership_registry_path=resolved_prefix_registry_path,
-            env=[env_name],
-            db_port=[f"{env_name}=5432"],
-            ui_port=ui_port,
-            schema_name=[],
-            force=False,
+        raise RuntimeError(
+            "Aurora bootstrap requires an explicit TapDB v4 config with a target "
+            "section. Run `tapdb --config <path> config init ...` first."
         )
-        return initialized_path
 
     @config_root_app.command("init")
     def config_init(
@@ -1345,10 +1120,10 @@ def build_app():
             "--owner-repo-name",
             help="Repo-name token used for Meridian prefix ownership validation",
         ),
-        domain_code: list[str] = typer.Option(
-            [],
+        domain_code: str = typer.Option(
+            ...,
             "--domain-code",
-            help="Per-env domain code mapping (ENV=CODE, repeatable)",
+            help="Meridian domain code for this TapDB target",
         ),
         domain_registry_path: str = typer.Option(
             str(DEFAULT_DOMAIN_REGISTRY_PATH),
@@ -1360,31 +1135,45 @@ def build_app():
             "--prefix-ownership-registry-path",
             help="Path to the shared Meridian prefix ownership registry JSON",
         ),
-        env: list[str] = typer.Option(
-            ["dev"],
-            "--env",
-            help="Environment to configure (repeat for multiple)",
+        engine_type: str = typer.Option(
+            ...,
+            "--engine-type",
+            help="Physical database backend: local or aurora",
         ),
-        db_port: list[str] = typer.Option(
-            [],
-            "--db-port",
-            help="Per-env DB port mapping (ENV=PORT, repeatable)",
+        host: str = typer.Option(..., "--host", help="Physical database host"),
+        port: int = typer.Option(..., "--port", help="Physical database port"),
+        ui_port: int = typer.Option(..., "--ui-port", help="TapDB UI port"),
+        user: str = typer.Option(..., "--user", help="Database user"),
+        password: str = typer.Option(
+            "",
+            "--password",
+            help="Database password. Use an empty string for passwordless local auth.",
         ),
-        ui_port: list[str] = typer.Option(
-            [],
-            "--ui-port",
-            help="Per-env UI port mapping (ENV=PORT, repeatable)",
+        database: str = typer.Option(
+            ...,
+            "--database",
+            help="Physical PostgreSQL database name",
         ),
-        schema_name: list[str] = typer.Option(
-            [],
+        schema_name: str = typer.Option(
+            ...,
             "--schema-name",
-            help="Per-env PostgreSQL schema mapping (ENV=SCHEMA, repeatable)",
+            help="PostgreSQL schema name for this service namespace",
+        ),
+        safety_tier: str = typer.Option(
+            "local",
+            "--safety-tier",
+            help="Safety tier: local, shared, or production",
+        ),
+        destructive_operations: str = typer.Option(
+            "confirm_required",
+            "--destructive-operations",
+            help="Destructive operation policy: blocked, confirm_required, or allowed",
         ),
         force: bool = typer.Option(
             False, "--force", help="Overwrite existing config metadata if needed"
         ),
     ) -> None:
-        """Initialize a namespaced TAPDB v3 config."""
+        """Initialize a single-target TAPDB v4 config."""
         config_path, root = _initialize_namespaced_config(
             client_id=client_id,
             database_name=database_name,
@@ -1392,27 +1181,31 @@ def build_app():
             domain_code=domain_code,
             domain_registry_path=domain_registry_path,
             prefix_ownership_registry_path=prefix_ownership_registry_path,
-            env=env,
-            db_port=db_port,
+            engine_type=engine_type,
+            host=host,
+            port=port,
             ui_port=ui_port,
+            user=user,
+            password=password,
+            database=database,
             schema_name=schema_name,
+            safety_tier=safety_tier,
+            destructive_operations=destructive_operations,
             force=force,
         )
-        ccyo_out.success("TAPDB namespaced config initialized")
+        ccyo_out.success("TAPDB explicit-target config initialized")
         ccyo_out.print_text(f"  Namespace: [bold]{client_id}/{database_name}[/bold]")
         ccyo_out.print_text(f"  Path:      [dim]{config_path}[/dim]")
-        env_names = sorted({e.strip().lower() for e in env if str(e).strip()})
-        for env_name in env_names:
-            env_cfg = root["environments"][env_name]
-            ccyo_out.print_text(
-                f"  {env_name}: db_port={env_cfg['port']} ui_port={env_cfg['ui_port']}"
-            )
+        target_cfg = root["target"]
+        ccyo_out.print_text(
+            f"  target:    engine={target_cfg['engine_type']} "
+            f"database={target_cfg['database']} schema={target_cfg['schema_name']}"
+        )
 
     @config_root_app.command("update")
     def config_update(
-        env: str = typer.Option(..., "--env", help="Environment to update"),
         engine_type: Optional[str] = typer.Option(
-            None, "--engine-type", help="Database engine type for this environment"
+            None, "--engine-type", help="Database engine type for this target"
         ),
         host: Optional[str] = typer.Option(None, "--host", help="Database host"),
         port: Optional[int] = typer.Option(None, "--port", help="Database port"),
@@ -1452,7 +1245,7 @@ def build_app():
             None, "--cognito-logout-url", help="Bound Cognito logout URL"
         ),
         domain_code: Optional[str] = typer.Option(
-            None, "--domain-code", help="Meridian domain code for this environment"
+            None, "--domain-code", help="Meridian domain code for this target"
         ),
         owner_repo_name: Optional[str] = typer.Option(
             None,
@@ -1533,17 +1326,23 @@ def build_app():
         clear: list[str] = typer.Option(
             [],
             "--clear",
-            help="Environment field to clear (repeatable)",
+            help="Target field to clear (repeatable)",
+        ),
+        safety_tier: Optional[str] = typer.Option(
+            None,
+            "--safety-tier",
+            help="Safety tier: local, shared, or production",
+        ),
+        destructive_operations: Optional[str] = typer.Option(
+            None,
+            "--destructive-operations",
+            help="Destructive operation policy: blocked, confirm_required, or allowed",
         ),
     ) -> None:
-        """Update fields inside a namespaced TAPDB v3 config."""
+        """Update fields inside a single-target TAPDB v4 config."""
         from daylily_tapdb.cli.db_config import get_config_path
 
         ctx = _require_context()
-        env_name = str(env or "").strip().lower()
-        if not env_name:
-            raise RuntimeError("--env is required")
-
         allowed_fields = {
             "engine_type",
             "host",
@@ -1568,7 +1367,7 @@ def build_app():
         invalid_fields = sorted(clear_fields - allowed_fields)
         if invalid_fields:
             raise RuntimeError(
-                "Unknown field(s) for --clear: " + ", ".join(invalid_fields)
+                "Unknown target field(s) for --clear: " + ", ".join(invalid_fields)
             )
 
         config_path = get_config_path()
@@ -1586,14 +1385,10 @@ def build_app():
                 f"Run: tapdb config init --client-id {ctx.client_id} --database-name {ctx.database_name}"
             )
 
-        envs = root.setdefault("environments", {})
-        if not isinstance(envs, dict):
-            envs = {}
-            root["environments"] = envs
-        env_cfg = envs.setdefault(env_name, {})
-        if not isinstance(env_cfg, dict):
-            env_cfg = {}
-            envs[env_name] = env_cfg
+        target_cfg = root.setdefault("target", {})
+        if not isinstance(target_cfg, dict):
+            target_cfg = {}
+            root["target"] = target_cfg
 
         admin_root = root.setdefault("admin", _default_admin_config())
         if not isinstance(admin_root, dict):
@@ -1706,23 +1501,47 @@ def build_app():
         if admin_metrics_flush_seconds is not None:
             metrics["flush_seconds"] = float(admin_metrics_flush_seconds)
             admin_changed = True
+        safety_changed = False
+        safety_root = root.setdefault("safety", {})
+        if not isinstance(safety_root, dict):
+            safety_root = {}
+            root["safety"] = safety_root
+        if safety_tier is not None:
+            normalized = str(safety_tier).strip().lower()
+            if normalized not in {"local", "shared", "production"}:
+                raise RuntimeError("--safety-tier must be local, shared, or production")
+            safety_root["safety_tier"] = normalized
+            safety_changed = True
+        if destructive_operations is not None:
+            normalized = str(destructive_operations).strip().lower()
+            if normalized not in {"blocked", "confirm_required", "allowed"}:
+                raise RuntimeError(
+                    "--destructive-operations must be blocked, confirm_required, or allowed"
+                )
+            safety_root["destructive_operations"] = normalized
+            safety_changed = True
 
-        if not updates and not clear_fields and not admin_changed:
+        if (
+            not updates
+            and not clear_fields
+            and not admin_changed
+            and not safety_changed
+        ):
             raise RuntimeError("No config changes requested.")
 
         for field_name in clear_fields:
-            env_cfg[field_name] = ""
-        env_cfg.update(updates)
+            target_cfg[field_name] = ""
+        target_cfg.update(updates)
+        root.pop("environments", None)
 
         _write_yaml_or_json_file(config_path, root)
-        ccyo_out.success("TAPDB namespaced config updated")
+        ccyo_out.success("TAPDB explicit-target config updated")
         ccyo_out.print_text(f"  Namespace: [bold]{ctx.namespace_slug()}[/bold]")
         ccyo_out.print_text(f"  Path:      [dim]{config_path}[/dim]")
-        ccyo_out.print_text(f"  Env:       [bold]{env_name}[/bold]")
         for field_name in sorted(clear_fields):
             ccyo_out.print_text(f"  cleared:   {field_name}")
         for field_name in sorted(updates.keys()):
-            ccyo_out.print_text(f"  set:       {field_name}={env_cfg[field_name]}")
+            ccyo_out.print_text(f"  set:       {field_name}={target_cfg[field_name]}")
 
     @app.command("version")
     def version():
@@ -1733,64 +1552,33 @@ def build_app():
 
     @app.command("info")
     def info(
-        check_all_envs: bool = typer.Option(
-            False,
-            "--check-all-envs",
-            help=(
-                "Probe PostgreSQL status for dev/test/prod (may contact remote hosts). "
-                "Default probes only the active TapDB env."
-            ),
-        ),
         as_json: bool = typer.Option(
             False, "--json", help="Emit machine-readable JSON (no tables)."
         ),
     ):
-        """Show TAPDB configuration and status."""
+        """Show TAPDB explicit-target configuration and status."""
         import json
         import shutil
         from datetime import UTC, datetime
-        from urllib.parse import urlsplit, urlunsplit
 
         from daylily_tapdb import __version__
-        from daylily_tapdb.cli.db_config import (
-            get_config_path,
-            get_db_config_for_env,
-        )
-
-        def _sanitize_url(raw: str) -> str:
-            if not raw:
-                return ""
-            try:
-                parts = urlsplit(raw)
-                if parts.username and parts.password:
-                    host = parts.hostname or ""
-                    netloc = f"{parts.username}@{host}"
-                    if parts.port:
-                        netloc = f"{netloc}:{parts.port}"
-                    return urlunsplit(
-                        (parts.scheme, netloc, parts.path, parts.query, parts.fragment)
-                    )
-            except Exception:
-                return raw
-            return raw
+        from daylily_tapdb.cli.db_config import get_config_path, get_db_config
 
         def _psql_query(cfg: dict[str, str], sql: str) -> tuple[bool, str]:
             psql = shutil.which("psql")
             if not psql:
                 return False, "psql not found"
-
             env_vars = os.environ.copy()
             env_vars["PGCONNECT_TIMEOUT"] = "3"
             if cfg.get("password"):
                 env_vars["PGPASSWORD"] = cfg["password"]
-
             cmd = [
                 psql,
                 "-X",
                 "-q",
                 "-t",
                 "-A",
-                "-w",  # never prompt for password
+                "-w",
                 "-v",
                 "ON_ERROR_STOP=1",
                 "-h",
@@ -1814,12 +1602,10 @@ def build_app():
                 )
             except Exception as e:
                 return False, str(e)
-
             if result.returncode != 0:
-                return (
-                    False,
-                    (result.stderr or "").strip() or f"psql exit={result.returncode}",
-                )
+                return False, (
+                    result.stderr or ""
+                ).strip() or f"psql exit={result.returncode}"
             return True, (result.stdout or "").strip()
 
         def _human_duration(seconds: int | None) -> str:
@@ -1841,10 +1627,6 @@ def build_app():
             return " ".join(parts)
 
         def _ui_process_times(pid: int) -> dict[str, object]:
-            """Return UI process start time + uptime, best-effort.
-
-            Uses `ps` (per requirement) for process start time.
-            """
             result: dict[str, object] = {
                 "pid": pid,
                 "running": True,
@@ -1870,8 +1652,6 @@ def build_app():
                 if not raw:
                     result["error"] = "ps returned empty start time"
                     return result
-
-                # macOS/BSD ps lstart format: "Mon Jan  2 15:04:05 2006"
                 start_dt = datetime.strptime(raw, "%a %b %d %H:%M:%S %Y").replace(
                     tzinfo=UTC
                 )
@@ -1884,45 +1664,12 @@ def build_app():
                 result["error"] = str(e)
                 return result
 
-        tapdb_env = _active_env_name()
-
-        def _pg_probe(env_name: str, cfg: dict[str, str]) -> dict[str, object]:
-            url = f"postgresql://{cfg['user']}@{cfg['host']}:{cfg['port']}/{cfg['database']}"
-            should_check = check_all_envs or (env_name == tapdb_env)
-            out: dict[str, object] = {
-                "env": env_name,
-                "url": url,
-                "password_set": bool(cfg.get("password")),
-                "checked": should_check,
-                "status": None,
-                "error": None,
-                "uptime": None,
-            }
-            if not should_check:
-                return out
-
-            ok, msg = _psql_query(cfg, "select 1;")
-            if not ok:
-                out["status"] = "error"
-                out["error"] = msg
-                return out
-            out["status"] = "ok"
-
-            ok_u, msg_u = _psql_query(cfg, "select now() - pg_postmaster_start_time();")
-            if ok_u:
-                out["uptime"] = msg_u
-            else:
-                out["uptime"] = f"error: {msg_u}"
-            return out
-
-        # NOTE: This function is nested inside build_app();
-        # keep indentation purely spaces to avoid TabError.
-        ctx = _require_context(env_name=tapdb_env)
+        ctx = _require_context()
+        cfg = get_db_config()
         effective_config_path = get_config_path()
-        ui_pid_file, ui_log_file, _ = _ui_runtime_paths(tapdb_env)
-        runtime_root = ctx.runtime_dir(tapdb_env)
+        ui_pid_file, ui_log_file, _ = _ui_runtime_paths()
+        runtime_root = ctx.runtime_dir()
 
-        # Template JSON config dir (repo-local)
         template_config_dir: str | None = None
         template_config_error: str | None = None
         try:
@@ -1933,35 +1680,35 @@ def build_app():
             template_config_error = str(e)
 
         ui_pid = _get_pid(ui_pid_file)
-        ui_times: dict[str, object] | None = None
-        if ui_pid:
-            ui_times = _ui_process_times(ui_pid)
-
-        pg_envs: dict[str, dict[str, object]] = {}
-        for env_name in ["dev", "test", "prod"]:
-            try:
-                cfg = get_db_config_for_env(env_name)
-                pg_envs[env_name] = _pg_probe(env_name, cfg)
-            except Exception as e:
-                checked = check_all_envs or (env_name == tapdb_env)
-                pg_envs[env_name] = {
-                    "env": env_name,
-                    "url": "(unconfigured)",
-                    "password_set": False,
-                    "checked": checked,
-                    "status": "error" if checked else None,
-                    "error": str(e),
-                    "uptime": None,
-                }
+        ui_times: dict[str, object] | None = (
+            _ui_process_times(ui_pid) if ui_pid else None
+        )
+        url = (
+            f"postgresql://{cfg['user']}@{cfg['host']}:{cfg['port']}/{cfg['database']}"
+        )
+        ok, msg = _psql_query(cfg, "select 1;")
+        uptime = None
+        if ok:
+            ok_u, msg_u = _psql_query(cfg, "select now() - pg_postmaster_start_time();")
+            uptime = msg_u if ok_u else f"error: {msg_u}"
+        postgres = {
+            "target": "explicit",
+            "url": url,
+            "schema_name": cfg.get("schema_name"),
+            "password_set": bool(cfg.get("password")),
+            "status": "ok" if ok else "error",
+            "error": None if ok else msg,
+            "uptime": uptime,
+        }
 
         if as_json:
             payload: dict[str, object] = {
                 "version": __version__,
                 "python": sys.version.split()[0],
-                "tapdb_env": tapdb_env,
+                "target": "explicit",
                 "client_id": ctx.client_id,
                 "database_name": ctx.database_name,
-                "check_all_envs": check_all_envs,
+                "schema_name": cfg.get("schema_name"),
                 "paths": {
                     "ui_pid_file": str(ui_pid_file),
                     "ui_log_file": str(ui_log_file),
@@ -1980,25 +1727,21 @@ def build_app():
                     "pid": ui_pid,
                     "process": ui_times,
                 },
-                "postgres": pg_envs,
+                "postgres": postgres,
             }
             sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
             return
 
-        # --- General ---
         general = Table(title="TAPDB Info", show_header=True)
         general.add_column("Property", style="cyan")
         general.add_column("Value")
         general.add_row("Version", __version__)
         general.add_row("Python", sys.version.split()[0])
-        general.add_row("TapDB Env", tapdb_env)
+        general.add_row("Target", "explicit")
         general.add_row("Client ID", ctx.client_id)
         general.add_row("Database Name", ctx.database_name)
+        general.add_row("Schema Name", str(cfg.get("schema_name") or ""))
         general.add_row("Namespace", ctx.namespace_slug())
-        general.add_row(
-            "DB probes", "all envs" if check_all_envs else "active env only"
-        )
-
         general.add_row("UI Server", f"Running (PID {ui_pid})" if ui_pid else "Stopped")
         if ui_times and ui_times.get("start_time"):
             general.add_row("UI Start Time", str(ui_times.get("start_time")))
@@ -2007,11 +1750,9 @@ def build_app():
         general.add_row("UI Log File", str(ui_log_file))
         print_renderable(general)
 
-        # --- Config ---
         config_table = Table(title="Config", show_header=True)
         config_table.add_column("Property", style="cyan")
         config_table.add_column("Value")
-
         exists_label = "exists" if effective_config_path.exists() else "missing"
         config_table.add_row(
             "Effective config",
@@ -2020,40 +1761,32 @@ def build_app():
         config_table.add_row("Config dir", str(effective_config_path.parent))
         config_table.add_row("Runtime root", str(runtime_root))
         config_table.add_row("DB log dir", str(runtime_root / "logs"))
-
         if template_config_dir:
             config_table.add_row("Template config dir", template_config_dir)
         else:
             config_table.add_row(
                 "Template config dir", f"(not found) {template_config_error}"
             )
-
         print_renderable(config_table)
 
-        # --- Postgres ---
         pg_table = Table(title="PostgreSQL", show_header=True)
-        pg_table.add_column("Env", style="cyan")
+        pg_table.add_column("Target", style="cyan")
         pg_table.add_column("URL")
+        pg_table.add_column("Schema")
         pg_table.add_column("Password")
         pg_table.add_column("Status")
         pg_table.add_column("Uptime")
-
-        for env_name in ["dev", "test", "prod"]:
-            row = pg_envs[env_name]
-            url = str(row.get("url") or "")
-            pw = "set" if row.get("password_set") else "(not set)"
-            checked = bool(row.get("checked"))
-            if not checked:
-                status = "-"
-                uptime = "-"
-            else:
-                status = str(row.get("status") or "-")
-                if status == "error" and row.get("error"):
-                    status = f"error: {row.get('error')}"
-                uptime = str(row.get("uptime") or "-")
-
-            pg_table.add_row(env_name, f"[dim]{url}[/dim]", pw, status, uptime)
-
+        status = str(postgres.get("status") or "-")
+        if status == "error" and postgres.get("error"):
+            status = f"error: {postgres.get('error')}"
+        pg_table.add_row(
+            "explicit",
+            f"[dim]{url}[/dim]",
+            str(cfg.get("schema_name") or ""),
+            "set" if postgres.get("password_set") else "(not set)",
+            status,
+            str(postgres.get("uptime") or "-"),
+        )
         print_renderable(pg_table)
 
     return app

--- a/daylily_tapdb/cli/admin_server.py
+++ b/daylily_tapdb/cli/admin_server.py
@@ -19,7 +19,6 @@ def _build_parser() -> argparse.ArgumentParser:
         description="Start the TAPDB admin UI with explicit TapDB context.",
     )
     parser.add_argument("--config", required=True, help="TapDB config file path")
-    parser.add_argument("--env", required=True, help="TapDB env name")
     parser.add_argument("--host", required=True, help="UI bind host")
     parser.add_argument("--port", required=True, type=int, help="UI bind port")
     parser.add_argument("--ssl-keyfile", required=True, help="TLS key file")
@@ -32,22 +31,19 @@ def _context_file_path() -> Path:
     return Path.cwd() / _CONTEXT_FILENAME
 
 
-def _write_context_file(
-    *, config_path: str, env_name: str, host: str, port: int
-) -> Path:
+def _write_context_file(*, config_path: str, host: str, port: int) -> Path:
     ctx = resolve_context(
         require_keys=True,
         config_path=config_path,
-        env_name=env_name,
     )
-    ui_dir = ctx.ui_dir(env_name)
+    ui_dir = ctx.ui_dir()
     ui_dir.mkdir(parents=True, exist_ok=True)
     context_file = ui_dir / _CONTEXT_FILENAME
     context_file.write_text(
         json.dumps(
             {
                 "config_path": str(Path(config_path).expanduser().resolve()),
-                "env_name": env_name,
+                "target": "explicit",
                 "host": host,
                 "port": port,
             },
@@ -65,7 +61,7 @@ def _read_context_file() -> dict[str, object]:
     if not context_file.exists():
         raise RuntimeError(
             "Explicit TapDB admin context is missing. "
-            "Start the UI through `tapdb --config <path> --env <name> ui start`."
+            "Start the UI through `tapdb --config <path> ui start`."
         )
     raw = json.loads(context_file.read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
@@ -73,9 +69,9 @@ def _read_context_file() -> dict[str, object]:
     return raw
 
 
-def load_admin_app(*, config_path: str, env_name: str):
-    """Build the TAPDB admin FastAPI app for an explicit config/env."""
-    set_cli_context(config_path=config_path, env_name=env_name)
+def load_admin_app(*, config_path: str):
+    """Build the TAPDB admin FastAPI app for an explicit config target."""
+    set_cli_context(config_path=config_path)
     admin_main = importlib.import_module("admin.main")
     admin_main = importlib.reload(admin_main)
     admin_main.app.state.tapdb_admin_module = admin_main
@@ -86,12 +82,11 @@ def main() -> None:
     args = _build_parser().parse_args()
     context_file = _write_context_file(
         config_path=args.config,
-        env_name=args.env,
         host=args.host,
         port=args.port,
     )
     os.chdir(context_file.parent)
-    set_cli_context(config_path=args.config, env_name=args.env)
+    set_cli_context(config_path=args.config)
 
     import uvicorn
 
@@ -109,12 +104,11 @@ def main() -> None:
 def build_app():
     context = _read_context_file()
     config_path = str(context.get("config_path") or "").strip()
-    env_name = str(context.get("env_name") or "").strip()
-    if not config_path or not env_name:
+    if not config_path:
         raise RuntimeError("TapDB admin context file is incomplete.")
     from daylily_tapdb.web import create_tapdb_web_app
 
-    return create_tapdb_web_app(config_path=config_path, env_name=env_name)
+    return create_tapdb_web_app(config_path=config_path)
 
 
 if __name__ == "__main__":

--- a/daylily_tapdb/cli/aurora.py
+++ b/daylily_tapdb/cli/aurora.py
@@ -18,8 +18,7 @@ from cli_core_yo import ccyo_out
 from rich.console import Console
 from rich.table import Table
 
-from daylily_tapdb.cli.context import resolve_context
-from daylily_tapdb.cli.db_config import default_database_name_for_namespace
+from daylily_tapdb.cli.db_config import get_db_config
 from daylily_tapdb.cli.output import print_renderable
 
 console = Console()
@@ -46,9 +45,22 @@ def _ensure_boto3():
         raise typer.Exit(1)
 
 
-def _stack_name_for_env(env: str) -> str:
-    """Derive CloudFormation stack name from environment name."""
-    return f"tapdb-{env}"
+def _target_cluster_identifier() -> str:
+    cfg = get_db_config()
+    cluster_identifier = str(
+        cfg.get("cluster_identifier") or cfg.get("database") or ""
+    ).strip()
+    if not cluster_identifier:
+        raise RuntimeError(
+            "TapDB target.cluster_identifier or target.database is required "
+            "for Aurora commands."
+        )
+    return cluster_identifier
+
+
+def _stack_name_for_target(cluster_identifier: str) -> str:
+    """Derive CloudFormation stack name from the explicit target config."""
+    return f"tapdb-{cluster_identifier}"
 
 
 def _detect_caller_public_ip() -> str:
@@ -87,7 +99,6 @@ def _resolve_ingress_cidr(
 
 
 def _update_config_file(
-    env: str,
     endpoint: str,
     port: str,
     region: str,
@@ -113,43 +124,32 @@ def _update_config_file(
         except ModuleNotFoundError:
             existing = json.loads(raw) if raw.strip() else {}
 
-    if "environments" not in existing:
-        existing["environments"] = {}
+    if not isinstance(existing, dict):
+        raise RuntimeError(f"invalid TapDB config: {config_path}")
+    target = existing.get("target")
+    if not isinstance(target, dict):
+        raise RuntimeError(f"TapDB explicit target config is required: {config_path}")
+    meta = existing.get("meta")
+    if not isinstance(meta, dict):
+        meta = {}
+    meta["config_version"] = 4
+    existing["meta"] = meta
 
-    try:
-        ctx = resolve_context(require_keys=False, env_name=env)
-    except RuntimeError:
-        ctx = None
-    if ctx:
-        meta = existing.get("meta") if isinstance(existing, dict) else None
-        existing["meta"] = {
-            "config_version": 3,
-            "client_id": ctx.client_id,
-            "database_name": ctx.database_name,
-            "owner_repo_name": str((meta or {}).get("owner_repo_name") or ""),
-            "domain_registry_path": str((meta or {}).get("domain_registry_path") or ""),
-            "prefix_ownership_registry_path": str(
-                (meta or {}).get("prefix_ownership_registry_path") or ""
-            ),
-        }
-
-    env_cfg = existing["environments"].get(env, {}) or {}
-    database_name = str(env_cfg.get("database") or "").strip()
-    if not database_name and ctx:
-        database_name = default_database_name_for_namespace(ctx.database_name, env)
-    existing["environments"][env] = {
-        **env_cfg,
+    existing["target"] = {
+        **target,
         "engine_type": "aurora",
         "host": endpoint,
         "port": port,
-        "database": database_name or f"tapdb_{env}",
-        "user": "tapdb_admin",
+        "database": str(target.get("database") or "").strip(),
+        "schema_name": str(target.get("schema_name") or "").strip(),
+        "user": str(target.get("user") or "tapdb_admin"),
         "region": region,
-        "cluster_identifier": cluster_identifier or env,
-        "iam_auth": "false" if secret_arn else str(env_cfg.get("iam_auth") or "true"),
-        "secret_arn": secret_arn or str(env_cfg.get("secret_arn") or ""),
+        "cluster_identifier": cluster_identifier
+        or str(target.get("cluster_identifier") or target.get("database") or ""),
+        "iam_auth": "false" if secret_arn else str(target.get("iam_auth") or "true"),
+        "secret_arn": secret_arn or str(target.get("secret_arn") or ""),
         "ssl": "true",
-        "ui_port": str(env_cfg.get("ui_port") or "8911"),
+        "ui_port": str(target.get("ui_port") or "8911"),
     }
 
     try:
@@ -168,7 +168,6 @@ def _update_config_file(
 
 @aurora_app.command("create")
 def aurora_create(
-    env: str = typer.Argument(..., help="Environment name (e.g. dev, staging, prod)"),
     region: str = typer.Option("us-west-2", "--region", "-r", help="AWS region"),
     instance_class: str = typer.Option(
         "db.r6g.large", "--instance-class", help="RDS instance class"
@@ -210,6 +209,12 @@ def aurora_create(
 ):
     """Create an Aurora PostgreSQL cluster via CloudFormation."""
     try:
+        cluster_identifier = _target_cluster_identifier()
+    except RuntimeError as exc:
+        ccyo_out.error(str(exc))
+        raise typer.Exit(1)
+
+    try:
         resolved_cidr = _resolve_ingress_cidr(cidr, publicly_accessible)
     except RuntimeError as exc:
         ccyo_out.error(str(exc))
@@ -232,7 +237,7 @@ def aurora_create(
 
     config = AuroraConfig(
         region=region,
-        cluster_identifier=env,
+        cluster_identifier=cluster_identifier,
         instance_class=instance_class,
         engine_version=engine_version,
         vpc_id=vpc_id,
@@ -243,9 +248,12 @@ def aurora_create(
         tags=tags,
     )
 
-    stack_name = _stack_name_for_env(env)
-    ccyo_out.print_text(f"\n[bold cyan]━━━ Aurora Create ({env}) ━━━[/bold cyan]")
+    stack_name = _stack_name_for_target(cluster_identifier)
+    ccyo_out.print_text(
+        "\n[bold cyan]━━━ Aurora Create (explicit target) ━━━[/bold cyan]"
+    )
     ccyo_out.print_text(f"  Stack:    {stack_name}")
+    ccyo_out.print_text(f"  Cluster:  {cluster_identifier}")
     ccyo_out.print_text(f"  Region:   {region}")
     ccyo_out.print_text(f"  Instance: {instance_class}")
     ccyo_out.print_text(f"  Engine:   PostgreSQL {engine_version}")
@@ -263,9 +271,7 @@ def aurora_create(
             ccyo_out.success(
                 f"Stack creation initiated (stack: {initiated['stack_name']})."
             )
-            ccyo_out.detail(
-                f"Check progress with: [cyan]tapdb aurora status {env}[/cyan]"
-            )
+            ccyo_out.detail("Check progress with: [cyan]tapdb aurora status[/cyan]")
             return
         else:
             # Block with live progress using rich status spinner
@@ -296,10 +302,10 @@ def aurora_create(
         ccyo_out.print_text(f"  Endpoint: [cyan]{endpoint}[/cyan]")
         ccyo_out.print_text(f"  Port:     {port}")
         _update_config_file(
-            env,
             endpoint,
             port,
             region,
+            cluster_identifier=cluster_identifier,
             secret_arn=outputs.get("SecretArn"),
         )
 
@@ -309,7 +315,6 @@ def aurora_create(
 
 @aurora_app.command("delete")
 def aurora_delete(
-    env: str = typer.Argument(..., help="Environment name"),
     region: str = typer.Option("us-west-2", "--region", "-r", help="AWS region"),
     retain_networking: bool = typer.Option(
         True,
@@ -320,10 +325,15 @@ def aurora_delete(
 ):
     """Delete an Aurora CloudFormation stack."""
     _ensure_boto3()
+    try:
+        cluster_identifier = _target_cluster_identifier()
+    except RuntimeError as exc:
+        ccyo_out.error(str(exc))
+        raise typer.Exit(1)
 
     from daylily_tapdb.aurora.stack_manager import AuroraStackManager
 
-    stack_name = _stack_name_for_env(env)
+    stack_name = _stack_name_for_target(cluster_identifier)
 
     if not force:
         from rich.prompt import Confirm
@@ -339,8 +349,11 @@ def aurora_delete(
             ccyo_out.print_text("[dim]Cancelled.[/dim]")
             raise typer.Exit(0)
 
-    ccyo_out.print_text(f"\n[bold cyan]━━━ Aurora Delete ({env}) ━━━[/bold cyan]")
+    ccyo_out.print_text(
+        "\n[bold cyan]━━━ Aurora Delete (explicit target) ━━━[/bold cyan]"
+    )
     ccyo_out.print_text(f"  Stack:  {stack_name}")
+    ccyo_out.print_text(f"  Cluster: {cluster_identifier}")
     ccyo_out.print_text(f"  Region: {region}")
     ccyo_out.print_text(f"  Retain networking: {retain_networking}")
     ccyo_out.print_text("")
@@ -351,7 +364,7 @@ def aurora_delete(
         mgr = AuroraStackManager(region=region)
 
         # Disable deletion protection before stack deletion
-        cluster_id = env
+        cluster_id = cluster_identifier
         try:
             rds = boto3.client("rds", region_name=region)
             rds.modify_db_cluster(
@@ -377,16 +390,20 @@ def aurora_delete(
 
 @aurora_app.command("status")
 def aurora_status(
-    env: str = typer.Argument(..., help="Environment name"),
     region: str = typer.Option("us-west-2", "--region", "-r", help="AWS region"),
     as_json: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """Show Aurora stack status, endpoint, and outputs."""
     _ensure_boto3()
+    try:
+        cluster_identifier = _target_cluster_identifier()
+    except RuntimeError as exc:
+        ccyo_out.error(str(exc))
+        raise typer.Exit(1)
 
     from daylily_tapdb.aurora.stack_manager import AuroraStackManager
 
-    stack_name = _stack_name_for_env(env)
+    stack_name = _stack_name_for_target(cluster_identifier)
 
     try:
         mgr = AuroraStackManager(region=region)
@@ -404,8 +421,11 @@ def aurora_status(
     if "FAILED" in status:
         color = "red"
 
-    ccyo_out.print_text(f"\n[bold cyan]━━━ Aurora Status ({env}) ━━━[/bold cyan]")
+    ccyo_out.print_text(
+        "\n[bold cyan]━━━ Aurora Status (explicit target) ━━━[/bold cyan]"
+    )
     ccyo_out.print_text(f"  Stack:  {stack_name}")
+    ccyo_out.print_text(f"  Cluster: {cluster_identifier}")
     ccyo_out.print_text(f"  Region: {region}")
     ccyo_out.print_text(f"  Status: [{color}]{status}[/{color}]")
 
@@ -418,26 +438,34 @@ def aurora_status(
 
 @aurora_app.command("connect")
 def aurora_connect(
-    env: str = typer.Argument(..., help="Environment name"),
     region: str = typer.Option("us-west-2", "--region", "-r", help="AWS region"),
     user: str = typer.Option("tapdb_admin", "--user", "-u", help="Database user"),
     database: str = typer.Option(
         None,
         "--database",
         "-d",
-        help="Database name (default: tapdb_<env>)",
+        help="Database name (default: target.database)",
     ),
     export: bool = typer.Option(
         False, "--export", "-e", help="Print export statements for shell"
     ),
 ):
-    """Print or export connection info for an Aurora environment."""
+    """Print or export connection info for the explicit Aurora target."""
     _ensure_boto3()
+    try:
+        cfg = get_db_config()
+        cluster_identifier = _target_cluster_identifier()
+    except RuntimeError as exc:
+        ccyo_out.error(str(exc))
+        raise typer.Exit(1)
 
     from daylily_tapdb.aurora.stack_manager import AuroraStackManager
 
-    db_name = database or f"tapdb_{env}"
-    stack_name = _stack_name_for_env(env)
+    db_name = database or str(cfg.get("database") or "").strip()
+    if not db_name:
+        ccyo_out.error("target.database is required for Aurora connection output.")
+        raise typer.Exit(1)
+    stack_name = _stack_name_for_target(cluster_identifier)
 
     try:
         mgr = AuroraStackManager(region=region)
@@ -463,7 +491,9 @@ def aurora_connect(
         ccyo_out.print_text(f"export PGUSER={user}")
         ccyo_out.print_text("export PGSSLMODE=verify-full")
     else:
-        ccyo_out.print_text(f"\n[bold cyan]━━━ Aurora Connect ({env}) ━━━[/bold cyan]")
+        ccyo_out.print_text(
+            "\n[bold cyan]━━━ Aurora Connect (explicit target) ━━━[/bold cyan]"
+        )
         ccyo_out.print_text(f"  Endpoint: [cyan]{endpoint}[/cyan]")
         ccyo_out.print_text(f"  Port:     {port}")
         ccyo_out.print_text(f"  Database: {db_name}")

--- a/daylily_tapdb/cli/cognito.py
+++ b/daylily_tapdb/cli/cognito.py
@@ -21,9 +21,8 @@ from cli_core_yo import ccyo_out
 from rich.console import Console
 
 from daylily_tapdb import TAPDBConnection
-from daylily_tapdb.cli.context import resolve_context
 from daylily_tapdb.cli.db import Environment
-from daylily_tapdb.cli.db_config import get_config_path, get_db_config_for_env
+from daylily_tapdb.cli.db_config import get_config_path, get_db_config
 from daylily_tapdb.user_store import create_or_get
 
 console = Console()
@@ -34,12 +33,11 @@ DEFAULT_COGNITO_CALLBACK_PORT = 8911
 REQUIRED_COGNITO_CLIENT_NAME = "tapdb"
 
 
-def _ui_pid_file_for_env(env: Environment) -> Path:
-    ctx = resolve_context(
-        require_keys=True,
-        env_name=env.value,
-    )
-    return ctx.ui_dir(env.value) / "ui.pid"
+def _ui_pid_file() -> Path:
+    from daylily_tapdb.cli.context import resolve_context
+
+    ctx = resolve_context(require_keys=True)
+    return ctx.ui_dir() / "ui.pid"
 
 
 def _split_uri_values(raw: str) -> list[str]:
@@ -68,9 +66,9 @@ def _iter_cognito_uri_values(values: dict[str, str]) -> list[tuple[str, str]]:
     return pairs
 
 
-def _detect_running_ui_port(env: Environment) -> tuple[Optional[int], str]:
+def _detect_running_ui_port() -> tuple[Optional[int], str]:
     """Best-effort detection of current TAPDB UI port from PID command line."""
-    ui_pid_file = _ui_pid_file_for_env(env)
+    ui_pid_file = _ui_pid_file()
     if not ui_pid_file.exists():
         return None, "ui not running"
     try:
@@ -98,13 +96,13 @@ def _detect_running_ui_port(env: Environment) -> tuple[Optional[int], str]:
     return int(m.group(1)), "running ui process"
 
 
-def _resolve_expected_ui_port(env: Environment) -> tuple[int, str]:
-    cfg = get_db_config_for_env(env.value)
+def _resolve_expected_ui_port() -> tuple[int, str]:
+    cfg = get_db_config()
     configured = (cfg.get("ui_port") or "").strip()
     if configured.isdigit():
-        return int(configured), f"config environments.{env.value}.ui_port"
+        return int(configured), "config target.ui_port"
 
-    running_port, source = _detect_running_ui_port(env)
+    running_port, source = _detect_running_ui_port()
     if running_port is not None:
         return running_port, source
 
@@ -112,11 +110,10 @@ def _resolve_expected_ui_port(env: Environment) -> tuple[int, str]:
 
 
 def _validate_bound_cognito_uris(
-    env: Environment,
     values: dict[str, str],
 ) -> tuple[int, str, list[str], list[str]]:
     """Validate Cognito URI fields against TAPDB UI HTTPS + local port rules."""
-    expected_port, port_source = _resolve_expected_ui_port(env)
+    expected_port, port_source = _resolve_expected_ui_port()
     uri_pairs = _iter_cognito_uri_values(values)
     if not uri_pairs:
         return expected_port, port_source, [], []
@@ -162,9 +159,11 @@ def _sanitize_filename_part(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-") or "app"
 
 
-def _default_pool_name(env: Environment) -> str:
-    cfg = get_db_config_for_env(env.value)
-    db_name = (cfg.get("database") or f"tapdb_{env.value}").strip()
+def _default_pool_name() -> str:
+    cfg = get_db_config()
+    db_name = (cfg.get("database") or "").strip()
+    if not db_name:
+        raise RuntimeError("TapDB target.database is required for Cognito pool naming")
     raw = f"tapdb-{db_name}-users"
     name = re.sub(r"[^a-zA-Z0-9-]+", "-", raw).strip("-").lower()
     return re.sub(r"-{2,}", "-", name)
@@ -321,7 +320,7 @@ def _resolve_daycog_pool_id_after_setup(
     )
 
 
-def _write_pool_id_to_tapdb_config(env: Environment, pool_id: str) -> Path:
+def _write_pool_id_to_tapdb_config(pool_id: str) -> Path:
     config_path = get_config_path()
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -335,25 +334,17 @@ def _write_pool_id_to_tapdb_config(env: Environment, pool_id: str) -> Path:
         except ModuleNotFoundError:
             existing = json.loads(raw) if raw.strip() else {}
 
-    envs = existing.setdefault("environments", {})
-    env_cfg = envs.setdefault(env.value, {})
-    env_cfg["cognito_user_pool_id"] = pool_id
-    try:
-        ctx = resolve_context(require_keys=False, env_name=env.value)
-    except RuntimeError:
-        ctx = None
-    if ctx:
-        meta = existing.get("meta") if isinstance(existing, dict) else None
-        existing["meta"] = {
-            "config_version": 3,
-            "client_id": ctx.client_id,
-            "database_name": ctx.database_name,
-            "owner_repo_name": str((meta or {}).get("owner_repo_name") or ""),
-            "domain_registry_path": str((meta or {}).get("domain_registry_path") or ""),
-            "prefix_ownership_registry_path": str(
-                (meta or {}).get("prefix_ownership_registry_path") or ""
-            ),
-        }
+    if not isinstance(existing, dict):
+        raise RuntimeError(f"invalid TapDB config: {config_path}")
+    target = existing.get("target")
+    if not isinstance(target, dict):
+        raise RuntimeError(f"TapDB explicit target config is required: {config_path}")
+    target["cognito_user_pool_id"] = pool_id
+    meta = existing.get("meta")
+    if not isinstance(meta, dict):
+        meta = {}
+    meta["config_version"] = 4
+    existing["meta"] = meta
 
     try:
         import yaml  # type: ignore
@@ -481,7 +472,6 @@ def _build_daycog_setup_args(
 
 def _finalize_setup_binding(
     *,
-    env: Environment,
     selected_pool_name: str,
     selected_client_name: str,
     region: str,
@@ -511,7 +501,7 @@ def _finalize_setup_binding(
         ccyo_out.error(f"{e}")
         raise typer.Exit(1)
 
-    cfg_path = _write_pool_id_to_tapdb_config(env, pool_id)
+    cfg_path = _write_pool_id_to_tapdb_config(pool_id)
     ccyo_out.success(f"Bound pool ID to tapdb config: {pool_id}")
     ccyo_out.print_text(f"  TAPDB config: [dim]{cfg_path}[/dim]")
     ccyo_out.print_text(
@@ -522,19 +512,20 @@ def _finalize_setup_binding(
 def _resolve_bound_daycog_context(
     env: Environment,
 ) -> tuple[str, str, dict[str, str], dict[str, str]]:
-    cfg = get_db_config_for_env(env.value)
+    _ = env
+    cfg = get_db_config()
     pool_id = (cfg.get("cognito_user_pool_id") or "").strip()
     if not pool_id:
         raise RuntimeError(
-            f"No cognito_user_pool_id set for env {env.value}. "
-            f"Run: tapdb cognito setup {env.value}"
+            "No cognito_user_pool_id set for the explicit TapDB target. "
+            "Run: tapdb cognito setup"
         )
 
     context_name, values = _find_pool_context_by_id(
         pool_id,
         prefer_client_name=REQUIRED_COGNITO_CLIENT_NAME,
     )
-    _validate_required_client_name(values, context_label=f"env {env.value}")
+    _validate_required_client_name(values, context_label="explicit TapDB target")
     proc_env = os.environ.copy()
     proc_env.update(values)
     return pool_id, context_name, values, proc_env
@@ -547,7 +538,8 @@ def _resolve_pool_command_context(
     region: Optional[str] = None,
     profile: Optional[str] = None,
 ) -> tuple[str, Optional[dict[str, str]], str, Optional[str]]:
-    selected_pool = pool_name or _default_pool_name(env)
+    _ = env
+    selected_pool = pool_name or _default_pool_name()
     selected_region = region
     selected_profile = profile
     proc_env: Optional[dict[str, str]] = None
@@ -579,7 +571,8 @@ def _ensure_actor_user_row(
         raise RuntimeError("email is required for TAPDB actor user creation")
     if role not in ("admin", "user"):
         raise RuntimeError(f"invalid role: {role}")
-    cfg = get_db_config_for_env(env.value)
+    _ = env
+    cfg = get_db_config()
     engine_type = (cfg.get("engine_type") or "local").strip().lower()
     iam_auth = (cfg.get("iam_auth") or "true").strip().lower() in (
         "true",
@@ -601,6 +594,7 @@ def _ensure_actor_user_row(
         app_username=normalized_email,
         domain_code=str(cfg["domain_code"]),
         owner_repo_name=str(cfg["owner_repo_name"]),
+        schema_name=str(cfg["schema_name"]),
     ) as conn:
         with conn.session_scope(commit=True) as session:
             user, _ = create_or_get(
@@ -620,7 +614,6 @@ def _ensure_actor_user_row(
 
 @cognito_app.command("setup")
 def cognito_setup(
-    env: Environment = typer.Argument(..., help="Target environment"),
     pool_name: Optional[str] = typer.Option(
         None, "--pool-name", "-n", help="Cognito pool name (defaults from DB name)"
     ),
@@ -647,7 +640,7 @@ def cognito_setup(
         None,
         "--port",
         "-p",
-        help="Callback port for daycog (defaults to environments.<env>.ui_port)",
+        help="Callback port for daycog (defaults to target.ui_port)",
     ),
     callback_path: str = typer.Option(
         "/auth/callback",
@@ -708,20 +701,20 @@ def cognito_setup(
     ),
 ) -> None:
     """Create/reuse Cognito pool via daycog and bind pool ID into tapdb config."""
-    cfg = get_db_config_for_env(env.value)
+    cfg = get_db_config()
     configured_port = int(str(cfg.get("ui_port") or DEFAULT_COGNITO_CALLBACK_PORT))
     if port is None:
         selected_port = configured_port
     elif port != configured_port:
         ccyo_out.error(
-            "--port does not match configured TAPDB UI port for env "
-            f"{env.value}: {configured_port}"
+            "--port does not match configured TAPDB UI port for explicit target: "
+            f"{configured_port}"
         )
         raise typer.Exit(1)
     else:
         selected_port = port
 
-    selected_pool_name = pool_name or _default_pool_name(env)
+    selected_pool_name = pool_name or _default_pool_name()
     selected_client_name = client_name or REQUIRED_COGNITO_CLIENT_NAME
     if selected_client_name != REQUIRED_COGNITO_CLIENT_NAME:
         ccyo_out.error(
@@ -730,7 +723,7 @@ def cognito_setup(
         raise typer.Exit(1)
     ccyo_out.print_text(
         f"[cyan]Setting up Cognito pool[/cyan] [bold]{selected_pool_name}[/bold] "
-        f"for env [bold]{env.value}[/bold]"
+        "for explicit TapDB target"
     )
 
     args = _build_daycog_setup_args(
@@ -761,7 +754,6 @@ def cognito_setup(
 
     _run_daycog(args)
     _finalize_setup_binding(
-        env=env,
         selected_pool_name=selected_pool_name,
         selected_client_name=selected_client_name,
         region=region,
@@ -770,7 +762,6 @@ def cognito_setup(
 
 @cognito_app.command("setup-with-google")
 def cognito_setup_with_google(
-    env: Environment = typer.Argument(..., help="Target environment"),
     pool_name: Optional[str] = typer.Option(
         None, "--pool-name", "-n", help="Cognito pool name (defaults from DB name)"
     ),
@@ -797,7 +788,7 @@ def cognito_setup_with_google(
         None,
         "--port",
         "-p",
-        help="Callback port for daycog (defaults to environments.<env>.ui_port)",
+        help="Callback port for daycog (defaults to target.ui_port)",
     ),
     callback_path: str = typer.Option(
         "/auth/callback",
@@ -870,20 +861,20 @@ def cognito_setup_with_google(
     ),
 ) -> None:
     """Create/reuse Cognito pool+app and configure Google IdP; bind pool ID."""
-    cfg = get_db_config_for_env(env.value)
+    cfg = get_db_config()
     configured_port = int(str(cfg.get("ui_port") or DEFAULT_COGNITO_CALLBACK_PORT))
     if port is None:
         selected_port = configured_port
     elif port != configured_port:
         ccyo_out.error(
-            "--port does not match configured TAPDB UI port for env "
-            f"{env.value}: {configured_port}"
+            "--port does not match configured TAPDB UI port for explicit target: "
+            f"{configured_port}"
         )
         raise typer.Exit(1)
     else:
         selected_port = port
 
-    selected_pool_name = pool_name or _default_pool_name(env)
+    selected_pool_name = pool_name or _default_pool_name()
     selected_client_name = client_name or REQUIRED_COGNITO_CLIENT_NAME
     if selected_client_name != REQUIRED_COGNITO_CLIENT_NAME:
         ccyo_out.error(
@@ -892,7 +883,7 @@ def cognito_setup_with_google(
         raise typer.Exit(1)
     ccyo_out.print_text(
         f"[cyan]Setting up Cognito (Google)[/cyan] [bold]{selected_pool_name}[/bold] "
-        f"for env [bold]{env.value}[/bold]"
+        "for explicit TapDB target"
     )
 
     args = _build_daycog_setup_args(
@@ -931,7 +922,6 @@ def cognito_setup_with_google(
 
     _run_daycog(args)
     _finalize_setup_binding(
-        env=env,
         selected_pool_name=selected_pool_name,
         selected_client_name=selected_client_name,
         region=region,
@@ -940,24 +930,21 @@ def cognito_setup_with_google(
 
 @cognito_app.command("bind")
 def cognito_bind(
-    env: Environment = typer.Argument(..., help="Target environment"),
     pool_id: str = typer.Option(..., "--pool-id", help="Cognito user pool ID"),
 ) -> None:
     """Bind an existing Cognito pool ID into tapdb config."""
-    cfg_path = _write_pool_id_to_tapdb_config(env, pool_id.strip())
-    ccyo_out.success(f"Bound {pool_id.strip()} to env '{env.value}'")
+    cfg_path = _write_pool_id_to_tapdb_config(pool_id.strip())
+    ccyo_out.success(f"Bound {pool_id.strip()} to explicit TapDB target")
     ccyo_out.print_text(f"  TAPDB config: [dim]{cfg_path}[/dim]")
 
 
 @cognito_app.command("status")
-def cognito_status(
-    env: Environment = typer.Argument(..., help="Target environment"),
-) -> None:
+def cognito_status() -> None:
     """Show TAPDB Cognito binding and the mapped Daycog context."""
-    cfg = get_db_config_for_env(env.value)
+    cfg = get_db_config()
     pool_id = (cfg.get("cognito_user_pool_id") or "").strip()
     if not pool_id:
-        ccyo_out.warning(f"No cognito_user_pool_id set for env {env.value}")
+        ccyo_out.warning("No cognito_user_pool_id set for explicit TapDB target")
         raise typer.Exit(1)
 
     context_name, values = _find_pool_context_by_id(
@@ -965,7 +952,7 @@ def cognito_status(
         prefer_client_name=REQUIRED_COGNITO_CLIENT_NAME,
     )
     try:
-        _validate_required_client_name(values, context_label=f"env {env.value}")
+        _validate_required_client_name(values, context_label="explicit TapDB target")
     except RuntimeError as e:
         ccyo_out.error(f"{e}")
         raise typer.Exit(1)
@@ -976,8 +963,8 @@ def cognito_status(
     callback_url = values.get("COGNITO_CALLBACK_URL") or "(missing)"
     logout_url = values.get("COGNITO_LOGOUT_URL") or "(not set)"
     profile = values.get("AWS_PROFILE") or "(missing)"
-    ui_pid_file = _ui_pid_file_for_env(env)
-    ccyo_out.success(f"Env:        {env.value}")
+    ui_pid_file = _ui_pid_file()
+    ccyo_out.success("Target:     explicit")
     ccyo_out.success(f"Pool ID:    {pool_id}")
     ccyo_out.success(f"Daycog context: {_daycog_config_path()} :: {context_name}")
     ccyo_out.success(f"Region:     {region}")
@@ -990,7 +977,6 @@ def cognito_status(
     ccyo_out.success(f"UI PID:     {ui_pid_file}")
 
     expected_port, port_source, errors, notices = _validate_bound_cognito_uris(
-        env,
         values,
     )
     ccyo_out.success(f"TAPDB UI port expectation: {expected_port} ({port_source})")
@@ -1006,7 +992,6 @@ def cognito_status(
 
 @cognito_app.command("list-pools")
 def cognito_list_pools(
-    env: Environment = typer.Argument(..., help="Target environment"),
     profile: Optional[str] = typer.Option(
         None, "--profile", help="AWS profile (fallback: active Daycog context)"
     ),
@@ -1015,6 +1000,7 @@ def cognito_list_pools(
     ),
 ) -> None:
     """List Cognito pools in the selected region via daycog."""
+    env = Environment.target
     _, proc_env, selected_region, selected_profile = _resolve_pool_command_context(
         env,
         region=region,
@@ -1028,9 +1014,8 @@ def cognito_list_pools(
 
 @cognito_app.command("list-apps")
 def cognito_list_apps(
-    env: Environment = typer.Argument(..., help="Target environment"),
     pool_name: Optional[str] = typer.Option(
-        None, "--pool-name", help="Cognito pool name (default from env DB name)"
+        None, "--pool-name", help="Cognito pool name (default from target DB name)"
     ),
     profile: Optional[str] = typer.Option(
         None, "--profile", help="AWS profile (fallback: Daycog context)"
@@ -1040,6 +1025,7 @@ def cognito_list_apps(
     ),
 ) -> None:
     """List app clients for a Cognito pool via daycog."""
+    env = Environment.target
     selected_pool, proc_env, selected_region, selected_profile = (
         _resolve_pool_command_context(
             env,
@@ -1056,11 +1042,10 @@ def cognito_list_apps(
 
 @cognito_app.command("add-app")
 def cognito_add_app(
-    env: Environment = typer.Argument(..., help="Target environment"),
     app_name: str = typer.Option(..., "--app-name", help="New app client name"),
     callback_url: str = typer.Option(..., "--callback-url", help="OAuth callback URL"),
     pool_name: Optional[str] = typer.Option(
-        None, "--pool-name", help="Cognito pool name (default from env DB name)"
+        None, "--pool-name", help="Cognito pool name (default from target DB name)"
     ),
     profile: Optional[str] = typer.Option(
         None, "--profile", help="AWS profile (fallback: Daycog context)"
@@ -1086,6 +1071,7 @@ def cognito_add_app(
     ),
 ) -> None:
     """Create a new app client in the pool via daycog."""
+    env = Environment.target
     selected_pool, proc_env, selected_region, selected_profile = (
         _resolve_pool_command_context(
             env,
@@ -1124,7 +1110,6 @@ def cognito_add_app(
 
 @cognito_app.command("edit-app")
 def cognito_edit_app(
-    env: Environment = typer.Argument(..., help="Target environment"),
     app_name: Optional[str] = typer.Option(
         None, "--app-name", help="Existing app client name"
     ),
@@ -1151,7 +1136,7 @@ def cognito_edit_app(
         help="Update the pool context and active Daycog context to this app",
     ),
     pool_name: Optional[str] = typer.Option(
-        None, "--pool-name", help="Cognito pool name (default from env DB name)"
+        None, "--pool-name", help="Cognito pool name (default from target DB name)"
     ),
     profile: Optional[str] = typer.Option(
         None, "--profile", help="AWS profile (fallback: Daycog context)"
@@ -1161,6 +1146,7 @@ def cognito_edit_app(
     ),
 ) -> None:
     """Edit an existing app client in the pool via daycog."""
+    env = Environment.target
     if not app_name and not client_id:
         ccyo_out.error("Provide one of --app-name or --client-id")
         raise typer.Exit(1)
@@ -1199,11 +1185,10 @@ def cognito_edit_app(
 
 @cognito_app.command("remove-app")
 def cognito_remove_app(
-    env: Environment = typer.Argument(..., help="Target environment"),
     app_name: Optional[str] = typer.Option(None, "--app-name", help="App client name"),
     client_id: Optional[str] = typer.Option(None, "--client-id", help="App client ID"),
     pool_name: Optional[str] = typer.Option(
-        None, "--pool-name", help="Cognito pool name (default from env DB name)"
+        None, "--pool-name", help="Cognito pool name (default from target DB name)"
     ),
     profile: Optional[str] = typer.Option(
         None, "--profile", help="AWS profile (fallback: Daycog context)"
@@ -1219,6 +1204,7 @@ def cognito_remove_app(
     ),
 ) -> None:
     """Remove an app client from the pool via daycog."""
+    env = Environment.target
     if not app_name and not client_id:
         ccyo_out.error("Provide one of --app-name or --client-id")
         raise typer.Exit(1)
@@ -1247,11 +1233,10 @@ def cognito_remove_app(
 
 @cognito_app.command("add-google-idp")
 def cognito_add_google_idp(
-    env: Environment = typer.Argument(..., help="Target environment"),
     app_name: Optional[str] = typer.Option(None, "--app-name", help="App client name"),
     client_id: Optional[str] = typer.Option(None, "--client-id", help="App client ID"),
     pool_name: Optional[str] = typer.Option(
-        None, "--pool-name", help="Cognito pool name (default from env DB name)"
+        None, "--pool-name", help="Cognito pool name (default from target DB name)"
     ),
     profile: Optional[str] = typer.Option(
         None, "--profile", help="AWS profile (fallback: Daycog context)"
@@ -1273,6 +1258,7 @@ def cognito_add_google_idp(
     ),
 ) -> None:
     """Configure Google IdP for a pool/app via daycog."""
+    env = Environment.target
     if not app_name and not client_id:
         ccyo_out.error("Provide one of --app-name or --client-id")
         raise typer.Exit(1)
@@ -1310,10 +1296,9 @@ def cognito_add_google_idp(
 
 
 @cognito_app.command("fix-auth-flows")
-def cognito_fix_auth_flows(
-    env: Environment = typer.Argument(..., help="Target environment"),
-) -> None:
+def cognito_fix_auth_flows() -> None:
     """Enable required auth flows on the active daycog app client."""
+    env = Environment.target
     try:
         _, _, _, proc_env = _resolve_bound_daycog_context(env)
     except RuntimeError as e:
@@ -1324,15 +1309,15 @@ def cognito_fix_auth_flows(
 
 @config_app.command("print")
 def cognito_config_print(
-    env: Environment = typer.Argument(..., help="Target environment"),
     pool_name: Optional[str] = typer.Option(
-        None, "--pool-name", help="Cognito pool name (default from env DB name)"
+        None, "--pool-name", help="Cognito pool name (default from target DB name)"
     ),
     region: Optional[str] = typer.Option(
         None, "--region", "-r", help="AWS region (fallback: Daycog context)"
     ),
 ) -> None:
     """Print the Daycog context entry for the target pool."""
+    env = Environment.target
     selected_pool, proc_env, selected_region, _ = _resolve_pool_command_context(
         env,
         pool_name=pool_name,
@@ -1352,9 +1337,8 @@ def cognito_config_print(
 
 @config_app.command("create")
 def cognito_config_create(
-    env: Environment = typer.Argument(..., help="Target environment"),
     pool_name: Optional[str] = typer.Option(
-        None, "--pool-name", help="Cognito pool name (default from env DB name)"
+        None, "--pool-name", help="Cognito pool name (default from target DB name)"
     ),
     profile: Optional[str] = typer.Option(
         None, "--profile", help="AWS profile (fallback: active Daycog context)"
@@ -1364,6 +1348,7 @@ def cognito_config_create(
     ),
 ) -> None:
     """Create a Daycog pool context from AWS and update the active context."""
+    env = Environment.target
     selected_pool, proc_env, selected_region, selected_profile = (
         _resolve_pool_command_context(
             env,
@@ -1387,9 +1372,8 @@ def cognito_config_create(
 
 @config_app.command("update")
 def cognito_config_update(
-    env: Environment = typer.Argument(..., help="Target environment"),
     pool_name: Optional[str] = typer.Option(
-        None, "--pool-name", help="Cognito pool name (default from env DB name)"
+        None, "--pool-name", help="Cognito pool name (default from target DB name)"
     ),
     profile: Optional[str] = typer.Option(
         None, "--profile", help="AWS profile (fallback: active Daycog context)"
@@ -1399,6 +1383,7 @@ def cognito_config_update(
     ),
 ) -> None:
     """Update a Daycog pool context from AWS and refresh the active context."""
+    env = Environment.target
     selected_pool, proc_env, selected_region, selected_profile = (
         _resolve_pool_command_context(
             env,
@@ -1422,7 +1407,6 @@ def cognito_config_update(
 
 @cognito_app.command("add-user")
 def cognito_add_user(
-    env: Environment = typer.Argument(..., help="Target environment"),
     email: str = typer.Argument(..., help="User email"),
     password: str = typer.Option(..., "--password", "-p", help="Initial password"),
     role: str = typer.Option("user", "--role", "-r", help="tapdb role: admin|user"),
@@ -1439,6 +1423,7 @@ def cognito_add_user(
     ),
 ) -> None:
     """Create a Cognito user in the TAPDB-bound pool via daycog."""
+    env = Environment.target
     if role not in ("admin", "user"):
         ccyo_out.error(f"Invalid role: {role}. Must be admin or user")
         raise typer.Exit(1)

--- a/daylily_tapdb/cli/context.py
+++ b/daylily_tapdb/cli/context.py
@@ -14,10 +14,10 @@ from pathlib import Path
 from typing import Optional
 
 CONFIG_FILENAME = "tapdb-config.yaml"
+RUNTIME_DIRNAME = "runtime"
 _KEY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 _ACTIVE_CLIENT_ID: Optional[str] = None
 _ACTIVE_DATABASE_NAME: Optional[str] = None
-_ACTIVE_ENV_NAME: Optional[str] = None
 _ACTIVE_CONFIG_PATH: Optional[Path] = None
 
 
@@ -68,7 +68,6 @@ class TapdbContext:
 
     client_id: str
     database_name: str
-    env_name: Optional[str] = None
     explicit_config_path: Optional[Path] = None
 
     def namespace_slug(self) -> str:
@@ -84,54 +83,42 @@ class TapdbContext:
             return self.explicit_config_path
         return self.config_dir() / CONFIG_FILENAME
 
-    def runtime_dir(self, env_name: Optional[str] = None) -> Path:
-        resolved_env = (env_name or self.env_name or "").strip()
-        if not resolved_env:
-            raise RuntimeError("Environment name is required to resolve runtime_dir")
-        return self.config_dir() / resolved_env
+    def runtime_dir(self) -> Path:
+        return self.config_dir() / RUNTIME_DIRNAME
 
-    def ui_dir(self, env_name: Optional[str] = None) -> Path:
-        return self.runtime_dir(env_name) / "ui"
+    def ui_dir(self) -> Path:
+        return self.runtime_dir() / "ui"
 
-    def postgres_dir(self, env_name: Optional[str] = None) -> Path:
-        return self.runtime_dir(env_name) / "postgres"
+    def postgres_dir(self) -> Path:
+        return self.runtime_dir() / "postgres"
 
-    def postgres_socket_dir(self, env_name: Optional[str] = None) -> Path:
-        candidate = self.postgres_dir(env_name) / "run"
+    def postgres_socket_dir(self) -> Path:
+        candidate = self.postgres_dir() / "run"
         max_socket_path = 103
         sample_socket = candidate / ".s.PGSQL.65535"
         if len(str(sample_socket)) <= max_socket_path:
             return candidate
 
-        resolved_env = (env_name or self.env_name or "").strip()
-        if not resolved_env:
-            raise RuntimeError("Environment name is required to resolve runtime_dir")
         digest = hashlib.sha256(
-            f"{self.client_id}:{self.database_name}:{resolved_env}".encode("utf-8")
+            f"{self.client_id}:{self.database_name}".encode("utf-8")
         ).hexdigest()[:12]
-        return Path(tempfile.gettempdir()) / f"tapdb-pg-{digest}-{resolved_env}"
+        return Path(tempfile.gettempdir()) / f"tapdb-pg-{digest}"
 
-    def lock_dir(self, env_name: Optional[str] = None) -> Path:
-        return self.runtime_dir(env_name) / "locks"
+    def lock_dir(self) -> Path:
+        return self.runtime_dir() / "locks"
 
 
 def set_cli_context(
     *,
     client_id: Optional[str] = None,
     database_name: Optional[str] = None,
-    env_name: Optional[str] = None,
     config_path: Optional[str | Path] = None,
 ) -> None:
     """Set process-local CLI context from explicit command-line inputs."""
 
-    global \
-        _ACTIVE_CLIENT_ID, \
-        _ACTIVE_DATABASE_NAME, \
-        _ACTIVE_ENV_NAME, \
-        _ACTIVE_CONFIG_PATH
+    global _ACTIVE_CLIENT_ID, _ACTIVE_DATABASE_NAME, _ACTIVE_CONFIG_PATH
     _ACTIVE_CLIENT_ID = _normalize_key(client_id, field_name="client-id")
     _ACTIVE_DATABASE_NAME = _normalize_key(database_name, field_name="database-name")
-    _ACTIVE_ENV_NAME = str(env_name or "").strip().lower() or None
     if config_path is None or str(config_path).strip() == "":
         _ACTIVE_CONFIG_PATH = None
     else:
@@ -142,14 +129,6 @@ def clear_cli_context() -> None:
     """Clear process-local CLI context."""
 
     set_cli_context()
-
-
-def active_env_name(default: str = "dev") -> str:
-    """Return the current explicit TapDB env name for this process."""
-    runtime_env = _runtime_invocation_value("env_name")
-    if runtime_env:
-        return runtime_env.lower()
-    return (_ACTIVE_ENV_NAME or default).strip()
 
 
 def active_config_path() -> Optional[Path]:
@@ -173,13 +152,11 @@ def active_context_overrides() -> dict[str, Optional[str | Path]]:
 
     runtime_client = _runtime_invocation_value("client_id")
     runtime_database = _runtime_invocation_value("database_name")
-    runtime_env = _runtime_invocation_value("env_name")
     return {
         "client_id": _ACTIVE_CLIENT_ID
         or _normalize_key(runtime_client, field_name="client-id"),
         "database_name": _ACTIVE_DATABASE_NAME
         or _normalize_key(runtime_database, field_name="database-name"),
-        "env_name": _ACTIVE_ENV_NAME or (runtime_env.lower() if runtime_env else None),
         "config_path": active_config_path(),
     }
 
@@ -215,7 +192,6 @@ def resolve_context(
     require_keys: bool = True,
     client_id: Optional[str] = None,
     database_name: Optional[str] = None,
-    env_name: Optional[str] = None,
     config_path: Optional[str | Path] = None,
 ) -> Optional[TapdbContext]:
     """Resolve TAPDB namespace context from config metadata.
@@ -256,13 +232,9 @@ def resolve_context(
         and resolved_client
         and resolved_db
     ):
-        resolved_env = (
-            env_name or active_overrides["env_name"] or ""
-        ).strip().lower() or None
         return TapdbContext(
             client_id=resolved_client,
             database_name=resolved_db,
-            env_name=resolved_env,
             explicit_config_path=None,
         )
 
@@ -277,12 +249,8 @@ def resolve_context(
             )
         raise RuntimeError("TapDB config path is required. Set --config.")
 
-    resolved_env = (
-        env_name or active_overrides["env_name"] or ""
-    ).strip().lower() or None
     return TapdbContext(
         client_id=resolved_client,
         database_name=resolved_db,
-        env_name=resolved_env,
         explicit_config_path=resolved_config_path,
     )

--- a/daylily_tapdb/cli/db.py
+++ b/daylily_tapdb/cli/db.py
@@ -15,11 +15,10 @@ import typer
 from cli_core_yo import ccyo_out
 from rich.console import Console
 from rich.panel import Panel
-from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
 from daylily_tapdb import TAPDBConnection
-from daylily_tapdb.cli.db_config import get_config_path, get_db_config_for_env
+from daylily_tapdb.cli.db_config import get_config_path, get_db_config
 from daylily_tapdb.euid import (
     AUDIT_LOG_PREFIX,
     GENERIC_INSTANCE_LINEAGE_PREFIX,
@@ -263,11 +262,8 @@ def _resolve_seed_config_dirs(config_path: Optional[Path]) -> list[Path]:
     return _loader_resolve_seed_config_dirs(config_path)
 
 
-# Environment enum
 class Environment(str, Enum):
-    dev = "dev"
-    test = "test"
-    prod = "prod"
+    target = "target"
 
 
 def _ensure_dirs():
@@ -289,8 +285,9 @@ def _log_operation(env: str, operation: str, details: str = ""):
 
 
 def _get_db_config(env: Environment) -> dict:
-    """Get database configuration for environment."""
-    return get_db_config_for_env(env.value)
+    """Get database configuration for the explicit target."""
+    _ = env
+    return get_db_config()
 
 
 def _configured_schema_name(env: Environment) -> Optional[str]:
@@ -322,6 +319,34 @@ def _get_connection_string(env: Environment, database: Optional[str] = None) -> 
     if cfg.get("engine_type") == "aurora":
         return f"{base}?sslmode=verify-full"
     return base
+
+
+def _resolved_target_label(cfg: dict[str, str]) -> str:
+    return (
+        f"{cfg.get('client_id')}/{cfg.get('database_name')}/"
+        f"{cfg.get('schema_name')}@{cfg.get('database')}"
+    )
+
+
+def _require_destructive_confirmation(
+    cfg: dict[str, str], *, operation: str, confirm_target: Optional[str]
+) -> None:
+    policy = str(cfg.get("destructive_operations") or "confirm_required").strip()
+    target_label = _resolved_target_label(cfg)
+    if policy == "blocked":
+        raise RuntimeError(
+            f"Destructive operation '{operation}' is blocked for target {target_label}."
+        )
+    if policy == "allowed":
+        return
+    if confirm_target != target_label:
+        ccyo_out.error("\nWARNING: DESTRUCTIVE OPERATION")
+        ccyo_out.print_text(f"Operation: [bold]{operation}[/bold]")
+        ccyo_out.print_text(f"Target:    [bold]{target_label}[/bold]")
+        ccyo_out.print_text(
+            f"Rerun with [cyan]--confirm-target {target_label}[/cyan] to proceed."
+        )
+        raise typer.Exit(1)
 
 
 def _schema_root_candidates() -> list[Path]:
@@ -507,7 +532,7 @@ def _bootstrap_user_candidates(preferred_user: str) -> list[str]:
 
 def _ensure_local_role(env: Environment, role_name: str) -> None:
     cfg = _get_db_config(env)
-    if env == Environment.prod or cfg.get("engine_type") != "local":
+    if cfg.get("engine_type") != "local":
         return
 
     requested_role = str(role_name or "").strip()
@@ -708,25 +733,25 @@ def _db_callback(ctx: typer.Context) -> None:
         ccyo_out.error(f"{exc}")
         ccyo_out.print_text(
             "  Example: [cyan]tapdb --client-id atlas --database-name app "
-            "db create dev[/cyan]"
+            "--config ~/.config/tapdb/atlas/app/tapdb-config.yaml db create[/cyan]"
         )
         raise typer.Exit(1) from exc
 
 
 @db_app.command("create")
 def db_create(
-    env: Environment = typer.Argument(..., help="Target environment"),
     owner: Optional[str] = typer.Option(
         None, "--owner", "-o", help="Database owner (default: connection user)"
     ),
 ):
-    """Create the TAPDB database for the specified environment."""
+    """Create the TAPDB database for the explicit target."""
+    env = Environment.target
     cfg = _get_db_config(env)
     db_name = cfg["database"]
     db_owner = owner or cfg["user"]
 
     ccyo_out.print_text(
-        f"\n[bold cyan]━━━ Create TAPDB Database ({env.value}) ━━━[/bold cyan]"
+        "\n[bold cyan]━━━ Create TAPDB Database (explicit target) ━━━[/bold cyan]"
     )
     ccyo_out.print_text(f"  Host:     {cfg['host']}:{cfg['port']}")
     ccyo_out.print_text(f"  Database: {db_name}")
@@ -757,15 +782,19 @@ def db_create(
         raise typer.Exit(1)
 
     ccyo_out.success(f"Database '{db_name}' created")
-    ccyo_out.print_text(f"  Next: [cyan]tapdb db schema apply {env.value}[/cyan]")
+    ccyo_out.print_text("  Next: [cyan]tapdb db schema apply[/cyan]")
 
 
 @db_app.command("delete")
 def db_delete(
-    env: Environment = typer.Argument(..., help="Target environment"),
-    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+    confirm_target: Optional[str] = typer.Option(
+        None,
+        "--confirm-target",
+        help="Required target label for destructive delete confirmation",
+    ),
 ):
-    """Delete the TAPDB database for the specified environment."""
+    """Delete the TAPDB database for the explicit target."""
+    env = Environment.target
     cfg = _get_db_config(env)
     db_name = cfg["database"]
 
@@ -779,25 +808,11 @@ def db_delete(
         ccyo_out.warning(f"Database '{db_name}' does not exist")
         return
 
-    if not force:
-        ccyo_out.error("\n⚠️  WARNING: DESTRUCTIVE OPERATION")
-        ccyo_out.print_text(
-            f"This will permanently delete database: [bold]{db_name}[/bold]"
-        )
-        ccyo_out.print_text("All data will be lost!\n")
-
-        if env == Environment.prod:
-            ccyo_out.error("🚨 THIS IS A PRODUCTION DATABASE! 🚨\n")
-
-        if not Confirm.ask(f"Delete database '{db_name}'?", default=False):
-            ccyo_out.print_text("[dim]Aborted.[/dim]")
-            raise typer.Exit(0)
-
-        if env == Environment.prod:
-            typed = typer.prompt("Type the database name to confirm")
-            if typed != db_name:
-                ccyo_out.error("Name mismatch. Aborted.")
-                raise typer.Exit(1)
+    _require_destructive_confirmation(
+        cfg,
+        operation="delete database",
+        confirm_target=confirm_target,
+    )
 
     ccyo_out.warning(f"► Deleting database '{db_name}'...")
     term_sql = f"""
@@ -820,7 +835,6 @@ def db_delete(
 
 @schema_app.command("apply")
 def db_schema_apply(
-    env: Environment = typer.Argument(..., help="Target environment"),
     reinitialize: bool = typer.Option(
         False,
         "--reinitialize",
@@ -832,11 +846,12 @@ def db_schema_apply(
     ),
 ):
     """Apply TAPDB schema to an existing database."""
+    env = Environment.target
     _ensure_dirs()
     cfg = _get_db_config(env)
 
     ccyo_out.print_text(
-        f"\n[bold cyan]━━━ Apply TAPDB Schema ({env.value}) ━━━[/bold cyan]"
+        "\n[bold cyan]━━━ Apply TAPDB Schema (explicit target) ━━━[/bold cyan]"
     )
     ccyo_out.print_text(f"  Host:     {cfg['host']}:{cfg['port']}")
     ccyo_out.print_text(f"  Database: {cfg['database']}")
@@ -846,7 +861,7 @@ def db_schema_apply(
 
     if not _check_db_exists(env, cfg["database"]):
         ccyo_out.error(f"Database '{cfg['database']}' does not exist")
-        ccyo_out.print_text(f"  Create with: [cyan]tapdb db create {env.value}[/cyan]")
+        ccyo_out.print_text("  Create with: [cyan]tapdb db create[/cyan]")
         raise typer.Exit(1)
 
     try:
@@ -906,20 +921,19 @@ def db_schema_apply(
 
 
 @schema_app.command("status")
-def db_status(
-    env: Environment = typer.Argument(..., help="Target environment"),
-):
-    """Check TAPDB schema status in the specified environment."""
+def db_status():
+    """Check TAPDB schema status for the explicit target."""
+    env = Environment.target
     cfg = _get_db_config(env)
 
-    ccyo_out.print_text(f"\n[bold cyan]━━━ TAPDB Status ({env.value}) ━━━[/bold cyan]")
+    ccyo_out.print_text(
+        "\n[bold cyan]━━━ TAPDB Status (explicit target) ━━━[/bold cyan]"
+    )
 
     # Check database exists
     if not _check_db_exists(env, cfg["database"]):
         ccyo_out.error(f"Database '{cfg['database']}' does not exist")
-        ccyo_out.print_text(
-            f"\n  Create with: [cyan]tapdb db create {env.value}[/cyan]"
-        )
+        ccyo_out.print_text("\n  Create with: [cyan]tapdb db create[/cyan]")
         raise typer.Exit(1)
 
     ccyo_out.success(f"Database: {cfg['database']}")
@@ -928,9 +942,7 @@ def db_status(
     # Check schema
     if not _schema_exists(env):
         ccyo_out.error("TAPDB schema not found")
-        ccyo_out.print_text(
-            f"\n  Initialize with: [cyan]tapdb db schema apply {env.value}[/cyan]"
-        )
+        ccyo_out.print_text("\n  Initialize with: [cyan]tapdb db schema apply[/cyan]")
         raise typer.Exit(1)
 
     ccyo_out.success("Schema objects: installed")
@@ -966,7 +978,6 @@ def db_status(
 
 @schema_app.command("drift-check")
 def db_schema_drift_check(
-    env: Environment = typer.Argument(..., help="Target environment"),
     json_output: bool = typer.Option(
         False, "--json", help="Emit machine-readable JSON report"
     ),
@@ -980,6 +991,7 @@ def db_schema_drift_check(
     ),
 ):
     """Detect TAPDB schema drift against canonical TAPDB schema assets."""
+    env = Environment.target
     cfg = _get_db_config(env)
     if not _check_db_exists(env, cfg["database"]):
         message = f"Database '{cfg['database']}' does not exist"
@@ -988,7 +1000,7 @@ def db_schema_drift_check(
                 json.dumps(
                     {
                         "status": "error",
-                        "env": env.value,
+                        "target": "explicit",
                         "database": cfg["database"],
                         "schema_name": cfg["schema_name"],
                         "strict": strict,
@@ -1011,7 +1023,7 @@ def db_schema_drift_check(
                 json.dumps(
                     {
                         "status": "error",
-                        "env": env.value,
+                        "target": "explicit",
                         "database": cfg["database"],
                         "schema_name": cfg["schema_name"],
                         "strict": strict,
@@ -1022,7 +1034,7 @@ def db_schema_drift_check(
                 )
             )
         else:
-            ccyo_out.error(f"Drift check failed for {env.value}: {message}")
+            ccyo_out.error(f"Drift check failed: {message}")
         raise typer.Exit(2) from exc
 
     if json_output:
@@ -1031,7 +1043,7 @@ def db_schema_drift_check(
 
     schema_name = payload.get("schema_name") or "(not found)"
     ccyo_out.print_text(
-        f"\n[bold cyan]━━━ TAPDB Schema Drift Check ({env.value}) ━━━[/bold cyan]"
+        "\n[bold cyan]━━━ TAPDB Schema Drift Check (explicit target) ━━━[/bold cyan]"
     )
     ccyo_out.print_text(f"  Database: {payload['database']}")
     ccyo_out.print_text(f"  Schema:   {schema_name}")
@@ -1061,9 +1073,10 @@ def db_schema_drift_check(
 
 @schema_app.command("reset")
 def db_nuke(
-    env: Environment = typer.Argument(..., help="Target environment"),
-    force: bool = typer.Option(
-        False, "--force", "-f", help="Skip confirmations (for CI/automation)"
+    confirm_target: Optional[str] = typer.Option(
+        None,
+        "--confirm-target",
+        help="Required target label for destructive reset confirmation",
     ),
 ):
     """
@@ -1071,6 +1084,7 @@ def db_nuke(
 
     ⚠️  DESTRUCTIVE OPERATION - This cannot be undone!
     """
+    env = Environment.target
     cfg = _get_db_config(env)
     is_aurora = cfg.get("engine_type") == "aurora"
 
@@ -1095,7 +1109,7 @@ def db_nuke(
     ccyo_out.print_text(
         Panel(
             f"[bold red]⚠️  DESTRUCTIVE OPERATION[/bold red]\n\n"
-            f"Environment: [bold]{env.value.upper()}[/bold]\n"
+            f"Target:      [bold]{_resolved_target_label(cfg)}[/bold]\n"
             f"Database:    [bold]{cfg['database']}[/bold]\n"
             f"Schema:      [bold]{_get_schema_name(env)}[/bold]\n"
             f"Host:        {cfg['host']}:{cfg['port']}\n"
@@ -1118,33 +1132,11 @@ def db_nuke(
         )
     )
 
-    if not force:
-        # Confirmation 1: Environment
-        env_upper = env.value.upper()
-        ccyo_out.error(
-            f"\nConfirmation 1/3: You are about to nuke the {env_upper} database."
-        )
-        if not Confirm.ask("  Proceed?", default=False):
-            ccyo_out.print_text("[dim]Aborted.[/dim]")
-            return
-
-        # Confirmation 2: Type environment name
-        ccyo_out.print_text(
-            "\n[bold]Confirmation 2/3:[/bold] Type the environment name to confirm:"
-        )
-        typed_env = Prompt.ask("  Environment name")
-        if typed_env.lower() != env.value.lower():
-            ccyo_out.error(
-                f"Input '{typed_env}' does not match '{env.value}'. Aborted."
-            )
-            return
-
-        # Confirmation 3: Type DELETE EVERYTHING
-        ccyo_out.error("\nConfirmation 3/3: Type DELETE EVERYTHING to proceed:")
-        typed_confirm = Prompt.ask("  Confirm")
-        if typed_confirm != "DELETE EVERYTHING":
-            ccyo_out.error("Input does not match 'DELETE EVERYTHING'. Aborted.")
-            return
+    _require_destructive_confirmation(
+        cfg,
+        operation="reset schema",
+        confirm_target=confirm_target,
+    )
 
     ccyo_out.warning("\n► Nuking TAPDB schema...")
 
@@ -1238,9 +1230,7 @@ def db_nuke(
     if success:
         _log_operation(env.value, "NUKE", f"Deleted {total_rows} rows from all tables")
         ccyo_out.success("TAPDB schema nuked successfully")
-        ccyo_out.print_text(
-            f"\n  Recreate with: [cyan]tapdb db schema apply {env.value}[/cyan]"
-        )
+        ccyo_out.print_text("\n  Recreate with: [cyan]tapdb db schema apply[/cyan]")
     else:
         ccyo_out.error(f"Nuke failed:\n{psql_out}")
         _log_operation(env.value, "NUKE_FAILED", psql_out[:200])
@@ -1249,16 +1239,16 @@ def db_nuke(
 
 @schema_app.command("migrate")
 def db_migrate(
-    env: Environment = typer.Argument(..., help="Target environment"),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Show what would be done without making changes"
     ),
 ):
-    """Apply schema migrations/updates to the specified environment."""
+    """Apply schema migrations/updates to the explicit target."""
+    env = Environment.target
     cfg = _get_db_config(env)
 
     ccyo_out.print_text(
-        f"\n[bold cyan]━━━ Migrate TAPDB Schema ({env.value}) ━━━[/bold cyan]"
+        "\n[bold cyan]━━━ Migrate TAPDB Schema (explicit target) ━━━[/bold cyan]"
     )
 
     # Check database and schema exist
@@ -1349,7 +1339,6 @@ def db_migrate(
 
 @data_app.command("backup")
 def db_backup(
-    env: Environment = typer.Argument(..., help="Target environment"),
     backup_path: Optional[Path] = typer.Option(
         None, "--output", "-o", help="Output file path"
     ),
@@ -1357,10 +1346,13 @@ def db_backup(
         False, "--data-only", help="Backup data only (no schema)"
     ),
 ):
-    """Backup TAPDB data from the specified environment."""
+    """Backup TAPDB data from the explicit target."""
+    env = Environment.target
     cfg = _get_db_config(env)
 
-    ccyo_out.print_text(f"\n[bold cyan]━━━ Backup TAPDB ({env.value}) ━━━[/bold cyan]")
+    ccyo_out.print_text(
+        "\n[bold cyan]━━━ Backup TAPDB (explicit target) ━━━[/bold cyan]"
+    )
 
     if not _check_db_exists(env, cfg["database"]):
         ccyo_out.error(f"Database '{cfg['database']}' does not exist")
@@ -1369,7 +1361,7 @@ def db_backup(
     # Generate output filename
     if backup_path is None:
         timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
-        backup_path = Path(f"tapdb_{env.value}_{timestamp}.sql")
+        backup_path = Path(f"tapdb_target_{timestamp}.sql")
 
     # Build pg_dump command
     cmd = [
@@ -1431,14 +1423,20 @@ def db_backup(
 
 @data_app.command("restore")
 def db_restore(
-    env: Environment = typer.Argument(..., help="Target environment"),
     input_file: Path = typer.Option(..., "--input", "-i", help="Input backup file"),
-    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+    confirm_target: Optional[str] = typer.Option(
+        None,
+        "--confirm-target",
+        help="Required target label for destructive restore confirmation",
+    ),
 ):
-    """Restore TAPDB data from a backup file."""
+    """Restore TAPDB data into the explicit target from a backup file."""
+    env = Environment.target
     cfg = _get_db_config(env)
 
-    ccyo_out.print_text(f"\n[bold cyan]━━━ Restore TAPDB ({env.value}) ━━━[/bold cyan]")
+    ccyo_out.print_text(
+        "\n[bold cyan]━━━ Restore TAPDB (explicit target) ━━━[/bold cyan]"
+    )
 
     if not input_file.exists():
         ccyo_out.error(f"Backup file not found: {input_file}")
@@ -1450,18 +1448,18 @@ def db_restore(
     )
 
     ccyo_out.print_text(f"  File:     {input_file} ({size_str})")
-    ccyo_out.print_text(f"  Target:   {cfg['database']} ({env.value})")
+    ccyo_out.print_text(f"  Target:   {_resolved_target_label(cfg)}")
 
-    if not force:
-        ccyo_out.warning(f"\nThis will overwrite existing data in {cfg['database']}")
-        if not Confirm.ask("  Proceed?", default=False):
-            ccyo_out.print_text("[dim]Aborted.[/dim]")
-            return
+    _require_destructive_confirmation(
+        cfg,
+        operation="restore data",
+        confirm_target=confirm_target,
+    )
 
     # Ensure database exists
     if not _check_db_exists(env, cfg["database"]):
         ccyo_out.error(f"Database '{cfg['database']}' does not exist")
-        ccyo_out.print_text(f"  Create with: [cyan]tapdb db create {env.value}[/cyan]")
+        ccyo_out.print_text("  Create with: [cyan]tapdb db create[/cyan]")
         raise typer.Exit(1)
 
     ccyo_out.warning("► Restoring from backup...")
@@ -1654,14 +1652,15 @@ def _create_default_admin(env: Environment, insecure_dev_defaults: bool) -> bool
             "  Skipping default admin creation (use --insecure-dev-defaults)"
         )
         return False
-    if env == Environment.prod:
-        ccyo_out.error("  Refusing to create default admin in prod")
+
+    cfg = _get_db_config(env)
+    if str(cfg.get("safety_tier") or "").strip().lower() == "production":
+        ccyo_out.error("  Refusing to create default admin for production safety tier")
         return False
 
     from daylily_tapdb.cli.user import _hash_password
     from daylily_tapdb.user_store import create_or_get
 
-    cfg = _get_db_config(env)
     engine_type = (cfg.get("engine_type") or "local").strip().lower()
     iam_auth = (cfg.get("iam_auth") or "true").strip().lower() in (
         "true",
@@ -1712,7 +1711,6 @@ def _create_default_admin(env: Environment, insecure_dev_defaults: bool) -> bool
 
 @data_app.command("seed")
 def db_seed(
-    env: Environment = typer.Argument(..., help="Target environment"),
     config_path: Optional[Path] = typer.Option(
         None, "--config", "-c", help="Path to config directory"
     ),
@@ -1739,11 +1737,12 @@ def db_seed(
     --include-workflow is retained for compatibility and includes optional
     non-core template packs when present in the provided config directory.
     """
+    env = Environment.target
     cfg = _get_db_config(env)
 
     mode = "core + optional packs" if include_workflow else "core only"
     ccyo_out.print_text(
-        f"\n[bold cyan]━━━ Seed TAPDB Templates ({env.value}) ━━━[/bold cyan]"
+        "\n[bold cyan]━━━ Seed TAPDB Templates (explicit target) ━━━[/bold cyan]"
     )
     ccyo_out.print_text(f"  Mode: {mode}")
     ccyo_out.print_text(f"  Core categories: {', '.join(sorted(CORE_CATEGORIES))}")
@@ -1766,14 +1765,12 @@ def db_seed(
     # Check database and schema exist
     if not _check_db_exists(env, cfg["database"]):
         ccyo_out.error(f"Database '{cfg['database']}' does not exist")
-        ccyo_out.print_text(f"  Create with: [cyan]tapdb db create {env.value}[/cyan]")
+        ccyo_out.print_text("  Create with: [cyan]tapdb db create[/cyan]")
         raise typer.Exit(1)
 
     if not _schema_exists(env):
         ccyo_out.error("TAPDB schema not found")
-        ccyo_out.print_text(
-            f"  Initialize with: [cyan]tapdb db schema apply {env.value}[/cyan]"
-        )
+        ccyo_out.print_text("  Initialize with: [cyan]tapdb db schema apply[/cyan]")
         raise typer.Exit(1)
 
     ccyo_out.warning("► Loading template configurations...")
@@ -1881,8 +1878,16 @@ def db_seed(
 
 @db_app.command("setup")
 def db_setup(
-    env: Environment = typer.Argument(..., help="Target environment"),
-    force: bool = typer.Option(False, "--force", "-f", help="Reinitialize if exists"),
+    recreate: bool = typer.Option(
+        False,
+        "--recreate",
+        help="Delete and recreate the target database before setup",
+    ),
+    confirm_target: Optional[str] = typer.Option(
+        None,
+        "--confirm-target",
+        help="Required target label when --recreate is used",
+    ),
     include_workflow: bool = typer.Option(
         False,
         "--include-workflow",
@@ -1892,7 +1897,7 @@ def db_setup(
     insecure_dev_defaults: bool = typer.Option(
         False,
         "--insecure-dev-defaults",
-        help="DEV ONLY: create default admin user (tapdb_admin/passw0rd)",
+        help="LOCAL/SHARED ONLY: create default admin user (tapdb_admin/passw0rd)",
     ),
 ):
     """Full database setup: create database, apply schema, seed templates.
@@ -1908,12 +1913,13 @@ def db_setup(
     For aurora environments, the database is already created by CloudFormation,
     so the "create database" step is skipped.
     """
+    env = Environment.target
     cfg = _get_db_config(env)
     is_aurora = cfg.get("engine_type") == "aurora"
 
     mode = "core + optional packs" if include_workflow else "core only"
     ccyo_out.print_text(
-        f"\n[bold cyan]━━━ TAPDB Full Setup ({env.value}) ━━━[/bold cyan]"
+        "\n[bold cyan]━━━ TAPDB Full Setup (explicit target) ━━━[/bold cyan]"
     )
     ccyo_out.print_text(f"  Database: {cfg['database']}")
     ccyo_out.print_text(f"  Host:     {cfg['host']}:{cfg['port']}")
@@ -1925,26 +1931,28 @@ def db_setup(
 
     # Step 1: Ensure database exists
     ccyo_out.print_text("\n[bold]Step 1/5: Ensure Database[/bold]")
-    if force and not is_aurora and _check_db_exists(env, cfg["database"]):
-        ccyo_out.warning("  ► --force requested; recreating database")
-        db_delete(env, force=True)
-    db_create(env, owner=None)
+    if recreate and is_aurora:
+        ccyo_out.error("--recreate is not supported for Aurora targets.")
+        raise typer.Exit(1)
+    if recreate and _check_db_exists(env, cfg["database"]):
+        ccyo_out.warning("  ► --recreate requested; recreating database")
+        db_delete(confirm_target=confirm_target)
+    db_create(owner=None)
 
     # Step 2: Apply schema
     ccyo_out.print_text("\n[bold]Step 2/5: Apply Schema[/bold]")
-    db_schema_apply(env, reinitialize=force)
+    db_schema_apply(reinitialize=recreate)
 
     # Step 3: Apply migrations
     ccyo_out.print_text("\n[bold]Step 3/5: Apply Migrations[/bold]")
-    db_migrate(env, dry_run=False)
+    db_migrate(dry_run=False)
 
     # Step 4: Seed templates
     ccyo_out.print_text("\n[bold]Step 4/5: Seed Templates[/bold]")
     db_seed(
-        env,
         config_path=None,
         include_workflow=include_workflow,
-        skip_existing=not force,
+        skip_existing=not recreate,
         dry_run=False,
     )
 
@@ -1968,39 +1976,62 @@ def db_setup(
 
 
 # Shared operation entry points used by orchestrators (e.g. bootstrap).
-def create_database(env: Environment, owner: Optional[str] = None) -> None:
-    db_create(env=env, owner=owner)
+def create_database(
+    env: Environment = Environment.target,
+    owner: Optional[str] = None,
+) -> None:
+    _ = env
+    db_create(owner=owner)
 
 
-def delete_database(env: Environment, force: bool = False) -> None:
-    db_delete(env=env, force=force)
+def delete_database(
+    env: Environment = Environment.target,
+    *,
+    confirm_target: Optional[str] = None,
+) -> None:
+    _ = env
+    db_delete(confirm_target=confirm_target)
 
 
-def apply_schema(env: Environment, reinitialize: bool = False) -> None:
-    db_schema_apply(env=env, reinitialize=reinitialize)
+def apply_schema(
+    env: Environment = Environment.target,
+    reinitialize: bool = False,
+) -> None:
+    _ = env
+    db_schema_apply(reinitialize=reinitialize)
 
 
-def schema_status(env: Environment) -> None:
-    db_status(env=env)
+def schema_status(env: Environment = Environment.target) -> None:
+    _ = env
+    db_status()
 
 
-def reset_schema(env: Environment, force: bool = False) -> None:
-    db_nuke(env=env, force=force)
+def reset_schema(
+    env: Environment = Environment.target,
+    *,
+    confirm_target: Optional[str] = None,
+) -> None:
+    _ = env
+    db_nuke(confirm_target=confirm_target)
 
 
-def run_migrations(env: Environment, dry_run: bool = False) -> None:
-    db_migrate(env=env, dry_run=dry_run)
+def run_migrations(
+    env: Environment = Environment.target,
+    dry_run: bool = False,
+) -> None:
+    _ = env
+    db_migrate(dry_run=dry_run)
 
 
 def seed_templates(
-    env: Environment,
+    env: Environment = Environment.target,
     config_path: Optional[Path] = None,
     include_workflow: bool = False,
     skip_existing: bool = True,
     dry_run: bool = False,
 ) -> None:
+    _ = env
     db_seed(
-        env=env,
         config_path=config_path,
         include_workflow=include_workflow,
         skip_existing=skip_existing,

--- a/daylily_tapdb/cli/db_config.py
+++ b/daylily_tapdb/cli/db_config.py
@@ -34,6 +34,7 @@ DEFAULT_CONFIG_FILENAME = CONFIG_FILENAME
 DEFAULT_TAPDB_POSTGRES_PORT = "5533"
 DEFAULT_UI_PORT = "8911"
 SUPPORTED_CONFIG_VERSION = "3"
+SUPPORTED_TARGET_CONFIG_VERSION = "4"
 DEFAULT_SUPPORT_EMAIL = "support@daylilyinformatics.com"
 DEFAULT_GITHUB_REPO_URL = "https://github.com/Daylily-Informatics/daylily-tapdb"
 DEFAULT_ADMIN_SHARED_SESSION_COOKIE = "session"
@@ -65,18 +66,17 @@ def normalize_postgres_identifier_component(value: str) -> str:
     return normalized
 
 
-def default_database_name_for_namespace(database_name: str, env_name: str) -> str:
-    """Build the default logical database name for a namespace/env pair."""
+def default_database_name_for_namespace(database_name: str, env_name: str = "") -> str:
+    """Build the default physical database name for a namespace."""
 
-    return (
-        "tapdb_"
-        f"{normalize_postgres_identifier_component(database_name)}_"
-        f"{normalize_postgres_identifier_component(env_name)}"
-    )
+    base = f"tapdb_{normalize_postgres_identifier_component(database_name)}"
+    if str(env_name or "").strip():
+        return f"{base}_{normalize_postgres_identifier_component(env_name)}"
+    return base
 
 
-def default_schema_name_for_database(database_name: str, env_name: str) -> str:
-    """Build the default schema name for a database namespace/env pair."""
+def default_schema_name_for_database(database_name: str, env_name: str = "") -> str:
+    """Build the default schema name for a database namespace."""
 
     return default_database_name_for_namespace(database_name, env_name)
 
@@ -196,10 +196,14 @@ def _validate_meta_for_context(root: dict[str, Any], ctx: TapdbContext) -> None:
         )
 
     cfg_version = meta.get("config_version")
-    version_ok = str(cfg_version).strip() == SUPPORTED_CONFIG_VERSION
+    version_ok = str(cfg_version).strip() in {
+        SUPPORTED_CONFIG_VERSION,
+        SUPPORTED_TARGET_CONFIG_VERSION,
+    }
     if not version_ok:
         raise RuntimeError(
-            f"Unsupported config_version {cfg_version!r}. Expected {SUPPORTED_CONFIG_VERSION}."
+            f"Unsupported config_version {cfg_version!r}. "
+            f"Expected {SUPPORTED_TARGET_CONFIG_VERSION}."
         )
 
     cfg_client = str(meta.get("client_id") or "").strip()
@@ -217,20 +221,17 @@ def _validate_meta_for_context(root: dict[str, Any], ctx: TapdbContext) -> None:
         )
 
 
-def get_db_config_for_env(
-    env_name: str,
+def get_db_config(
     *,
     config_path: Optional[str | Path] = None,
     client_id: Optional[str] = None,
     database_name: Optional[str] = None,
 ) -> dict[str, str]:
-    """Resolve DB config for an environment name (dev/test/prod/aurora_*)."""
-    env_key = env_name.lower()
+    """Resolve the single explicit TapDB target from the active config."""
     ctx = resolve_context(
         require_keys=True,
         client_id=client_id,
         database_name=database_name,
-        env_name=env_key,
         config_path=config_path,
     )
 
@@ -245,8 +246,7 @@ def get_db_config_for_env(
             f"No TAPDB config found at {resolved_config_path}. "
             "Run: tapdb config init --client-id <id> --database-name <name>"
         )
-    if ctx:
-        _validate_meta_for_context(root, ctx)
+    _validate_target_meta_for_context(root, ctx, resolved_config_path)
     meta = root.get("meta") if isinstance(root, dict) else None
     if not isinstance(meta, dict):
         raise RuntimeError(f"Config metadata is required in {resolved_config_path}.")
@@ -268,16 +268,11 @@ def get_db_config_for_env(
         )
     ).expanduser()
 
-    file_cfg: dict[str, Any] = {}
-    if "environments" in root and isinstance(root.get("environments"), dict):
-        file_cfg = root["environments"].get(env_key, {}) or {}
-    else:
-        file_cfg = root.get(env_key, {}) or {}
-
-    if not file_cfg:
+    file_cfg = root.get("target") if isinstance(root, dict) else None
+    if not isinstance(file_cfg, dict) or not file_cfg:
         raise RuntimeError(
-            f"Environment {env_key!r} is not configured in {resolved_config_path}. "
-            f"Run: tapdb config init --env {env_key}"
+            f"TapDB target is not configured in {resolved_config_path}. "
+            "Run: tapdb config init --client-id <id> --database-name <name>."
         )
 
     def _file_str(key: str) -> str | None:
@@ -290,20 +285,35 @@ def get_db_config_for_env(
     try:
         schema_name = validate_postgres_identifier_component(
             _file_str("schema_name") or "",
-            field_name=f"environments.{env_key}.schema_name",
+            field_name="target.schema_name",
         )
     except RuntimeError as exc:
         raise RuntimeError(f"Config {resolved_config_path}: {exc}") from exc
 
+    safety = root.get("safety") if isinstance(root.get("safety"), dict) else {}
+    safety_tier = str(safety.get("safety_tier") or "local").strip().lower()
+    destructive_operations = (
+        str(safety.get("destructive_operations") or "confirm_required").strip().lower()
+    )
+    if safety_tier not in {"local", "shared", "production"}:
+        raise RuntimeError(
+            "TapDB config safety.safety_tier must be one of: local, shared, production."
+        )
+    if destructive_operations not in {"blocked", "confirm_required", "allowed"}:
+        raise RuntimeError(
+            "TapDB config safety.destructive_operations must be one of: "
+            "blocked, confirm_required, allowed."
+        )
+
     cfg: dict[str, str] = {
         "engine_type": engine_type,
-        "host": _file_str("host") or "localhost",
-        "port": _file_str("port") or DEFAULT_TAPDB_POSTGRES_PORT,
-        "ui_port": _file_str("ui_port") or DEFAULT_UI_PORT,
-        "user": _file_str("user") or "postgres",
+        "host": _require_file_str(file_cfg, "host", resolved_config_path),
+        "port": _require_file_str(file_cfg, "port", resolved_config_path),
+        "ui_port": _require_file_str(file_cfg, "ui_port", resolved_config_path),
+        "user": _require_file_str(file_cfg, "user", resolved_config_path),
         "password": _file_str("password") or "",
         "secret_arn": _file_str("secret_arn") or "",
-        "database": _file_str("database") or f"tapdb_{env_key}",
+        "database": _require_file_str(file_cfg, "database", resolved_config_path),
         "schema_name": schema_name,
         "cognito_user_pool_id": _file_str("cognito_user_pool_id") or "",
         "cognito_app_client_id": _file_str("cognito_app_client_id") or "",
@@ -315,7 +325,13 @@ def get_db_config_for_env(
         "cognito_logout_url": _file_str("cognito_logout_url") or "",
         "support_email": _file_str("support_email") or "",
         "aws_profile": _file_str("aws_profile") or "",
-        "domain_code": _file_str("domain_code") or "",
+        "region": _file_str("region") or "",
+        "cluster_identifier": _file_str("cluster_identifier") or "",
+        "iam_auth": _file_str("iam_auth") or "",
+        "ssl": _file_str("ssl") or "",
+        "domain_code": _require_file_str(file_cfg, "domain_code", resolved_config_path),
+        "safety_tier": safety_tier,
+        "destructive_operations": destructive_operations,
     }
 
     if ctx:
@@ -340,26 +356,15 @@ def get_db_config_for_env(
     else:
         cfg.setdefault(
             "unix_socket_dir",
-            _file_str("unix_socket_dir") or str(ctx.postgres_socket_dir(env_key)),
+            _file_str("unix_socket_dir") or str(ctx.postgres_socket_dir()),
         )
 
         # Local connections must always use localhost to avoid accidental cross-host
         # reuse.
         if str(cfg["host"]).strip().lower() != "localhost":
             raise RuntimeError(
-                f"Invalid local host {cfg['host']!r} for env {env_key}. "
+                f"Invalid local host {cfg['host']!r} for explicit target. "
                 "Local TAPDB must use host 'localhost'."
-            )
-        required_fields = ("port", "ui_port", "domain_code")
-        missing_required = [
-            field
-            for field in required_fields
-            if not str(file_cfg.get(field) or "").strip()
-        ]
-        if missing_required:
-            raise RuntimeError(
-                f"Config {resolved_config_path} is missing required field(s) for "
-                f"env {env_key}: {', '.join(missing_required)}"
             )
 
     governance = GovernanceContext.load(
@@ -371,6 +376,30 @@ def get_db_config_for_env(
     cfg["domain_code"] = governance.domain_code
 
     return cfg
+
+
+def _validate_target_meta_for_context(
+    root: dict[str, Any], ctx: TapdbContext, resolved_config_path: Path
+) -> None:
+    meta = root.get("meta")
+    if not isinstance(meta, dict):
+        raise RuntimeError(f"Config metadata is required in {resolved_config_path}.")
+    cfg_version = str(meta.get("config_version") or "").strip()
+    if cfg_version != SUPPORTED_TARGET_CONFIG_VERSION:
+        raise RuntimeError(
+            f"Unsupported config_version {cfg_version!r}. "
+            f"Expected {SUPPORTED_TARGET_CONFIG_VERSION} for explicit-target TapDB config."
+        )
+    _validate_meta_for_context(root, ctx)
+
+
+def _require_file_str(
+    file_cfg: dict[str, Any], key: str, resolved_config_path: Path
+) -> str:
+    val = file_cfg.get(key)
+    if val is None or not str(val).strip():
+        raise RuntimeError(f"Config {resolved_config_path} is missing target.{key}.")
+    return str(val).strip()
 
 
 def _as_mapping(value: Any, *, field_name: str) -> dict[str, Any]:
@@ -429,20 +458,14 @@ def _string_list(value: Any) -> list[str]:
     return [item.strip() for item in text.split(",") if item.strip()]
 
 
-def get_admin_settings_for_env(
-    env_name: str,
+def get_admin_settings(
     *,
     config_path: Optional[str | Path] = None,
     client_id: Optional[str] = None,
     database_name: Optional[str] = None,
 ) -> dict[str, Any]:
     """Resolve normalized admin/UI settings from the active TapDB config."""
-    env_key = str(env_name or "").strip().lower()
-    if not env_key:
-        raise RuntimeError("TapDB env name is required to load admin settings.")
-
-    cfg = get_db_config_for_env(
-        env_key,
+    cfg = get_db_config(
         config_path=config_path,
         client_id=client_id,
         database_name=database_name,
@@ -480,7 +503,7 @@ def get_admin_settings_for_env(
 
     return {
         "config_path": str(resolved_config_path),
-        "env_name": env_key,
+        "target_name": "target",
         "support_email": _string(
             cfg.get("support_email"),
             default=DEFAULT_SUPPORT_EMAIL,

--- a/daylily_tapdb/cli/pg.py
+++ b/daylily_tapdb/cli/pg.py
@@ -7,7 +7,6 @@ import re
 import shlex
 import shutil
 import subprocess
-import tempfile
 from pathlib import Path
 from typing import Optional
 
@@ -15,9 +14,9 @@ import typer
 from cli_core_yo import ccyo_out
 from rich.console import Console
 
-from daylily_tapdb.cli.context import active_env_name, resolve_context
+from daylily_tapdb.cli.context import resolve_context
 from daylily_tapdb.cli.db import Environment
-from daylily_tapdb.cli.db_config import get_db_config_for_env
+from daylily_tapdb.cli.db_config import get_db_config
 
 console = Console()
 
@@ -25,53 +24,32 @@ pg_app = typer.Typer(help="PostgreSQL service management commands")
 
 
 def _get_postgres_data_dir(env: "Environment") -> Path:
-    """Get PostgreSQL data directory for environment.
-
-    dev/test: ~/.config/tapdb/<client>/<database>/<env>/postgres/data
-    prod: system default or PGDATA env var
-    """
-    if env.value == "prod":
-        # Production uses system default
-        return Path(os.environ.get("PGDATA", "/var/lib/postgresql/data"))
-    ctx = resolve_context(
-        require_keys=True,
-        env_name=env.value,
-    )
-    return ctx.postgres_dir(env.value) / "data"
+    """Get PostgreSQL data directory for the explicit target."""
+    _ = env
+    ctx = resolve_context(require_keys=True)
+    return ctx.postgres_dir() / "data"
 
 
 def _get_postgres_log_file(env: "Environment") -> Path:
-    if env.value == "prod":
-        return Path("/var/log/postgresql/postgresql.log")
-    ctx = resolve_context(
-        require_keys=True,
-        env_name=env.value,
-    )
-    return ctx.postgres_dir(env.value) / "postgresql.log"
+    _ = env
+    ctx = resolve_context(require_keys=True)
+    return ctx.postgres_dir() / "postgresql.log"
 
 
 def _get_postgres_socket_dir(env: "Environment") -> Path:
-    if env.value == "prod":
-        return Path("/var/run/postgresql")
-    cfg = get_db_config_for_env(env.value)
+    _ = env
+    cfg = get_db_config()
     configured = str(cfg.get("unix_socket_dir") or "").strip()
     if configured:
         return Path(configured).expanduser()
-    ctx = resolve_context(
-        require_keys=True,
-        env_name=env.value,
-    )
-    return ctx.postgres_socket_dir(env.value)
+    ctx = resolve_context(require_keys=True)
+    return ctx.postgres_socket_dir()
 
 
 def _get_instance_lock_file(env: "Environment") -> Path:
-    if env.value == "prod":
-        return Path(tempfile.gettempdir()) / "tapdb-prod-instance.lock"
-    ctx = resolve_context(
-        require_keys=True,
-        env_name=env.value,
-    )
-    return ctx.lock_dir(env.value) / "instance.lock"
+    _ = env
+    ctx = resolve_context(require_keys=True)
+    return ctx.lock_dir() / "instance.lock"
 
 
 def _build_pg_ctl_options(port: int, socket_dir: Path) -> str:
@@ -142,21 +120,16 @@ def _is_port_available(port: int) -> bool:
 
 
 def _active_env() -> Environment:
-    raw = active_env_name("dev").strip()
-    try:
-        return Environment(raw)
-    except ValueError:
-        return Environment.dev
+    return Environment.target
 
 
 def _get_pg_service_cmd() -> tuple[str, list[str], list[str], Path]:
     """
     Get platform-specific system PostgreSQL service commands.
 
-    This is intended for production environments where PostgreSQL is managed as a
-    system service (e.g., systemd on Linux). Local dev/test should use the
-    data-dir based commands: `tapdb --config <path> --env <name> pg init`
-    + `tapdb --config <path> --env <name> pg start-local`.
+    This is intended for system-managed PostgreSQL. Local explicit targets should
+    use data-dir based commands: `tapdb --config <path> pg init` +
+    `tapdb --config <path> pg start-local`.
 
     Returns: (method, start_cmd, stop_cmd, log_path)
     """
@@ -223,8 +196,7 @@ def _is_pg_running() -> tuple[bool, str]:
 def pg_start():
     """Start system PostgreSQL service (production only).
 
-    For local development, prefer:
-    tapdb --config <path> --env <name> pg start-local <env>
+    For local development, prefer: tapdb --config <path> pg start-local
     """
     running, details = _is_pg_running()
     if running:
@@ -237,15 +209,9 @@ def pg_start():
     if method == "unknown":
         ccyo_out.error("No system PostgreSQL service found")
         ccyo_out.print_text("")
-        ccyo_out.print_text(
-            "[bold]Recommended: Use TAPDB local dev/test commands[/bold]"
-        )
-        ccyo_out.print_text(
-            "  [cyan]tapdb pg init dev[/cyan]         # Initialize data directory"
-        )
-        ccyo_out.print_text(
-            "  [cyan]tapdb --config <path> --env dev pg start-local dev[/cyan]  # Start local instance"
-        )
+        ccyo_out.print_text("[bold]Recommended: Use TAPDB local target commands[/bold]")
+        ccyo_out.print_text("  [cyan]tapdb --config <path> pg init[/cyan]")
+        ccyo_out.print_text("  [cyan]tapdb --config <path> pg start-local[/cyan]")
         ccyo_out.print_text("")
         ccyo_out.print_text(
             "[dim]Install PostgreSQL so initdb/pg_ctl"
@@ -288,7 +254,7 @@ def pg_start():
 def pg_stop():
     """Stop system PostgreSQL service (production only).
 
-    For local development instances, use: tapdb pg stop-local <env>
+    For local development instances, use: tapdb --config <path> pg stop-local
     """
     running, _ = _is_pg_running()
     if not running:
@@ -300,7 +266,7 @@ def pg_stop():
     if method == "unknown":
         ccyo_out.error("No system PostgreSQL service found")
         ccyo_out.print_text(
-            "  For local instances, use: [cyan]tapdb pg stop-local <env>[/cyan]"
+            "  For local instances, use: [cyan]tapdb --config <path> pg stop-local[/cyan]"
         )
         raise typer.Exit(1)
 
@@ -336,19 +302,7 @@ def pg_status():
     ccyo_out.print_text("\n[bold cyan]━━━ PostgreSQL Status ━━━[/bold cyan]")
 
     env = _active_env()
-    if env == Environment.prod:
-        running, details = _is_pg_running()
-        if running:
-            ccyo_out.success("PostgreSQL is running")
-            ccyo_out.print_text(f"  Version: {details}")
-        else:
-            ccyo_out.error("○ PostgreSQL is not running")
-            if details and details not in ("", "timeout"):
-                ccyo_out.print_text(f"  Error: {details}")
-            ccyo_out.print_text("\n  Start with: [cyan]tapdb pg start[/cyan]")
-        return
-
-    cfg = get_db_config_for_env(env.value)
+    cfg = get_db_config()
     host = cfg["host"]
     port = cfg["port"]
     user = cfg["user"]
@@ -367,15 +321,11 @@ def pg_status():
     else:
         ccyo_out.error("○ Local PostgreSQL is not running")
         ccyo_out.print_text(
-            f"  Start with: [cyan]tapdb --config <path> --env {env.value} "
-            f"pg start-local {env.value}[/cyan]"
+            "  Start with: [cyan]tapdb --config <path> pg start-local[/cyan]"
         )
 
     ccyo_out.print_text("\n[bold]Local Runtime:[/bold]")
-    ctx = resolve_context(
-        require_keys=True,
-        env_name=env.value,
-    )
+    ctx = resolve_context(require_keys=True)
     ccyo_out.print_text(f"  Namespace: {ctx.namespace_slug()}")
     ccyo_out.print_text(f"  Host:      {host}")
     ccyo_out.print_text(f"  Port:      {port}")
@@ -399,8 +349,7 @@ def pg_logs(
     env = _active_env()
     local_logs: list[Path] = []
     try:
-        if env != Environment.prod:
-            local_logs.append(_get_postgres_log_file(env))
+        local_logs.append(_get_postgres_log_file(env))
     except RuntimeError:
         # Namespace may be unresolved for non-local invocations.
         pass
@@ -470,29 +419,16 @@ def pg_restart():
 
 @pg_app.command("init")
 def pg_init(
-    env: Environment = typer.Argument(..., help="Target environment (dev/test only)"),
     force: bool = typer.Option(
         False, "--force", "-f", help="Reinitialize if already exists"
     ),
 ):
-    """Initialize a PostgreSQL data directory for dev/test.
-
-    Creates a local PostgreSQL data directory in:
-    ~/.config/tapdb/<client-id>/<database-name>/<env>/postgres/data
-    for development and testing. Production uses system PostgreSQL.
-
-    After init, start with:
-    tapdb --config <path> --env <name> pg start-local <env>
-    """
-    if env == Environment.prod:
-        ccyo_out.error("Cannot init prod environment locally")
-        ccyo_out.print_text("  Production should use system PostgreSQL installation")
-        raise typer.Exit(1)
-
+    """Initialize the local PostgreSQL data directory for the explicit target."""
+    env = Environment.target
     data_dir = _get_postgres_data_dir(env)
 
     ccyo_out.print_text(
-        f"\n[bold cyan]━━━ Initialize PostgreSQL ({env.value}) ━━━[/bold cyan]"
+        "\n[bold cyan]━━━ Initialize PostgreSQL (explicit target) ━━━[/bold cyan]"
     )
     ccyo_out.print_text(f"  Data directory: {data_dir}")
 
@@ -520,7 +456,7 @@ def pg_init(
     data_dir.parent.mkdir(parents=True, exist_ok=True)
 
     ccyo_out.warning("► Running initdb...")
-    cfg = get_db_config_for_env(env.value)
+    cfg = get_db_config()
     initdb_superuser = str(cfg.get("user") or "postgres").strip() or "postgres"
 
     # Run initdb
@@ -544,15 +480,8 @@ def pg_init(
         if result.returncode == 0:
             ccyo_out.success("PostgreSQL data directory initialized")
             ccyo_out.print_text("\n[bold]Next steps:[/bold]")
-            ccyo_out.print_text(
-                f"  [cyan]tapdb --config <path> --env {env.value} "
-                f"pg start-local {env.value}[/cyan]  # Start PostgreSQL"
-            )
-            ccyo_out.print_text(
-                f"  [cyan]tapdb --config <path> --env {env.value} "
-                f"db setup {env.value}[/cyan]"
-                "        # Create DB + schema + seed"
-            )
+            ccyo_out.print_text("  [cyan]tapdb --config <path> pg start-local[/cyan]")
+            ccyo_out.print_text("  [cyan]tapdb --config <path> db setup[/cyan]")
         else:
             ccyo_out.error("initdb failed")
             ccyo_out.print_text(f"  {result.stderr}")
@@ -569,38 +498,30 @@ def pg_init(
 
 @pg_app.command("start-local")
 def pg_start_local(
-    env: Environment = typer.Argument(..., help="Target environment (dev/test only)"),
     port: Optional[int] = typer.Option(
         None,
         "--port",
         "-p",
-        help="Port override (must match configured environments.<env>.port)",
+        help="Port override (must match configured target.port)",
     ),
 ):
-    """Start a local PostgreSQL instance for dev/test.
+    """Start a local PostgreSQL instance for the explicit target.
 
     Uses the data directory created by 'tapdb pg init'.
     """
-    if env == Environment.prod:
-        ccyo_out.error("Use 'tapdb pg start' for production")
-        raise typer.Exit(1)
-
-    cfg = get_db_config_for_env(env.value)
+    env = Environment.target
+    cfg = get_db_config()
     configured_port = int(str(cfg.get("port") or "0"))
     if configured_port < 1:
-        ccyo_out.error(f"Missing/invalid configured port for env {env.value}.")
-        ccyo_out.print_text(
-            f"  Set environments.{env.value}.port in the namespaced TAPDB config."
-        )
+        ccyo_out.error("Missing/invalid configured target.port.")
+        ccyo_out.print_text("  Set target.port in the explicit TAPDB config.")
         raise typer.Exit(1)
 
     if port is None:
         port = configured_port
     elif port != configured_port:
-        ccyo_out.error("--port override does not match configured TAPDB env port.")
-        ccyo_out.print_text(
-            f"  Configured environments.{env.value}.port = {configured_port}"
-        )
+        ccyo_out.error("--port override does not match configured TAPDB target port.")
+        ccyo_out.print_text(f"  Configured target.port = {configured_port}")
         raise typer.Exit(1)
 
     data_dir = _get_postgres_data_dir(env)
@@ -611,7 +532,7 @@ def pg_start_local(
 
     if not data_dir.exists() or not (data_dir / "PG_VERSION").exists():
         ccyo_out.error("Data directory not initialized")
-        ccyo_out.print_text(f"  Run: [cyan]tapdb pg init {env.value}[/cyan]")
+        ccyo_out.print_text("  Run: [cyan]tapdb --config <path> pg init[/cyan]")
         raise typer.Exit(1)
 
     # Find pg_ctl (must be in PATH)
@@ -632,12 +553,11 @@ def pg_start_local(
     if not _is_port_available(port):
         ccyo_out.error(f"{_port_conflict_details(port)}")
         ccyo_out.print_text(
-            "  Update environments."
-            f"{env.value}.port in the namespaced TAPDB config to a free port."
+            "  Update target.port in the explicit TAPDB config to a free port."
         )
         raise typer.Exit(1)
 
-    ccyo_out.warning(f"► Starting PostgreSQL ({env.value}) on port {port}...")
+    ccyo_out.warning(f"► Starting PostgreSQL explicit target on port {port}...")
 
     log_file = _get_postgres_log_file(env)
     log_file.parent.mkdir(parents=True, exist_ok=True)
@@ -672,7 +592,7 @@ def pg_start_local(
             ccyo_out.print_text(f"  Log:  {log_file}")
             ccyo_out.print_text(f"  Socket dir: {socket_dir}")
             lock_payload = {
-                "env": env.value,
+                "target": "explicit",
                 "port": port,
                 "data_dir": str(data_dir),
                 "log_file": str(log_file),
@@ -684,9 +604,7 @@ def pg_start_local(
             )
             ccyo_out.print_text(f"  Lock: {lock_file}")
             ccyo_out.print_text("\n[bold]Next step:[/bold]")
-            ccyo_out.print_text(
-                f"  [cyan]tapdb --env {env.value} db setup {env.value}[/cyan]"
-            )
+            ccyo_out.print_text("  [cyan]tapdb --config <path> db setup[/cyan]")
         else:
             ccyo_out.error("Failed to start PostgreSQL")
             ccyo_out.print_text(f"  {result.stderr}")
@@ -700,14 +618,9 @@ def pg_start_local(
 
 
 @pg_app.command("stop-local")
-def pg_stop_local(
-    env: Environment = typer.Argument(..., help="Target environment (dev/test only)"),
-):
-    """Stop a local PostgreSQL instance for dev/test."""
-    if env == Environment.prod:
-        ccyo_out.error("Use 'tapdb pg stop' for production")
-        raise typer.Exit(1)
-
+def pg_stop_local():
+    """Stop a local PostgreSQL instance for the explicit target."""
+    env = Environment.target
     data_dir = _get_postgres_data_dir(env)
     lock_file = _get_instance_lock_file(env)
 
@@ -723,7 +636,7 @@ def pg_stop_local(
         ccyo_out.print_text("  [cyan]conda install -c conda-forge postgresql[/cyan]")
         raise typer.Exit(1)
 
-    ccyo_out.warning(f"► Stopping PostgreSQL ({env.value})...")
+    ccyo_out.warning("► Stopping PostgreSQL explicit target...")
 
     try:
         result = subprocess.run(

--- a/daylily_tapdb/cli/spec.py
+++ b/daylily_tapdb/cli/spec.py
@@ -17,16 +17,10 @@ spec = CliSpec(
     policy=PolicySpec(),
     config=ConfigSpec(
         xdg_relative_path="config.yaml",
-        template_bytes=b"environments: {}\n",
+        template_bytes=b"meta: {}\ntarget: {}\n",
     ),
     context=InvocationContextSpec(
         options=[
-            ContextOptionSpec(
-                name="env_name",
-                option_flags=("--env",),
-                value_type="str",
-                help="Explicit TapDB environment name for this invocation.",
-            ),
             ContextOptionSpec(
                 name="client_id",
                 option_flags=("--client-id",),

--- a/daylily_tapdb/cli/user.py
+++ b/daylily_tapdb/cli/user.py
@@ -16,7 +16,7 @@ from rich.table import Table
 
 from daylily_tapdb import TAPDBConnection
 from daylily_tapdb.cli.db import Environment
-from daylily_tapdb.cli.db_config import get_db_config_for_env
+from daylily_tapdb.cli.db_config import get_db_config
 from daylily_tapdb.cli.output import print_renderable
 from daylily_tapdb.passwords import hash_password as _hash_password
 from daylily_tapdb.user_store import (
@@ -33,7 +33,8 @@ console = Console()
 
 
 def _open_connection(env: Environment, *, app_username: str) -> TAPDBConnection:
-    cfg = get_db_config_for_env(env.value)
+    _ = env
+    cfg = get_db_config()
     engine_type = (cfg.get("engine_type") or "local").strip().lower()
     iam_auth = (cfg.get("iam_auth") or "true").strip().lower() in (
         "true",
@@ -54,6 +55,7 @@ def _open_connection(env: Environment, *, app_username: str) -> TAPDBConnection:
         app_username=app_username,
         domain_code=str(cfg["domain_code"]),
         owner_repo_name=str(cfg["owner_repo_name"]),
+        schema_name=str(cfg["schema_name"]),
     )
 
 
@@ -75,12 +77,12 @@ def _format_date(value: object, *, include_time: bool = False) -> str:
 
 @user_app.command("list")
 def user_list(
-    env: Environment = typer.Argument(..., help="Target environment"),
     show_inactive: bool = typer.Option(
         False, "--inactive", "-i", help="Include inactive users"
     ),
 ):
     """List all users."""
+    env = Environment.target
     try:
         with _open_connection(env, app_username="tapdb_user_cli") as conn:
             with conn.session_scope() as session:
@@ -93,7 +95,7 @@ def user_list(
         ccyo_out.print_text("[dim]No users found[/dim]")
         return
 
-    table = Table(title=f"TAPDB Users ({env.value})")
+    table = Table(title="TAPDB Users (explicit target)")
     table.add_column("Username", style="cyan")
     table.add_column("Email")
     table.add_column("Display Name")
@@ -120,7 +122,6 @@ def user_list(
 
 @user_app.command("add")
 def user_add(
-    env: Environment = typer.Argument(..., help="Target environment"),
     username: str = typer.Option(..., "--username", "-u", help="Username (unique)"),
     role: str = typer.Option("user", "--role", "-r", help="Role: admin or user"),
     email: Optional[str] = typer.Option(None, "--email", "-e", help="Email address"),
@@ -132,6 +133,7 @@ def user_add(
     ),
 ):
     """Add a new user."""
+    env = Environment.target
     if role not in ("admin", "user"):
         ccyo_out.error(f"Invalid role: {role}. Must be 'admin' or 'user'")
         raise typer.Exit(1)
@@ -174,11 +176,11 @@ def user_add(
 
 @user_app.command("set-role")
 def user_set_role(
-    env: Environment = typer.Argument(..., help="Target environment"),
     username: str = typer.Argument(..., help="Username to modify"),
     role: str = typer.Argument(..., help="New role: admin or user"),
 ):
     """Set user role (admin or user)."""
+    env = Environment.target
     if role not in ("admin", "user"):
         ccyo_out.error(f"Invalid role: {role}. Must be 'admin' or 'user'")
         raise typer.Exit(1)
@@ -199,10 +201,10 @@ def user_set_role(
 
 @user_app.command("deactivate")
 def user_deactivate(
-    env: Environment = typer.Argument(..., help="Target environment"),
     username: str = typer.Argument(..., help="Username to deactivate"),
 ):
     """Deactivate a user (soft disable)."""
+    env = Environment.target
     try:
         with _open_connection(env, app_username=username) as conn:
             with conn.session_scope(commit=True) as session:
@@ -218,10 +220,10 @@ def user_deactivate(
 
 @user_app.command("activate")
 def user_activate(
-    env: Environment = typer.Argument(..., help="Target environment"),
     username: str = typer.Argument(..., help="Username to activate"),
 ):
     """Activate a user."""
+    env = Environment.target
     try:
         with _open_connection(env, app_username=username) as conn:
             with conn.session_scope(commit=True) as session:
@@ -237,7 +239,6 @@ def user_activate(
 
 @user_app.command("set-password")
 def user_set_password(
-    env: Environment = typer.Argument(..., help="Target environment"),
     username: str = typer.Argument(..., help="Username"),
     password: str = typer.Option(
         ...,
@@ -250,6 +251,7 @@ def user_set_password(
     ),
 ):
     """Set user password."""
+    env = Environment.target
     try:
         pw_hash = _hash_password(password)
     except RuntimeError as e:
@@ -281,11 +283,11 @@ def user_set_password(
 
 @user_app.command("delete")
 def user_delete(
-    env: Environment = typer.Argument(..., help="Target environment"),
     username: str = typer.Argument(..., help="Username to delete"),
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
 ):
     """Delete a user (soft delete)."""
+    env = Environment.target
     if not force:
         confirm = typer.confirm(f"Permanently delete user '{username}'?")
         if not confirm:

--- a/daylily_tapdb/web/dag.py
+++ b/daylily_tapdb/web/dag.py
@@ -25,14 +25,13 @@ from . import runtime as dag_runtime
 CONTRACT_VERSION = "dag:v1"
 
 
-def _service_name_for(config_path: str, env_name: str, service_name: str | None) -> str:
+def _service_name_for(config_path: str, service_name: str | None) -> str:
     normalized = str(service_name or "").strip()
     if normalized:
         return normalized
     context = resolve_context(
         require_keys=True,
         config_path=config_path,
-        env_name=env_name,
     )
     return str(context.client_id or "tapdb").strip() or "tapdb"
 
@@ -91,21 +90,17 @@ def build_dag_capability_advertisement(
 def create_tapdb_dag_router(
     *,
     config_path: str,
-    env_name: str,
     service_name: str | None = None,
 ) -> APIRouter:
     """Build the canonical `/api/dag/*` router for a TapDB-backed service."""
 
     resolved_config_path = str(config_path or "").strip()
-    resolved_env_name = str(env_name or "").strip()
-    resolved_service_name = _service_name_for(
-        resolved_config_path, resolved_env_name, service_name
-    )
+    resolved_service_name = _service_name_for(resolved_config_path, service_name)
     router = APIRouter()
 
     @router.get("/api/dag/object/{euid}")
     async def dag_object_detail(euid: str) -> dict[str, Any]:
-        with dag_runtime.get_db(resolved_config_path, resolved_env_name) as conn:
+        with dag_runtime.get_db(resolved_config_path) as conn:
             with conn.session_scope() as session:
                 obj, record_type = find_object_by_euid(session, euid)
                 if obj is None or not record_type:
@@ -123,7 +118,7 @@ def create_tapdb_dag_router(
         start_euid: str,
         depth: int = Query(4, ge=0, le=10),
     ) -> dict[str, Any]:
-        with dag_runtime.get_db(resolved_config_path, resolved_env_name) as conn:
+        with dag_runtime.get_db(resolved_config_path) as conn:
             with conn.session_scope() as session:
                 obj, record_type = find_object_by_euid(session, start_euid)
                 if obj is None or not record_type:
@@ -158,7 +153,7 @@ def create_tapdb_dag_router(
         relationship_type: str = "",
         limit: int = Query(25, ge=1, le=100),
     ) -> dict[str, Any]:
-        with dag_runtime.get_db(resolved_config_path, resolved_env_name) as conn:
+        with dag_runtime.get_db(resolved_config_path) as conn:
             with conn.session_scope() as session:
                 payload = search_objects(
                     session,
@@ -186,7 +181,7 @@ def create_tapdb_dag_router(
         ref_index: int = Query(..., ge=0),
         depth: int = Query(4, ge=0, le=10),
     ) -> dict[str, Any]:
-        with dag_runtime.get_db(resolved_config_path, resolved_env_name) as conn:
+        with dag_runtime.get_db(resolved_config_path) as conn:
             with conn.session_scope() as session:
                 obj, _record_type = find_object_by_euid(session, source_euid)
                 if obj is None:
@@ -227,7 +222,7 @@ def create_tapdb_dag_router(
         ref_index: int = Query(..., ge=0),
         euid: str = Query(...),
     ) -> dict[str, Any]:
-        with dag_runtime.get_db(resolved_config_path, resolved_env_name) as conn:
+        with dag_runtime.get_db(resolved_config_path) as conn:
             with conn.session_scope() as session:
                 obj, _record_type = find_object_by_euid(session, source_euid)
                 if obj is None:

--- a/daylily_tapdb/web/factory.py
+++ b/daylily_tapdb/web/factory.py
@@ -55,14 +55,12 @@ def _attach_canonical_dag_router(
     app,
     *,
     config_path: str,
-    env_name: str,
     service_name: str | None,
 ) -> None:
     if getattr(app.state, "tapdb_dag_router_attached", False):
         return
     router = create_tapdb_dag_router(
         config_path=config_path,
-        env_name=env_name,
         service_name=service_name,
     )
     app.include_router(router, dependencies=[Depends(require_tapdb_api_user)])
@@ -119,20 +117,18 @@ class TapdbHostBridgeMount:
 def create_tapdb_web_app(
     *,
     config_path: str,
-    env_name: str,
     host_bridge: TapdbHostBridge | None = None,
 ):
     """Build the reusable TapDB web surface for standalone or embedded use."""
 
     from daylily_tapdb.cli.admin_server import load_admin_app
 
-    app = load_admin_app(config_path=config_path, env_name=env_name)
+    app = load_admin_app(config_path=config_path)
     app.state.tapdb_host_bridge = host_bridge
     _configure_template_environment(app.state.tapdb_admin_module, host_bridge)
     _attach_canonical_dag_router(
         app,
         config_path=config_path,
-        env_name=env_name,
         service_name=(host_bridge.service_name if host_bridge is not None else None),
     )
     if host_bridge is not None and host_bridge.auth_mode == "host_session":

--- a/daylily_tapdb/web/runtime.py
+++ b/daylily_tapdb/web/runtime.py
@@ -15,8 +15,8 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from daylily_tapdb.aurora.connection import AuroraConnectionBuilder
 from daylily_tapdb.cli.db_config import (
-    get_admin_settings_for_env,
-    get_db_config_for_env,
+    get_admin_settings,
+    get_db_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,12 +48,10 @@ def _set_audit_username(session: Session, username: Optional[str]) -> None:
         logger.warning("Could not set session audit username: %s", exc)
 
 
-def _require_schema_name(cfg: dict[str, str], *, env_name: str) -> str:
+def _require_schema_name(cfg: dict[str, str]) -> str:
     schema_name = str(cfg.get("schema_name") or "").strip()
     if not schema_name:
-        raise RuntimeError(
-            f"Config for env {env_name!r} is missing required field: schema_name"
-        )
+        raise RuntimeError("TapDB target config is missing required field: schema_name")
     return schema_name
 
 
@@ -73,7 +71,7 @@ def _set_search_path(session: Session, schema_name: str) -> None:
 @dataclass(frozen=True)
 class RuntimeBundle:
     config_path: str
-    env_name: str
+    target_name: str
     engine: Engine
     SessionFactory: sessionmaker
     cfg: dict[str, str]
@@ -120,10 +118,9 @@ def _create_engine(
     url: URL,
     *,
     config_path: str,
-    env_name: str,
     echo_sql: bool,
 ) -> Engine:
-    settings = get_admin_settings_for_env(env_name, config_path=config_path)
+    settings = get_admin_settings(config_path=config_path)
     pool_size = int(settings.get("db_pool_size") or 5)
     max_overflow = int(settings.get("db_max_overflow") or 10)
     pool_timeout = int(settings.get("db_pool_timeout") or 30)
@@ -184,9 +181,8 @@ def _build_engine_for_cfg(
     cfg: dict[str, str],
     *,
     config_path: str,
-    env_name: str,
 ) -> Engine:
-    _require_schema_name(cfg, env_name=env_name)
+    _require_schema_name(cfg)
     engine_type = (cfg.get("engine_type") or "local").strip().lower()
     echo_sql = _parse_bool(os.environ.get("ECHO_SQL"), default=False)
 
@@ -218,7 +214,6 @@ def _build_engine_for_cfg(
         engine = _create_engine(
             url,
             config_path=config_path,
-            env_name=env_name,
             echo_sql=echo_sql,
         )
         _attach_aurora_password_provider(
@@ -245,22 +240,17 @@ def _build_engine_for_cfg(
     return _create_engine(
         url,
         config_path=config_path,
-        env_name=env_name,
         echo_sql=echo_sql,
     )
 
 
-def get_db(config_path: str, env_name: str) -> RuntimeDBConnection:
+def get_db(config_path: str) -> RuntimeDBConnection:
     """Return a pooled DB connection wrapper for the DAG router."""
 
-    env = str(env_name or "").strip().lower()
-    if not env:
-        raise RuntimeError("TapDB env name is required.")
-
-    cfg = get_db_config_for_env(env, config_path=config_path)
-    schema_name = _require_schema_name(cfg, env_name=env)
+    cfg = get_db_config(config_path=config_path)
+    schema_name = _require_schema_name(cfg)
     resolved_config_path = str(cfg.get("config_path") or str(config_path)).strip()
-    key = (resolved_config_path, env)
+    key = (resolved_config_path, schema_name)
 
     with _bundle_lock:
         bundle = _bundles.get(key)
@@ -268,11 +258,10 @@ def get_db(config_path: str, env_name: str) -> RuntimeDBConnection:
             engine = _build_engine_for_cfg(
                 cfg,
                 config_path=resolved_config_path,
-                env_name=env,
             )
             bundle = RuntimeBundle(
                 config_path=resolved_config_path,
-                env_name=env,
+                target_name="target",
                 engine=engine,
                 SessionFactory=sessionmaker(bind=engine),
                 cfg=cfg,
@@ -297,6 +286,6 @@ def _clear_runtime_cache_for_tests() -> None:
             logger.warning(
                 "Error disposing DAG runtime engine for %s/%s: %s",
                 bundle.config_path,
-                bundle.env_name,
+                bundle.target_name,
                 exc,
             )

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ This directory holds the support material for the TAPDB substrate. The root [REA
 - TAPDB is a reusable substrate, not a domain repo.
 - The current codebase is organized around templates, instances, lineage, audit, outbox, inbox, and explicit scoping.
 - Meridian terminology in the docs should use `domain` and `domain_code`, not older sandbox language.
-- CLI examples should reflect the current `tapdb --config ... --env ...` namespace model.
+- CLI examples should reflect the current `tapdb --config ...` explicit-target model.
 
 ## Deep Dives
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,9 @@ The codebase exposes three main surfaces:
 - the Python library for application code that needs to resolve templates or create instances
 - PostgreSQL for authoritative storage, triggers, and row-level scoping
 
-The CLI is the operational boundary. Runtime commands are always namespaced with `--config <path>` and `--env <name>`, because TAPDB is designed to be used by more than one client and more than one environment at once.
+The CLI is the operational boundary. Runtime commands always use an explicit
+`--config <path>`. That config resolves one target: client namespace, logical
+database namespace, PostgreSQL schema, and physical database connection.
 
 ## What TAPDB Is Not
 

--- a/docs/identity-and-scoping.md
+++ b/docs/identity-and-scoping.md
@@ -70,7 +70,7 @@ TapDB has two relevant runtime layers:
 The supported CLI form is:
 
 ```bash
-tapdb --config <path> --env <name> ...
+tapdb --config <path> ...
 ```
 
 The config metadata must include:
@@ -80,10 +80,9 @@ The config metadata must include:
 - `meta.owner_repo_name`
 - `meta.domain_registry_path`
 - `meta.prefix_ownership_registry_path`
-
-Each configured environment must include:
-
-- `domain_code`
+- `target.domain_code`
+- `target.database`
+- `target.schema_name`
 
 There is no client-code-derived prefix behavior, no passive prefix inheritance,
 and no compatibility path for missing governance metadata.
@@ -99,7 +98,7 @@ The Python connection layer sets session values before work begins:
 The SQL layer rejects missing session state. Application code must provide both
 domain and owner repo deliberately.
 
-Environment defaults:
+Runtime ownership inputs:
 
 - `MERIDIAN_DOMAIN_CODE`
 - `TAPDB_OWNER_REPO`
@@ -138,8 +137,8 @@ Do not substitute one for another.
 
 ```mermaid
 flowchart LR
-    CLI["tapdb --config <path> --env <name>"]
-    CFG["tapdb-config.yaml\nmeta.owner_repo_name\nmeta.domain_registry_path\nmeta.prefix_ownership_registry_path\nenv.domain_code"]
+    CLI["tapdb --config <path>"]
+    CFG["tapdb-config.yaml\nmeta.owner_repo_name\nmeta.domain_registry_path\nmeta.prefix_ownership_registry_path\ntarget.domain_code"]
     CONN["TAPDBConnection"]
     SESS["PostgreSQL session state\nsession.current_username\nsession.current_domain_code\nsession.current_owner_repo_name"]
     ROWS["Rows and triggers\nuid, euid, domain_code, issuer_app_code, tenant_id"]

--- a/docs/integration-and-embedding.md
+++ b/docs/integration-and-embedding.md
@@ -56,14 +56,12 @@ app.mount(
     "/tapdb",
     create_tapdb_web_app(
         config_path="/abs/path/to/tapdb-config.yaml",
-        env_name="dev",
         host_bridge=bridge,
     ),
 )
 app.include_router(
     create_tapdb_dag_router(
         config_path="/abs/path/to/tapdb-config.yaml",
-        env_name="dev",
         service_name="dewey",
     ),
     dependencies=[Depends(my_session_or_service_auth)],

--- a/docs/repository-review.md
+++ b/docs/repository-review.md
@@ -46,9 +46,9 @@ The current CLI is config-first and namespace-scoped, but the existing documenta
 The codebase currently expects:
 
 - explicit `--config`
-- explicit `--env`
+- one explicit target per config
 - metadata-driven namespace resolution
-- runtime layout under `~/.config/tapdb/<client>/<database>/<env>/`
+- runtime layout under `~/.config/tapdb/<client>/<database>/runtime/`
 
 That needs to be documented as the operational contract, not as an implementation detail.
 

--- a/docs/runtime-and-cli.md
+++ b/docs/runtime-and-cli.md
@@ -6,17 +6,19 @@ This document describes how TAPDB is operated today: config-first, namespace-sco
 
 ## Operating Model
 
-TAPDB treats a deployment as a namespace made from `client_id` + `database_name` + `env`.
+TAPDB treats a runtime as one explicit resolved target made from
+`client_id`, `database_name`, `schema_name`, and the physical database
+connection fields in a single config file.
 
 The CLI resolves that namespace from config metadata and explicit runtime flags:
 
 ```bash
-tapdb --config /abs/path/to/tapdb-config.yaml --env dev ...
+tapdb --config /abs/path/to/tapdb-config.yaml ...
 ```
 
 The config file must carry `meta.client_id` and `meta.database_name`. The runtime context helpers live in [`daylily_tapdb/cli/context.py`](../daylily_tapdb/cli/context.py), and the public command groups are defined in [`daylily_tapdb/cli/__init__.py`](../daylily_tapdb/cli/__init__.py).
 
-Config initialization is the main exception: it requires `--config` but creates the metadata that later runtime commands resolve through `--env`.
+Config initialization requires `--config` and writes the single target that later runtime commands use directly.
 
 ### Namespace Layout
 
@@ -26,10 +28,10 @@ The current runtime layout is rooted under:
 ~/.config/tapdb/<client-id>/<database-name>/
 ```
 
-The environment-specific runtime tree is then nested beneath the active `env`:
+The runtime tree is nested beneath `runtime/`:
 
 ```text
-~/.config/tapdb/<client-id>/<database-name>/<env>/
+~/.config/tapdb/<client-id>/<database-name>/runtime/
 ```
 
 Important subpaths used by the CLI:
@@ -39,7 +41,7 @@ Important subpaths used by the CLI:
 - `locks/` for local lock metadata
 
 For most namespaces the local Postgres socket directory lives under
-`<env>/postgres/run/`. When the full path would exceed PostgreSQL's Unix socket
+`runtime/postgres/run/`. When the full path would exceed PostgreSQL's Unix socket
 path limit, TAPDB automatically falls back to a short deterministic temp
 directory so the local bootstrap path remains runnable from deep worktrees or
 temporary test paths.
@@ -55,7 +57,6 @@ The root command is `tapdb`. The current help surface shows these top-level grou
 - `config`
 - `bootstrap`
 - `ui`
-- `db-config`
 - `db`
 - `pg`
 - `users`
@@ -64,8 +65,7 @@ The root command is `tapdb`. The current help surface shows these top-level grou
 
 That split is deliberate:
 
-- `config` manages generic config-file operations.
-- `db-config` initializes or updates the namespace-aware TAPDB config.
+- `config` initializes or updates the explicit-target TAPDB config.
 - `pg` manages local or system PostgreSQL processes.
 - `db` manages database lifecycle, schema, migrations, backup, and data seeding.
 - `ui` manages the admin server process.
@@ -78,7 +78,7 @@ That split is deliberate:
 
 The basic local flow is:
 
-1. Create or update the namespace config.
+1. Create or update the explicit target config.
 2. Initialize a local Postgres data directory.
 3. Start the local Postgres instance.
 4. Apply schema.
@@ -88,26 +88,30 @@ The basic local flow is:
 The CLI surfaces for that flow are already present and exercised in tests:
 
 ```bash
-tapdb --config <path> db-config init \
+tapdb --config <path> config init \
   --client-id <client-id> \
   --database-name <database-name> \
   --owner-repo-name <repo-name> \
-  --env dev \
-  --domain-code dev=<domain-code> \
+  --domain-code <domain-code> \
   --domain-registry-path /abs/path/to/domain_code_registry.json \
   --prefix-ownership-registry-path /abs/path/to/prefix_ownership_registry.json \
-  --db-port dev=5533 \
-  --ui-port dev=8911
+  --engine-type local \
+  --host localhost \
+  --port 5533 \
+  --ui-port 8911 \
+  --user tapdb \
+  --database tapdb_<client-id>_<database-name> \
+  --schema-name tapdb_<client-id>_<database-name>
 
-tapdb --config <path> --env dev pg init dev
-tapdb --config <path> --env dev pg start-local dev
-tapdb --config <path> --env dev db config validate
-tapdb --config <path> --env dev db schema apply dev
-tapdb --config <path> --env dev db data seed dev
-tapdb --config <path> --env dev bootstrap local --no-gui
+tapdb --config <path> pg init
+tapdb --config <path> pg start-local
+tapdb --config <path> db config validate
+tapdb --config <path> db schema apply
+tapdb --config <path> db data seed
+tapdb --config <path> bootstrap local --no-gui
 ```
 
-`tapdb bootstrap local` is the preferred orchestration entrypoint for local developer setup. It includes optional flags for `--no-gui`, `--include-workflow`, and `--insecure-dev-defaults` for dev-only bootstrap flows. The command is documented by the CLI help and covered by the CLI test suite in [`tests/test_cli.py`](../tests/test_cli.py) and [`tests/test_cli_coverage.py`](../tests/test_cli_coverage.py).
+`tapdb bootstrap local` is the preferred orchestration entrypoint for local developer setup. It includes optional flags for `--no-gui`, `--include-workflow`, and `--insecure-dev-defaults` for local-only bootstrap flows. The command is documented by the CLI help and covered by the CLI test suite in [`tests/test_cli.py`](../tests/test_cli.py) and [`tests/test_cli_coverage.py`](../tests/test_cli_coverage.py).
 
 For local single-repo runs, TAPDB also ships packaged example registry fixtures
 under [`daylily_tapdb/etc`](../daylily_tapdb/etc). They are useful for docs
@@ -117,10 +121,10 @@ examples, tests, and isolated TapDB-only bootstrap flows.
 
 Schema work is separated from data seeding:
 
-- `tapdb db schema apply <env>` applies the SQL schema.
+- `tapdb db schema apply` applies the SQL schema.
 - `tapdb db config validate` checks namespace config and template-pack structure without touching the database.
-- `tapdb db schema migrate <env>` runs tracked SQL migrations.
-- `tapdb db data seed <env>` loads templates into the database.
+- `tapdb db schema migrate` runs tracked SQL migrations.
+- `tapdb db data seed` loads templates into the database.
 
 That separation matters because TAPDB uses the database as the runtime source of truth for templates, while JSON packs are just input material for seeding and validation. The schema and seed commands are part of the CLI contract and are exercised against a real ephemeral PostgreSQL instance in [`tests/test_pg_integration.py`](../tests/test_pg_integration.py).
 
@@ -135,7 +139,7 @@ That separation matters because TAPDB uses the database as the runtime source of
 - Postgres probe status
 - optional JSON output via `--json`
 
-For CLI v2, JSON is a root-global flag, so use `tapdb --config <path> --env <name> --json info` rather than a command-local JSON switch.
+For CLI v2, JSON is a root-global flag, so use `tapdb --config <path> --json info` rather than a command-local JSON switch.
 
 It also performs best-effort `psql` probes when available. The implementation lives in [`daylily_tapdb/cli/__init__.py`](../daylily_tapdb/cli/__init__.py), and the runtime context resolution lives in [`daylily_tapdb/cli/context.py`](../daylily_tapdb/cli/context.py).
 
@@ -146,11 +150,11 @@ The admin UI is managed separately from the database, but still inside the TAPDB
 Relevant commands:
 
 ```bash
-tapdb --config <path> --env <name> ui start
-tapdb --config <path> --env <name> ui stop
-tapdb --config <path> --env <name> ui status
-tapdb --config <path> --env <name> ui restart
-tapdb --config <path> --env <name> ui logs
+tapdb --config <path> ui start
+tapdb --config <path> ui stop
+tapdb --config <path> ui status
+tapdb --config <path> ui restart
+tapdb --config <path> ui logs
 ```
 
 The UI server supports foreground/background operation, explicit port and host overrides, and explicit TLS certificate overrides. The admin app itself is loaded through [`daylily_tapdb.cli.admin_server`](../daylily_tapdb/cli/admin_server.py).

--- a/docs/tapdb_gui_inclusion.md
+++ b/docs/tapdb_gui_inclusion.md
@@ -30,7 +30,6 @@ app.mount(
     "/tapdb",
     create_tapdb_web_app(
         config_path="/abs/path/to/tapdb-config.yaml",
-        env_name="dev",
         host_bridge=bridge,
     ),
 )
@@ -122,7 +121,7 @@ Use this only for local development or diagnostics.
 ## 6) Troubleshooting
 
 - `OAuth login is not configured ... cognito_user_pool_id`:
-  Set `environments.<env>.cognito_user_pool_id` in tapdb config.
+  Set `target.cognito_user_pool_id` in the explicit TapDB config.
 - `redirect_mismatch` from Cognito:
   Ensure callback/logout URLs in Cognito app client match actual TAPDB URL/port.
 - Host bridge auth not taking effect:

--- a/examples/readme/10_bootstrap_local.sh
+++ b/examples/readme/10_bootstrap_local.sh
@@ -25,6 +25,8 @@ CLIENT_ID="${TAPDB_DOCS_CLIENT_ID:-docs}"
 DATABASE_NAME="${TAPDB_DOCS_DATABASE_NAME:-demo}"
 OWNER_REPO_NAME="${TAPDB_DOCS_OWNER_REPO_NAME:-daylily-tapdb}"
 DOMAIN_CODE="${TAPDB_DOCS_DOMAIN_CODE:-Z}"
+PHYSICAL_DATABASE="${TAPDB_DOCS_PHYSICAL_DATABASE:-tapdb_docs_demo}"
+SCHEMA_NAME="${TAPDB_DOCS_SCHEMA_NAME:-tapdb_docs_demo}"
 DB_PORT="${TAPDB_DOCS_DB_PORT:-15533}"
 UI_PORT="${TAPDB_DOCS_UI_PORT:-18911}"
 CONFIG_PATH="${TAPDB_DOCS_CONFIG:-$WORKDIR/.config/tapdb/$CLIENT_ID/$DATABASE_NAME/tapdb-config.yaml}"
@@ -82,21 +84,25 @@ prefix_registry_path.write_text(
 )
 PY
 
-tapdb --config "$CONFIG_PATH" db-config init \
+tapdb --config "$CONFIG_PATH" config init \
     --client-id "$CLIENT_ID" \
     --database-name "$DATABASE_NAME" \
     --owner-repo-name "$OWNER_REPO_NAME" \
-    --env dev \
-    --domain-code "dev=$DOMAIN_CODE" \
+    --domain-code "$DOMAIN_CODE" \
     --domain-registry-path "$DOMAIN_REGISTRY_PATH" \
     --prefix-ownership-registry-path "$PREFIX_OWNERSHIP_REGISTRY_PATH" \
-    --db-port "dev=$DB_PORT" \
-    --ui-port "dev=$UI_PORT" \
+    --engine-type local \
+    --host localhost \
+    --port "$DB_PORT" \
+    --ui-port "$UI_PORT" \
+    --user tapdb \
+    --database "$PHYSICAL_DATABASE" \
+    --schema-name "$SCHEMA_NAME" \
     --force
 
-tapdb --config "$CONFIG_PATH" --env dev bootstrap local --no-gui
+tapdb --config "$CONFIG_PATH" bootstrap local --no-gui
 
 printf '\nBootstrap example completed.\n'
 printf 'Config: %s\n' "$CONFIG_PATH"
-printf 'Runtime root: %s\n' "$(dirname "$CONFIG_PATH")/dev"
+printf 'Runtime root: %s\n' "$(dirname "$CONFIG_PATH")/runtime"
 printf 'Next: TAPDB_DOCS_WORKDIR=%s python examples/readme/20_python_api.py\n' "$WORKDIR"

--- a/examples/readme/20_python_api.py
+++ b/examples/readme/20_python_api.py
@@ -8,7 +8,8 @@ import os
 from pathlib import Path
 
 from daylily_tapdb import InstanceFactory, TAPDBConnection, TemplateManager
-from daylily_tapdb.cli.db_config import get_db_config_for_env
+from daylily_tapdb.cli.context import set_cli_context
+from daylily_tapdb.cli.db_config import get_db_config
 
 TEMPLATE_CODE = "MSG/message/webhook_event/1.0/"
 
@@ -33,7 +34,6 @@ def _default_config_path() -> Path:
 
 def main() -> None:
     config_path = _default_config_path()
-    env_name = os.environ.get("TAPDB_DOCS_ENV", "dev")
     instance_name = os.environ.get(
         "TAPDB_DOCS_INSTANCE_NAME",
         "README Webhook Event",
@@ -45,7 +45,8 @@ def main() -> None:
             "Run examples/readme/10_bootstrap_local.sh first or set TAPDB_DOCS_CONFIG."
         )
 
-    cfg = get_db_config_for_env(env_name, config_path=config_path)
+    set_cli_context(config_path=config_path)
+    cfg = get_db_config()
     domain_code = os.environ.get("TAPDB_DOCS_DOMAIN_CODE", str(cfg["domain_code"]))
     owner_repo_name = os.environ.get(
         "TAPDB_DOCS_OWNER_REPO_NAME",
@@ -56,6 +57,7 @@ def main() -> None:
         db_user=cfg["user"],
         db_pass=cfg["password"],
         db_name=cfg["database"],
+        schema_name=cfg["schema_name"],
         app_username="tapdb_readme_example",
         domain_code=domain_code,
         owner_repo_name=owner_repo_name,
@@ -89,7 +91,6 @@ def main() -> None:
 
             payload = {
                 "config_path": str(config_path),
-                "env": env_name,
                 "template_code": TEMPLATE_CODE,
                 "template_euid": template.euid,
                 "instance_uid": int(instance.uid),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,21 +37,20 @@ def pytest_addoption(parser):
         "--tapdb-env",
         action="store",
         default="",
-        help="Explicit TapDB env name for integration tests.",
+        help="Deprecated; TapDB tests now use the explicit config target.",
     )
 
 
 def resolve_tapdb_test_dsn(pytestconfig) -> str:
     config_path = str(pytestconfig.getoption("--tapdb-config") or "").strip()
-    env_name = str(pytestconfig.getoption("--tapdb-env") or "").strip().lower()
-    if not config_path or not env_name:
-        pytest.skip(
-            "Set --tapdb-config and --tapdb-env to run Postgres integration tests"
-        )
+    if not config_path:
+        pytest.skip("Set --tapdb-config to run Postgres integration tests")
 
-    from daylily_tapdb.cli.db_config import get_db_config_for_env
+    from daylily_tapdb.cli.context import set_cli_context
+    from daylily_tapdb.cli.db_config import get_db_config
 
-    cfg = get_db_config_for_env(env_name, config_path=config_path)
+    set_cli_context(config_path=config_path)
+    cfg = get_db_config(config_path=config_path)
     user = str(cfg.get("user") or "postgres")
     password = str(cfg.get("password") or "")
     host = str(cfg.get("host") or "localhost")
@@ -198,36 +197,39 @@ def pg_instance(tmp_path_factory):
 
     cfg_data = {
         "meta": {
-            "config_version": 3,
+            "config_version": 4,
             "client_id": "testclient",
             "database_name": "testdb",
             "owner_repo_name": "daylily-tapdb",
             "domain_registry_path": str(domain_registry_path),
             "prefix_ownership_registry_path": str(prefix_registry_path),
         },
-        "environments": {
-            "dev": {
-                "engine_type": "local",
-                "host": "localhost",
-                "port": port,
-                "ui_port": 18911,
-                "domain_code": "Z",
-                "user": user,
-                "password": "",
-                "database": database,
-                "schema_name": "tapdb_testdb_dev",
-            },
+        "target": {
+            "engine_type": "local",
+            "host": "localhost",
+            "port": port,
+            "ui_port": 18911,
+            "domain_code": "Z",
+            "user": user,
+            "password": "",
+            "database": database,
+            "schema_name": "tapdb_testdb",
+            "unix_socket_dir": str(socket_dir),
+        },
+        "safety": {
+            "safety_tier": "local",
+            "destructive_operations": "confirm_required",
         },
     }
     cfg_path.write_text(yaml.safe_dump(cfg_data), encoding="utf-8")
     os.chmod(cfg_path, 0o600)
 
     # Construct a postgres_dir layout that matches what pg.py expects
-    pg_runtime = cfg_dir / "dev" / "postgres"
+    pg_runtime = cfg_dir / "runtime" / "postgres"
     pg_runtime.mkdir(parents=True, exist_ok=True)
     # Symlink data and run dirs so CLI pg commands find them
     (pg_runtime / "data").symlink_to(data_dir)
-    run_link = pg_runtime / "run"
+    run_link = pg_runtime / "socket"
     run_link.symlink_to(socket_dir)
 
     dsn = f"postgresql://{user}:@localhost:{port}/{database}"
@@ -240,7 +242,7 @@ def pg_instance(tmp_path_factory):
         "config_dir": cfg_dir,
         "user": user,
         "database": database,
-        "schema_name": "tapdb_testdb_dev",
+        "schema_name": "tapdb_testdb",
         "dsn": dsn,
         "base": base,
     }

--- a/tests/test_admin_cognito.py
+++ b/tests/test_admin_cognito.py
@@ -1,5 +1,7 @@
 """Tests for TAPDB Admin Cognito runtime resolution."""
 
+from __future__ import annotations
+
 import os
 from pathlib import Path
 
@@ -28,7 +30,8 @@ def _write_test_registries(tmp_path: Path) -> tuple[Path, Path]:
     )
     prefix_registry.write_text(
         (
-            '{"version":"0.4.0","ownership":{"Z":{"TPX":{"issuer_app_code":"daylily-tapdb"},'
+            '{"version":"0.4.0","ownership":{"Z":{'
+            '"TPX":{"issuer_app_code":"daylily-tapdb"},'
             '"EDG":{"issuer_app_code":"daylily-tapdb"},'
             '"ADT":{"issuer_app_code":"daylily-tapdb"},'
             '"SYS":{"issuer_app_code":"daylily-tapdb"},'
@@ -39,6 +42,35 @@ def _write_test_registries(tmp_path: Path) -> tuple[Path, Path]:
     return domain_registry, prefix_registry
 
 
+def _write_config(tmp_path: Path, target_extra: str = "") -> Path:
+    cfg_path = _config_path(tmp_path)
+    domain_registry, prefix_registry = _write_test_registries(tmp_path)
+    _write(
+        cfg_path,
+        "meta:\n"
+        "  config_version: 4\n"
+        "  client_id: local\n"
+        "  database_name: tapdb\n"
+        "  owner_repo_name: daylily-tapdb\n"
+        f"  domain_registry_path: {domain_registry}\n"
+        f"  prefix_ownership_registry_path: {prefix_registry}\n"
+        "target:\n"
+        "  engine_type: local\n"
+        "  host: localhost\n"
+        "  port: 5432\n"
+        "  ui_port: 8911\n"
+        "  domain_code: Z\n"
+        "  user: test\n"
+        "  database: tapdb_shared\n"
+        "  schema_name: tapdb_tapdb\n"
+        f"{target_extra}"
+        "safety:\n"
+        "  safety_tier: shared\n"
+        "  destructive_operations: confirm_required\n",
+    )
+    return cfg_path
+
+
 @pytest.fixture(autouse=True)
 def _clear_cli_context_fixture() -> None:
     clear_cli_context()
@@ -46,42 +78,21 @@ def _clear_cli_context_fixture() -> None:
     clear_cli_context()
 
 
-def test_resolve_tapdb_pool_config_from_tapdb_yaml(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
-    cfg_path = _config_path(tmp_path)
-    domain_registry, prefix_registry = _write_test_registries(tmp_path)
-
-    _write(
-        cfg_path,
-        "meta:\n"
-        "  config_version: 3\n"
-        "  client_id: local\n"
-        "  database_name: tapdb\n"
-        "  owner_repo_name: daylily-tapdb\n"
-        f"  domain_registry_path: {domain_registry}\n"
-        f"  prefix_ownership_registry_path: {prefix_registry}\n"
-        "environments:\n"
-        "  dev:\n"
-        "    host: localhost\n"
-        "    port: 5432\n"
-        "    ui_port: 8911\n"
-        "    domain_code: Z\n"
-        "    user: test\n"
-        "    database: tapdb_dev\n"
-        "    schema_name: tapdb_tapdb_dev\n"
-        "    cognito_user_pool_id: us-east-1_TESTPOOL\n"
-        "    cognito_app_client_id: client123\n"
-        "    cognito_client_name: tapdb\n"
-        "    cognito_region: us-east-1\n"
-        "    cognito_domain: tapdb-dev-users.auth.us-east-1.amazoncognito.com\n"
-        "    cognito_callback_url: https://localhost:8911/auth/callback\n"
-        "    cognito_logout_url: https://localhost:8911/login\n"
-        "    aws_profile: test-profile\n",
+def test_resolve_tapdb_pool_config_from_tapdb_yaml(tmp_path: Path):
+    cfg_path = _write_config(
+        tmp_path,
+        "  cognito_user_pool_id: us-east-1_TESTPOOL\n"
+        "  cognito_app_client_id: client123\n"
+        "  cognito_client_name: tapdb\n"
+        "  cognito_region: us-east-1\n"
+        "  cognito_domain: tapdb-users.auth.us-east-1.amazoncognito.com\n"
+        "  cognito_callback_url: https://localhost:8911/auth/callback\n"
+        "  cognito_logout_url: https://localhost:8911/login\n"
+        "  aws_profile: test-profile\n",
     )
 
-    set_cli_context(config_path=cfg_path, env_name="dev")
-    cfg = resolve_tapdb_pool_config("dev")
+    set_cli_context(config_path=cfg_path)
+    cfg = resolve_tapdb_pool_config()
     assert cfg.pool_id == "us-east-1_TESTPOOL"
     assert cfg.app_client_id == "client123"
     assert cfg.region == "us-east-1"
@@ -89,101 +100,36 @@ def test_resolve_tapdb_pool_config_from_tapdb_yaml(
     assert cfg.source_file == cfg_path
 
 
-def test_resolve_tapdb_pool_config_requires_pool_id(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
-    cfg_path = _config_path(tmp_path)
-    domain_registry, prefix_registry = _write_test_registries(tmp_path)
+def test_resolve_tapdb_pool_config_requires_pool_id(tmp_path: Path):
+    cfg_path = _write_config(tmp_path)
 
-    _write(
-        cfg_path,
-        "meta:\n"
-        "  config_version: 3\n"
-        "  client_id: local\n"
-        "  database_name: tapdb\n"
-        "  owner_repo_name: daylily-tapdb\n"
-        f"  domain_registry_path: {domain_registry}\n"
-        f"  prefix_ownership_registry_path: {prefix_registry}\n"
-        "environments:\n"
-        "  dev:\n"
-        "    host: localhost\n"
-        "    port: 5432\n"
-        "    ui_port: 8911\n"
-        "    domain_code: Z\n"
-        "    user: test\n"
-        "    database: tapdb_dev\n"
-        "    schema_name: tapdb_tapdb_dev\n",
-    )
-
-    set_cli_context(config_path=cfg_path, env_name="dev")
+    set_cli_context(config_path=cfg_path)
     with pytest.raises(RuntimeError, match="cognito_user_pool_id"):
-        resolve_tapdb_pool_config("dev")
+        resolve_tapdb_pool_config()
 
 
-def test_resolve_tapdb_pool_config_requires_client_id(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
-    cfg_path = _config_path(tmp_path)
-    domain_registry, prefix_registry = _write_test_registries(tmp_path)
-
-    _write(
-        cfg_path,
-        "meta:\n"
-        "  config_version: 3\n"
-        "  client_id: local\n"
-        "  database_name: tapdb\n"
-        "  owner_repo_name: daylily-tapdb\n"
-        f"  domain_registry_path: {domain_registry}\n"
-        f"  prefix_ownership_registry_path: {prefix_registry}\n"
-        "environments:\n"
-        "  dev:\n"
-        "    host: localhost\n"
-        "    port: 5432\n"
-        "    ui_port: 8911\n"
-        "    domain_code: Z\n"
-        "    user: test\n"
-        "    database: tapdb_dev\n"
-        "    schema_name: tapdb_tapdb_dev\n"
-        "    cognito_user_pool_id: us-east-1_TESTPOOL\n"
-        "    cognito_client_name: tapdb\n"
-        "    cognito_region: us-east-1\n",
+def test_resolve_tapdb_pool_config_requires_client_id(tmp_path: Path):
+    cfg_path = _write_config(
+        tmp_path,
+        "  cognito_user_pool_id: us-east-1_TESTPOOL\n"
+        "  cognito_client_name: tapdb\n"
+        "  cognito_region: us-east-1\n",
     )
 
-    set_cli_context(config_path=cfg_path, env_name="dev")
+    set_cli_context(config_path=cfg_path)
     with pytest.raises(RuntimeError, match="cognito_app_client_id"):
-        resolve_tapdb_pool_config("dev")
+        resolve_tapdb_pool_config()
 
 
-def test_resolve_tapdb_pool_config_requires_tapdb_client_name(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
-    cfg_path = _config_path(tmp_path)
-    domain_registry, prefix_registry = _write_test_registries(tmp_path)
-
-    _write(
-        cfg_path,
-        "meta:\n"
-        "  config_version: 3\n"
-        "  client_id: local\n"
-        "  database_name: tapdb\n"
-        "  owner_repo_name: daylily-tapdb\n"
-        f"  domain_registry_path: {domain_registry}\n"
-        f"  prefix_ownership_registry_path: {prefix_registry}\n"
-        "environments:\n"
-        "  dev:\n"
-        "    host: localhost\n"
-        "    port: 5432\n"
-        "    ui_port: 8911\n"
-        "    domain_code: Z\n"
-        "    user: test\n"
-        "    database: tapdb_dev\n"
-        "    schema_name: tapdb_tapdb_dev\n"
-        "    cognito_user_pool_id: us-east-1_TESTPOOL\n"
-        "    cognito_app_client_id: client123\n"
-        "    cognito_client_name: wrong-client\n"
-        "    cognito_region: us-east-1\n",
+def test_resolve_tapdb_pool_config_requires_tapdb_client_name(tmp_path: Path):
+    cfg_path = _write_config(
+        tmp_path,
+        "  cognito_user_pool_id: us-east-1_TESTPOOL\n"
+        "  cognito_app_client_id: client123\n"
+        "  cognito_client_name: wrong-client\n"
+        "  cognito_region: us-east-1\n",
     )
 
-    set_cli_context(config_path=cfg_path, env_name="dev")
+    set_cli_context(config_path=cfg_path)
     with pytest.raises(RuntimeError, match="cognito_client_name"):
-        resolve_tapdb_pool_config("dev")
+        resolve_tapdb_pool_config()

--- a/tests/test_admin_db_connection.py
+++ b/tests/test_admin_db_connection.py
@@ -28,8 +28,8 @@ def test_admin_get_db_reuses_single_engine_bundle(monkeypatch):
     )
     monkeypatch.setattr(
         pool_mod,
-        "get_db_config_for_env",
-        lambda _env: {
+        "get_db_config",
+        lambda: {
             "engine_type": "local",
             "host": "localhost",
             "port": "5533",
@@ -60,8 +60,8 @@ def test_admin_get_engine_bundle_requires_schema_name(monkeypatch):
     pool_mod._clear_engine_cache_for_tests()
     monkeypatch.setattr(
         pool_mod,
-        "get_db_config_for_env",
-        lambda _env: {
+        "get_db_config",
+        lambda: {
             "engine_type": "local",
             "host": "localhost",
             "port": "5533",
@@ -72,7 +72,7 @@ def test_admin_get_engine_bundle_requires_schema_name(monkeypatch):
     )
 
     with pytest.raises(RuntimeError, match="schema_name"):
-        pool_mod.get_engine_bundle("dev")
+        pool_mod.get_engine_bundle()
 
 
 def test_admin_session_scope_sets_search_path(monkeypatch):

--- a/tests/test_admin_db_metrics.py
+++ b/tests/test_admin_db_metrics.py
@@ -33,7 +33,7 @@ def _write_config(path: Path, *, queue_max: int) -> Path:
     )
     path.write_text(
         "meta:\n"
-        "  config_version: 3\n"
+        "  config_version: 4\n"
         "  client_id: alpha\n"
         "  database_name: beta\n"
         "  owner_repo_name: daylily-tapdb\n"
@@ -67,17 +67,19 @@ def _write_config(path: Path, *, queue_max: int) -> Path:
         "  db_max_overflow: 10\n"
         "  db_pool_timeout: 30\n"
         "  db_pool_recycle: 1800\n"
-        "environments:\n"
-        "  dev:\n"
-        "    engine_type: local\n"
-        "    host: localhost\n"
-        "    port: '5533'\n"
-        "    ui_port: '8911'\n"
-        "    domain_code: Z\n"
-        "    user: tapdb\n"
-        "    password: ''\n"
-        "    database: tapdb_dev\n"
-        "    schema_name: tapdb_beta_dev\n",
+        "target:\n"
+        "  engine_type: local\n"
+        "  host: localhost\n"
+        "  port: '5533'\n"
+        "  ui_port: '8911'\n"
+        "  domain_code: Z\n"
+        "  user: tapdb\n"
+        "  password: ''\n"
+        "  database: tapdb_shared\n"
+        "  schema_name: tapdb_beta\n"
+        "safety:\n"
+        "  safety_tier: shared\n"
+        "  destructive_operations: confirm_required\n",
         encoding="utf-8",
     )
     return path
@@ -97,7 +99,7 @@ def test_tsv_writer_writes_header_and_rows(tmp_path):
         queue_max=100,
     )
     clear_cli_context()
-    set_cli_context(config_path=cfg_path, env_name="dev")
+    set_cli_context(config_path=cfg_path)
 
     writer = TSVMetricsWriter("dev")
     writer.enqueue(
@@ -132,7 +134,7 @@ def test_tsv_writer_drops_when_queue_full(tmp_path):
         queue_max=1,
     )
     clear_cli_context()
-    set_cli_context(config_path=cfg_path, env_name="dev")
+    set_cli_context(config_path=cfg_path)
 
     writer = TSVMetricsWriter("dev")
     time.sleep(0.05)

--- a/tests/test_admin_main_coverage.py
+++ b/tests/test_admin_main_coverage.py
@@ -457,8 +457,8 @@ def route_client(monkeypatch: pytest.MonkeyPatch):
     )
     monkeypatch.setattr(
         admin_main,
-        "get_db_config_for_env",
-        lambda _env: {
+        "get_db_config",
+        lambda: {
             "host": "127.0.0.1",
             "port": 5432,
             "database": "tapdb_dev_runtime",
@@ -467,7 +467,7 @@ def route_client(monkeypatch: pytest.MonkeyPatch):
         },
     )
     monkeypatch.setattr(admin_main, "get_config_path", lambda: "/tmp/tapdb-config.yaml")
-    monkeypatch.setattr(admin_main, "_active_tapdb_env", lambda: "dev")
+    monkeypatch.setattr(admin_main, "_active_tapdb_target", lambda: "target")
     monkeypatch.setattr(
         admin_main,
         "resolve_tapdb_pool_config",

--- a/tests/test_admin_routes_smoke.py
+++ b/tests/test_admin_routes_smoke.py
@@ -448,8 +448,8 @@ def route_client(monkeypatch: pytest.MonkeyPatch):
     )
     monkeypatch.setattr(
         admin_main,
-        "get_db_config_for_env",
-        lambda _env: {
+        "get_db_config",
+        lambda: {
             "host": "127.0.0.1",
             "port": 5432,
             "database": "tapdb_dev_runtime",

--- a/tests/test_admin_support_coverage.py
+++ b/tests/test_admin_support_coverage.py
@@ -96,11 +96,10 @@ def test_db_metrics_helpers_cover_parse_extract_tail_and_summary(tmp_path, monke
     )
     assert metrics_mod._extract_table_hint("bad sql", "UPDATE") == ""
 
-    monkeypatch.setattr(metrics_mod, "active_env_name", lambda default="dev": "DEV")
     monkeypatch.setattr(
         metrics_mod,
-        "get_admin_settings_for_env",
-        lambda env_name: {"metrics_enabled": False, "metrics_queue_max": 7},
+        "get_admin_settings",
+        lambda: {"metrics_enabled": False, "metrics_queue_max": 7},
     )
     assert metrics_mod._admin_settings()["metrics_queue_max"] == 7
     assert metrics_mod.metrics_enabled() is False
@@ -118,9 +117,9 @@ def test_db_metrics_helpers_cover_parse_extract_tail_and_summary(tmp_path, monke
     monkeypatch.setattr(
         metrics_mod,
         "resolve_context",
-        lambda **_kwargs: SimpleNamespace(runtime_dir=lambda env: tmp_path / env),
+        lambda **_kwargs: SimpleNamespace(runtime_dir=lambda: tmp_path / "runtime"),
     )
-    assert metrics_mod._metrics_root_dir("dev") == tmp_path / "dev" / "metrics"
+    assert metrics_mod._metrics_root_dir("ignored") == tmp_path / "runtime" / "metrics"
 
     metrics_file = tmp_path / "metrics.tsv"
     metrics_file.write_text(
@@ -660,8 +659,8 @@ def test_db_pool_helpers_cover_engine_build_session_scope_and_dispose(
 
     monkeypatch.setattr(
         pool_mod,
-        "get_db_config_for_env",
-        lambda _env: {
+        "get_db_config",
+        lambda: {
             "engine_type": "local",
             "host": "localhost",
             "port": "5432",
@@ -682,8 +681,8 @@ def test_db_pool_helpers_cover_engine_build_session_scope_and_dispose(
     )
     pool_mod._clear_engine_cache_for_tests()
     bundle = pool_mod.get_engine_bundle("DEV")
-    assert bundle.env_name == "dev"
-    assert captured["metrics"] == ["dev"]
+    assert bundle.env_name == "target"
+    assert captured["metrics"] == ["target"]
     assert isinstance(pool_mod.get_db_connection("dev"), pool_mod.AdminDBConnection)
 
     bad_engine = SimpleNamespace(

--- a/tests/test_aurora_cli.py
+++ b/tests/test_aurora_cli.py
@@ -1,10 +1,13 @@
 """Tests for tapdb aurora CLI commands."""
 
+from __future__ import annotations
+
 import json
 import re
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
+import yaml
 from typer.testing import CliRunner
 
 from daylily_tapdb.cli import build_app
@@ -22,39 +25,59 @@ def _strip(s: str) -> str:
     return _ANSI_RE.sub("", s)
 
 
-_TEST_CONFIG_PATH: str = ""
-
-
-def _namespaced(args: list[str]) -> list[str]:
-    return ["--config", _TEST_CONFIG_PATH, *args]
-
-
-@pytest.fixture(autouse=True)
-def _namespace_env(tmp_path, monkeypatch):
-    global _TEST_CONFIG_PATH
-    # Create a minimal config file with metadata so resolve_context succeeds
-    config_dir = tmp_path / ".config" / "tapdb" / "testclient" / "testdb"
-    config_dir.mkdir(parents=True, exist_ok=True)
-    config_file = config_dir / "tapdb-config.yaml"
-    config_file.write_text(
-        "metadata:\n  client_id: testclient\n  database_name: testdb\n"
-        "environments:\n  dev:\n    host: localhost\n    port: 5432\n"
+def _write_config(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    domain_registry = path.parent / "domain_code_registry.json"
+    prefix_registry = path.parent / "prefix_ownership_registry.json"
+    domain_registry.write_text(
+        '{"version":"0.4.0","domains":{"Z":{"name":"test-localhost"}}}\n',
+        encoding="utf-8",
     )
-    _TEST_CONFIG_PATH = str(config_file)
-    monkeypatch.setenv("HOME", str(tmp_path))
+    prefix_registry.write_text(
+        (
+            '{"version":"0.4.0","ownership":{"Z":{'
+            '"TPX":{"issuer_app_code":"daylily-tapdb"},'
+            '"EDG":{"issuer_app_code":"daylily-tapdb"},'
+            '"ADT":{"issuer_app_code":"daylily-tapdb"},'
+            '"SYS":{"issuer_app_code":"daylily-tapdb"},'
+            '"MSG":{"issuer_app_code":"daylily-tapdb"}}}}\n'
+        ),
+        encoding="utf-8",
+    )
+    path.write_text(
+        "meta:\n"
+        "  config_version: 4\n"
+        "  client_id: testclient\n"
+        "  database_name: testdb\n"
+        "  owner_repo_name: daylily-tapdb\n"
+        f"  domain_registry_path: {domain_registry}\n"
+        f"  prefix_ownership_registry_path: {prefix_registry}\n"
+        "target:\n"
+        "  engine_type: local\n"
+        "  host: localhost\n"
+        "  port: '5432'\n"
+        "  ui_port: '8911'\n"
+        "  domain_code: Z\n"
+        "  user: tapdb_admin\n"
+        "  password: ''\n"
+        "  database: tapdb_dev\n"
+        "  schema_name: tapdb_testdb\n"
+        "  cluster_identifier: dev\n"
+        "safety:\n"
+        "  safety_tier: shared\n"
+        "  destructive_operations: blocked\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+    return path
 
 
-@pytest.fixture()
-def app():
-    """Build a fresh Typer app for each test."""
-    return build_app()
-
-
-# ── helpers ──────────────────────────────────────────────────────────
+def _namespaced(tmp_path: Path, args: list[str]) -> list[str]:
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+    return ["--config", str(cfg_path), *args]
 
 
 def _mock_stack_manager():
-    """Return a MagicMock that quacks like AuroraStackManager."""
     mgr = MagicMock()
     mgr.create_stack.return_value = {
         "stack_name": "tapdb-dev",
@@ -94,337 +117,170 @@ def _mock_stack_manager():
     return mgr
 
 
-# ── aurora help ──────────────────────────────────────────────────────
-
-
-class TestAuroraHelp:
-    def test_aurora_help(self, app):
-        result = runner.invoke(app, ["aurora", "--help"])
-        assert result.exit_code == 0
-        out = _strip(result.output)
-        assert "create" in out
-        assert "delete" in out
-        assert "status" in out
-        assert "connect" in out
-        assert "list" in out
-
-    def test_tapdb_help_shows_aurora(self, app):
-        result = runner.invoke(app, ["--help"])
-        assert result.exit_code == 0
-        assert "aurora" in _strip(result.output)
-
-
-# ── aurora create ────────────────────────────────────────────────────
-
-
-class TestAuroraCreate:
-    def test_resolve_ingress_cidr_uses_explicit_value(self):
-        assert (
-            _resolve_ingress_cidr(
-                "1.2.3.4/32",
-                True,
-                public_ip_resolver=lambda: "5.6.7.8",
-            )
-            == "1.2.3.4/32"
-        )
-
-    def test_resolve_ingress_cidr_uses_current_ip_for_public_access(self):
-        assert (
-            _resolve_ingress_cidr(
-                None,
-                True,
-                public_ip_resolver=lambda: "24.7.124.62",
-            )
-            == "24.7.124.62/32"
-        )
-
-    def test_resolve_ingress_cidr_defaults_private_range(self):
-        assert (
-            _resolve_ingress_cidr(
-                None,
-                False,
-                public_ip_resolver=lambda: "24.7.124.62",
-            )
-            == _DEFAULT_PRIVATE_INGRESS_CIDR
-        )
-
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_create_success(self, mock_mgr_cls, app, tmp_path, monkeypatch):
-        monkeypatch.setenv("HOME", str(tmp_path))
-        mock_mgr = _mock_stack_manager()
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(
-            app, _namespaced(["aurora", "create", "dev", "--vpc-id", "vpc-123"])
-        )
-        assert result.exit_code == 0
-        out = _strip(result.output)
-        assert "created" in out.lower() or "✓" in result.output
-        mock_mgr.create_stack.assert_called_once()
-        config = mock_mgr.create_stack.call_args.args[0]
-        assert config.cidr == _DEFAULT_PRIVATE_INGRESS_CIDR
-
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_create_publicly_accessible_resolves_current_ip(
-        self, mock_mgr_cls, app, tmp_path, monkeypatch
-    ):
-        monkeypatch.setenv("HOME", str(tmp_path))
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.aurora._detect_caller_public_ip",
-            lambda: "24.7.124.62",
-        )
-        mock_mgr = _mock_stack_manager()
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(
-            app,
-            _namespaced(["aurora", "create", "dev", "--publicly-accessible"]),
-        )
-        assert result.exit_code == 0
-        config = mock_mgr.create_stack.call_args.args[0]
-        assert config.publicly_accessible is True
-        assert config.cidr == "24.7.124.62/32"
-        assert "24.7.124.62/32" in _strip(result.output)
-
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_create_failure(self, mock_mgr_cls, app):
-        mock_mgr_cls.return_value.create_stack.side_effect = RuntimeError("boom")
-        result = runner.invoke(app, _namespaced(["aurora", "create", "dev"]))
-        assert result.exit_code == 1
-
-    def test_create_publicly_accessible_fails_when_ip_resolution_fails(
-        self, app, monkeypatch
-    ):
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.aurora._detect_caller_public_ip",
-            lambda: (_ for _ in ()).throw(RuntimeError("resolve failed")),
-        )
-
-        result = runner.invoke(
-            app,
-            _namespaced(["aurora", "create", "dev", "--publicly-accessible"]),
-        )
-        assert result.exit_code == 1
-        assert "resolve failed" in _strip(result.output)
-
-
-# ── aurora delete ────────────────────────────────────────────────────
-
-
-class TestAuroraDelete:
-    @patch("boto3.client")
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_delete_force(self, mock_mgr_cls, mock_boto3_client, app):
-        mock_mgr = _mock_stack_manager()
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(app, ["aurora", "delete", "dev", "--force"])
-        assert result.exit_code == 0
-        mock_mgr.delete_stack.assert_called_once_with(
-            "tapdb-dev", retain_networking=True
-        )
-
-    @patch("boto3.client")
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_delete_no_retain(self, mock_mgr_cls, mock_boto3_client, app):
-        mock_mgr = _mock_stack_manager()
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(
-            app, ["aurora", "delete", "dev", "--force", "--no-retain-networking"]
-        )
-        assert result.exit_code == 0
-        mock_mgr.delete_stack.assert_called_once_with(
-            "tapdb-dev", retain_networking=False
-        )
-
-    @patch("boto3.client")
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_delete_failure(self, mock_mgr_cls, mock_boto3_client, app):
-        mock_mgr_cls.return_value.delete_stack.side_effect = RuntimeError("boom")
-        result = runner.invoke(app, ["aurora", "delete", "dev", "--force"])
-        assert result.exit_code == 1
-
-
-# ── aurora status ────────────────────────────────────────────────────
-
-
-class TestAuroraStatus:
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_status_success(self, mock_mgr_cls, app):
-        mock_mgr = _mock_stack_manager()
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(app, ["aurora", "status", "dev"])
-        assert result.exit_code == 0
-        out = _strip(result.output)
-        assert "CREATE_COMPLETE" in out
-        assert "ClusterEndpoint" in out
-
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_status_json(self, mock_mgr_cls, app):
-        mock_mgr = _mock_stack_manager()
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(app, ["aurora", "status", "dev", "--json"])
-        assert result.exit_code == 0
-        data = json.loads(_strip(result.output))
-        assert data["status"] == "CREATE_COMPLETE"
-
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_status_not_found(self, mock_mgr_cls, app):
-        mock_mgr_cls.return_value.get_stack_status.side_effect = RuntimeError(
-            "not found"
-        )
-        result = runner.invoke(app, ["aurora", "status", "dev"])
-        assert result.exit_code == 1
-
-
-# ── aurora connect ───────────────────────────────────────────────────
-
-
-class TestAuroraConnect:
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_connect_info(self, mock_mgr_cls, app):
-        mock_mgr = _mock_stack_manager()
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(app, ["aurora", "connect", "dev"])
-        assert result.exit_code == 0
-        out = _strip(result.output)
-        assert "tapdb-dev.cluster-xyz" in out
-        assert "5432" in out
-
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_connect_export(self, mock_mgr_cls, app):
-        mock_mgr = _mock_stack_manager()
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(app, ["aurora", "connect", "dev", "--export"])
-        assert result.exit_code == 0
-        out = _strip(result.output)
-        assert "export PGHOST=" in out
-        assert "export PGPORT=" in out
-
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_connect_no_endpoint(self, mock_mgr_cls, app):
-        mock_mgr = MagicMock()
-        mock_mgr.get_stack_status.return_value = {
-            "stack_name": "tapdb-dev",
-            "status": "CREATE_IN_PROGRESS",
-            "outputs": {},
-        }
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(app, ["aurora", "connect", "dev"])
-        assert result.exit_code == 1
-
-
-# ── aurora list ──────────────────────────────────────────────────────
-
-
-class TestAuroraList:
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_list_table(self, mock_mgr_cls, app):
-        mock_mgr = _mock_stack_manager()
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(app, ["aurora", "list"])
-        assert result.exit_code == 0
-        out = _strip(result.output)
-        assert "tapdb-dev" in out
-
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_list_json(self, mock_mgr_cls, app):
-        mock_mgr = _mock_stack_manager()
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(app, ["aurora", "list", "--json"])
-        assert result.exit_code == 0
-        data = json.loads(_strip(result.output))
-        assert "tapdb-dev" in data
-
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_list_empty(self, mock_mgr_cls, app):
-        mock_mgr = MagicMock()
-        mock_mgr.detect_existing_resources.return_value = {}
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(app, ["aurora", "list"])
-        assert result.exit_code == 0
-        assert "No tapdb Aurora stacks" in _strip(result.output)
-
-
-# ── config update ────────────────────────────────────────────────────
-
-
-class TestConfigUpdate:
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_create_updates_config(self, mock_mgr_cls, app, tmp_path, monkeypatch):
-        monkeypatch.setenv("HOME", str(tmp_path))
-        mock_mgr = _mock_stack_manager()
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(app, _namespaced(["aurora", "create", "staging"]))
-        assert result.exit_code == 0
-
-        config_path = (
-            tmp_path
-            / ".config"
-            / "tapdb"
-            / "testclient"
-            / "testdb"
-            / "tapdb-config.yaml"
-        )
-        assert config_path.exists()
-        raw = config_path.read_text()
-        # Should contain the environment entry
-        assert "staging" in raw
-        assert "aurora" in raw
-
-
-# ── aurora create --background ──────────────────────────────────────
-
-
-class TestAuroraCreateBackground:
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_background_returns_immediately(self, mock_mgr_cls, app):
-        mock_mgr = _mock_stack_manager()
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(
-            app,
-            _namespaced(
-                ["aurora", "create", "dev", "--background", "--vpc-id", "vpc-123"]
-            ),
-        )
-        assert result.exit_code == 0
-        out = _strip(result.output)
-        assert "initiated" in out.lower()
-        assert "tapdb aurora status dev" in out
-        mock_mgr.initiate_create_stack.assert_called_once()
-        mock_mgr.create_stack.assert_not_called()
-
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_no_background_calls_create_stack(
-        self, mock_mgr_cls, app, tmp_path, monkeypatch
-    ):
-        monkeypatch.setenv("HOME", str(tmp_path))
-        mock_mgr = _mock_stack_manager()
-        mock_mgr_cls.return_value = mock_mgr
-
-        result = runner.invoke(
-            app, _namespaced(["aurora", "create", "dev", "--vpc-id", "vpc-123"])
-        )
-        assert result.exit_code == 0
-        mock_mgr.create_stack.assert_called_once()
-        mock_mgr.initiate_create_stack.assert_not_called()
-
-    @patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
-    def test_background_failure(self, mock_mgr_cls, app):
-        mock_mgr_cls.return_value.initiate_create_stack.side_effect = RuntimeError(
-            "No default VPC"
-        )
-        result = runner.invoke(app, ["aurora", "create", "dev", "--background"])
-        assert result.exit_code == 1
-        assert "No default VPC" in _strip(result.output)
+def test_aurora_help(app=None):
+    app = app or build_app()
+    result = runner.invoke(app, ["aurora", "--help"])
+    assert result.exit_code == 0
+    out = _strip(result.output)
+    assert "create" in out
+    assert "delete" in out
+    assert "status" in out
+    assert "connect" in out
+    assert "list" in out
+
+
+def test_resolve_ingress_cidr_modes():
+    assert (
+        _resolve_ingress_cidr("1.2.3.4/32", True, public_ip_resolver=lambda: "5.6.7.8")
+        == "1.2.3.4/32"
+    )
+    assert (
+        _resolve_ingress_cidr(None, True, public_ip_resolver=lambda: "24.7.124.62")
+        == "24.7.124.62/32"
+    )
+    assert (
+        _resolve_ingress_cidr(None, False, public_ip_resolver=lambda: "24.7.124.62")
+        == _DEFAULT_PRIVATE_INGRESS_CIDR
+    )
+
+
+@patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
+def test_create_success(mock_mgr_cls, tmp_path):
+    mock_mgr = _mock_stack_manager()
+    mock_mgr_cls.return_value = mock_mgr
+
+    result = runner.invoke(
+        build_app(), _namespaced(tmp_path, ["aurora", "create", "--vpc-id", "vpc-123"])
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "created" in _strip(result.output).lower() or "✓" in result.output
+    mock_mgr.create_stack.assert_called_once()
+    config = mock_mgr.create_stack.call_args.args[0]
+    assert config.cluster_identifier == "dev"
+    assert config.cidr == _DEFAULT_PRIVATE_INGRESS_CIDR
+
+
+@patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
+def test_create_publicly_accessible_resolves_current_ip(
+    mock_mgr_cls, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "daylily_tapdb.cli.aurora._detect_caller_public_ip",
+        lambda: "24.7.124.62",
+    )
+    mock_mgr = _mock_stack_manager()
+    mock_mgr_cls.return_value = mock_mgr
+
+    result = runner.invoke(
+        build_app(),
+        _namespaced(tmp_path, ["aurora", "create", "--publicly-accessible"]),
+    )
+
+    assert result.exit_code == 0, result.output
+    config = mock_mgr.create_stack.call_args.args[0]
+    assert config.publicly_accessible is True
+    assert config.cidr == "24.7.124.62/32"
+
+
+@patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
+def test_create_failure(mock_mgr_cls, tmp_path):
+    mock_mgr_cls.return_value.create_stack.side_effect = RuntimeError("boom")
+
+    result = runner.invoke(build_app(), _namespaced(tmp_path, ["aurora", "create"]))
+
+    assert result.exit_code == 1
+    assert "boom" in _strip(result.output)
+
+
+@patch("boto3.client")
+@patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
+def test_delete_force(mock_mgr_cls, _mock_boto3_client, tmp_path):
+    mock_mgr = _mock_stack_manager()
+    mock_mgr_cls.return_value = mock_mgr
+
+    result = runner.invoke(
+        build_app(), _namespaced(tmp_path, ["aurora", "delete", "--force"])
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_mgr.delete_stack.assert_called_once_with("tapdb-dev", retain_networking=True)
+
+
+@patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
+def test_status_json(mock_mgr_cls, tmp_path):
+    mock_mgr = _mock_stack_manager()
+    mock_mgr_cls.return_value = mock_mgr
+
+    result = runner.invoke(
+        build_app(), _namespaced(tmp_path, ["aurora", "status", "--json"])
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(_strip(result.output))
+    assert data["status"] == "CREATE_COMPLETE"
+
+
+@patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
+def test_connect_export(mock_mgr_cls, tmp_path):
+    mock_mgr = _mock_stack_manager()
+    mock_mgr_cls.return_value = mock_mgr
+
+    result = runner.invoke(
+        build_app(), _namespaced(tmp_path, ["aurora", "connect", "--export"])
+    )
+
+    assert result.exit_code == 0, result.output
+    out = _strip(result.output)
+    assert "export PGHOST=" in out
+    assert "export PGDATABASE=tapdb_dev" in out
+
+
+@patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
+def test_list_json(mock_mgr_cls):
+    mock_mgr = _mock_stack_manager()
+    mock_mgr_cls.return_value = mock_mgr
+
+    result = runner.invoke(build_app(), ["aurora", "list", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(_strip(result.output))
+    assert "tapdb-dev" in data
+
+
+@patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
+def test_create_updates_explicit_target_config(mock_mgr_cls, tmp_path):
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+    mock_mgr = _mock_stack_manager()
+    mock_mgr_cls.return_value = mock_mgr
+
+    result = runner.invoke(build_app(), ["--config", str(cfg_path), "aurora", "create"])
+
+    assert result.exit_code == 0, result.output
+    payload = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    assert payload["meta"]["config_version"] == 4
+    assert "environments" not in payload
+    assert payload["target"]["engine_type"] == "aurora"
+    assert payload["target"]["host"].startswith("tapdb-dev.cluster-xyz")
+    assert payload["target"]["cluster_identifier"] == "dev"
+    assert payload["target"]["secret_arn"].endswith(":secret:tapdb-dev")
+
+
+@patch("daylily_tapdb.aurora.stack_manager.AuroraStackManager")
+def test_background_returns_immediately(mock_mgr_cls, tmp_path):
+    mock_mgr = _mock_stack_manager()
+    mock_mgr_cls.return_value = mock_mgr
+
+    result = runner.invoke(
+        build_app(),
+        _namespaced(
+            tmp_path, ["aurora", "create", "--background", "--vpc-id", "vpc-123"]
+        ),
+    )
+
+    assert result.exit_code == 0, result.output
+    out = _strip(result.output)
+    assert "initiated" in out.lower()
+    assert "tapdb aurora status" in out
+    mock_mgr.initiate_create_stack.assert_called_once()
+    mock_mgr.create_stack.assert_not_called()

--- a/tests/test_aurora_config.py
+++ b/tests/test_aurora_config.py
@@ -1,19 +1,11 @@
-"""Tests for Aurora configuration support (T1).
-
-Covers:
-- AuroraConfig dataclass defaults and tag enforcement
-- AuroraConfig.from_dict() construction
-- get_db_config_for_env() engine_type field for local and aurora envs
-- Aurora-specific fields in get_db_config_for_env()
-- namespaced database identifier normalization
-"""
+"""Tests for Aurora and explicit-target database configuration support."""
 
 from __future__ import annotations
 
-import textwrap
 from pathlib import Path
 
 import pytest
+import yaml
 
 from daylily_tapdb.aurora.config import AuroraConfig
 from daylily_tapdb.cli.context import (
@@ -21,32 +13,21 @@ from daylily_tapdb.cli.context import (
     resolve_context,
     set_cli_context,
 )
+from daylily_tapdb.cli.db_config import get_db_config
 
 
 @pytest.fixture(autouse=True)
-def _reset_namespace_env(monkeypatch):
-    monkeypatch.setenv("TAPDB_STRICT_NAMESPACE", "0")
+def _reset_context():
     clear_cli_context()
     yield
     clear_cli_context()
 
 
-# ---------------------------------------------------------------------------
-# AuroraConfig dataclass
-# ---------------------------------------------------------------------------
-
-
 class TestAuroraConfigDefaults:
     def test_default_region(self):
-        cfg = AuroraConfig()
-        assert cfg.region == "us-west-2"
+        assert AuroraConfig().region == "us-west-2"
 
     def test_default_tags_present(self):
-        cfg = AuroraConfig()
-        assert "lsmc-cost-center" in cfg.tags
-        assert "lsmc-project" in cfg.tags
-
-    def test_default_tag_values(self):
         cfg = AuroraConfig()
         assert cfg.tags["lsmc-cost-center"] == "global"
         assert cfg.tags["lsmc-project"] == "tapdb-us-west-2"
@@ -60,20 +41,11 @@ class TestAuroraConfigDefaults:
         assert cfg.tags["lsmc-cost-center"] == "global"
         assert cfg.tags["team"] == "genomics"
 
-    def test_iam_auth_default_true(self):
+    def test_defaults(self):
         cfg = AuroraConfig()
         assert cfg.iam_auth is True
-
-    def test_ssl_default_true(self):
-        cfg = AuroraConfig()
         assert cfg.ssl is True
-
-    def test_publicly_accessible_default_false(self):
-        cfg = AuroraConfig()
         assert cfg.publicly_accessible is False
-
-    def test_deletion_protection_default_true(self):
-        cfg = AuroraConfig()
         assert cfg.deletion_protection is True
 
 
@@ -94,25 +66,11 @@ class TestAuroraConfigFromDict:
         assert cfg.ssl is False
 
     def test_ignores_unknown_keys(self):
-        data = {"region": "us-west-2", "unknown_key": "ignored"}
-        cfg = AuroraConfig.from_dict(data)
+        cfg = AuroraConfig.from_dict({"region": "us-west-2", "unknown_key": "ignored"})
         assert cfg.region == "us-west-2"
 
-    def test_empty_dict_gives_defaults(self):
-        cfg = AuroraConfig.from_dict({})
-        assert cfg.region == "us-west-2"
-        assert cfg.tags["lsmc-cost-center"] == "global"
 
-
-# ---------------------------------------------------------------------------
-# get_db_config_for_env — engine_type and aurora fields
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def _yaml_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Write a temp config with both local and aurora envs."""
-    cfg_file = tmp_path / "tapdb-config.yaml"
+def _write_registries(tmp_path: Path) -> tuple[Path, Path]:
     domain_registry = tmp_path / "domain_code_registry.json"
     prefix_registry = tmp_path / "prefix_ownership_registry.json"
     domain_registry.write_text(
@@ -121,7 +79,8 @@ def _yaml_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     )
     prefix_registry.write_text(
         (
-            '{"version":"0.4.0","ownership":{"Z":{"TPX":{"issuer_app_code":"daylily-tapdb"},'
+            '{"version":"0.4.0","ownership":{"Z":{'
+            '"TPX":{"issuer_app_code":"daylily-tapdb"},'
             '"EDG":{"issuer_app_code":"daylily-tapdb"},'
             '"ADT":{"issuer_app_code":"daylily-tapdb"},'
             '"SYS":{"issuer_app_code":"daylily-tapdb"},'
@@ -129,226 +88,115 @@ def _yaml_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         ),
         encoding="utf-8",
     )
+    return domain_registry, prefix_registry
+
+
+def _write_config(tmp_path: Path, target: dict[str, object]) -> Path:
+    domain_registry, prefix_registry = _write_registries(tmp_path)
+    cfg_file = tmp_path / "tapdb-config.yaml"
     cfg_file.write_text(
-        textwrap.dedent("""\
-        meta:
-          config_version: 3
-          client_id: clientx
-          database_name: dbx
-          owner_repo_name: daylily-tapdb
-          domain_registry_path: {domain_registry}
-          prefix_ownership_registry_path: {prefix_registry}
-        environments:
-          dev:
-            host: localhost
-            port: 5432
-            ui_port: 8911
-            domain_code: Z
-            user: daylily
-            password: ""
-            database: tapdb_dev
-            schema_name: tapdb_dbx_dev
-          aurora_dev:
-            engine_type: aurora
-            host: my-cluster.us-west-2.rds.amazonaws.com
-            port: 5432
-            domain_code: Z
-            user: tapdb_admin
-            password: ""
-            database: tapdb_dev
-            schema_name: tapdb_dbx_aurora_dev
-            region: us-west-2
-            cluster_identifier: my-cluster
-            iam_auth: true
-            ssl: true
-        """).format(
-            domain_registry=domain_registry,
-            prefix_registry=prefix_registry,
-        )
+        yaml.safe_dump(
+            {
+                "meta": {
+                    "config_version": 4,
+                    "client_id": "clientx",
+                    "database_name": "dbx",
+                    "owner_repo_name": "daylily-tapdb",
+                    "domain_registry_path": str(domain_registry),
+                    "prefix_ownership_registry_path": str(prefix_registry),
+                },
+                "target": target,
+                "safety": {
+                    "safety_tier": "shared",
+                    "destructive_operations": "confirm_required",
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
     )
+    cfg_file.chmod(0o600)
     set_cli_context(config_path=cfg_file)
     return cfg_file
 
 
-class TestGetDbConfigEngineType:
-    @pytest.mark.usefixtures("_yaml_config")
-    def test_local_env_has_engine_type_local(self):
-        from daylily_tapdb.cli.db_config import get_db_config_for_env
+def _local_target(schema_name: str = "tapdb_dbx") -> dict[str, object]:
+    return {
+        "engine_type": "local",
+        "host": "localhost",
+        "port": 5432,
+        "ui_port": 8911,
+        "domain_code": "Z",
+        "user": "daylily",
+        "password": "",
+        "database": "tapdb_shared",
+        "schema_name": schema_name,
+    }
 
-        cfg = get_db_config_for_env("dev")
-        assert cfg["engine_type"] == "local"
-        assert cfg["schema_name"] == "tapdb_dbx_dev"
 
-    @pytest.mark.usefixtures("_yaml_config")
-    def test_aurora_env_has_engine_type_aurora(self):
-        from daylily_tapdb.cli.db_config import get_db_config_for_env
+def _aurora_target() -> dict[str, object]:
+    return {
+        "engine_type": "aurora",
+        "host": "my-cluster.us-west-2.rds.amazonaws.com",
+        "port": 5432,
+        "ui_port": 8911,
+        "domain_code": "Z",
+        "user": "tapdb_admin",
+        "password": "",
+        "database": "tapdb_shared",
+        "schema_name": "tapdb_dbx_aurora",
+        "region": "us-west-2",
+        "cluster_identifier": "my-cluster",
+        "iam_auth": True,
+        "ssl": True,
+    }
 
-        cfg = get_db_config_for_env("aurora_dev")
-        assert cfg["engine_type"] == "aurora"
-        assert cfg["schema_name"] == "tapdb_dbx_aurora_dev"
 
-    @pytest.mark.usefixtures("_yaml_config")
-    def test_aurora_env_has_aurora_fields(self):
-        from daylily_tapdb.cli.db_config import get_db_config_for_env
+def test_local_target_has_engine_type_and_socket_dir(tmp_path: Path):
+    cfg_file = _write_config(tmp_path, _local_target())
 
-        cfg = get_db_config_for_env("aurora_dev")
-        assert cfg["region"] == "us-west-2"
-        assert cfg["cluster_identifier"] == "my-cluster"
-        # YAML parses `true` as Python bool True; str(True) == "True"
-        assert cfg["iam_auth"] == "True"
-        assert cfg["ssl"] == "True"
+    cfg = get_db_config()
+    context = resolve_context(config_path=cfg_file)
 
-    @pytest.mark.usefixtures("_yaml_config")
-    def test_local_env_no_aurora_fields(self):
-        from daylily_tapdb.cli.db_config import get_db_config_for_env
+    assert cfg["engine_type"] == "local"
+    assert cfg["schema_name"] == "tapdb_dbx"
+    assert cfg["unix_socket_dir"] == str(context.postgres_socket_dir())
 
-        cfg = get_db_config_for_env("dev")
-        assert "region" not in cfg
-        assert "cluster_identifier" not in cfg
 
-    @pytest.mark.usefixtures("_yaml_config")
-    def test_local_env_backward_compat(self):
-        from daylily_tapdb.cli.db_config import get_db_config_for_env
+def test_local_target_unix_socket_dir_override(tmp_path: Path):
+    target = _local_target()
+    target["unix_socket_dir"] = "/tmp/from-config"
+    _write_config(tmp_path, target)
 
-        cfg = get_db_config_for_env("dev")
-        # All original keys still present
-        for key in ("host", "port", "user", "password", "database"):
-            assert key in cfg
-        assert cfg["host"] == "localhost"
-        assert cfg["database"] == "tapdb_dev"
+    cfg = get_db_config()
 
-    def test_local_env_derives_namespaced_unix_socket_dir(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        from daylily_tapdb.cli.db_config import get_db_config_for_env
+    assert cfg["unix_socket_dir"] == "/tmp/from-config"
 
-        cfg_file = tmp_path / "tapdb-config.yaml"
-        domain_registry = tmp_path / "domain_code_registry.json"
-        prefix_registry = tmp_path / "prefix_ownership_registry.json"
-        domain_registry.write_text(
-            '{"version":"0.4.0","domains":{"Z":{"name":"test-localhost"}}}\n',
-            encoding="utf-8",
-        )
-        prefix_registry.write_text(
-            (
-                '{"version":"0.4.0","ownership":{"Z":{"TPX":{"issuer_app_code":"daylily-tapdb"},'
-                '"EDG":{"issuer_app_code":"daylily-tapdb"},'
-                '"ADT":{"issuer_app_code":"daylily-tapdb"},'
-                '"SYS":{"issuer_app_code":"daylily-tapdb"},'
-                '"MSG":{"issuer_app_code":"daylily-tapdb"}}}}\n'
-            ),
-            encoding="utf-8",
-        )
-        cfg_file.write_text(
-            textwrap.dedent("""\
-            meta:
-              config_version: 3
-              client_id: clientx
-              database_name: dbx
-              owner_repo_name: daylily-tapdb
-              domain_registry_path: {domain_registry}
-              prefix_ownership_registry_path: {prefix_registry}
-            environments:
-              dev:
-                host: localhost
-                port: 5432
-                ui_port: 8911
-                domain_code: Z
-                user: daylily
-                password: ""
-                database: tapdb_dev
-                schema_name: tapdb_dbx_dev
-            """).format(
-                domain_registry=domain_registry,
-                prefix_registry=prefix_registry,
-            )
-        )
-        monkeypatch.setenv("HOME", str(tmp_path))
-        set_cli_context(config_path=cfg_file)
 
-        cfg = get_db_config_for_env("dev")
-        context = resolve_context(config_path=cfg_file)
-        assert context is not None
+def test_aurora_target_has_aurora_fields_and_no_socket_dir(tmp_path: Path):
+    _write_config(tmp_path, _aurora_target())
 
-        assert cfg["unix_socket_dir"] == str(context.postgres_socket_dir("dev"))
+    cfg = get_db_config()
 
-    def test_local_env_unix_socket_dir_env_override(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        from daylily_tapdb.cli.db_config import get_db_config_for_env
-
-        cfg_file = tmp_path / "tapdb-config.yaml"
-        domain_registry = tmp_path / "domain_code_registry.json"
-        prefix_registry = tmp_path / "prefix_ownership_registry.json"
-        domain_registry.write_text(
-            '{"version":"0.4.0","domains":{"Z":{"name":"test-localhost"}}}\n',
-            encoding="utf-8",
-        )
-        prefix_registry.write_text(
-            (
-                '{"version":"0.4.0","ownership":{"Z":{"TPX":{"issuer_app_code":"daylily-tapdb"},'
-                '"EDG":{"issuer_app_code":"daylily-tapdb"},'
-                '"ADT":{"issuer_app_code":"daylily-tapdb"},'
-                '"SYS":{"issuer_app_code":"daylily-tapdb"},'
-                '"MSG":{"issuer_app_code":"daylily-tapdb"}}}}\n'
-            ),
-            encoding="utf-8",
-        )
-        cfg_file.write_text(
-            textwrap.dedent("""\
-            meta:
-              config_version: 3
-              client_id: clientx
-              database_name: dbx
-              owner_repo_name: daylily-tapdb
-              domain_registry_path: {domain_registry}
-              prefix_ownership_registry_path: {prefix_registry}
-            environments:
-              dev:
-                host: localhost
-                port: 5432
-                ui_port: 8911
-                domain_code: Z
-                user: daylily
-                password: ""
-                database: tapdb_dev
-                schema_name: tapdb_dbx_dev
-                unix_socket_dir: /tmp/from-config
-            """).format(
-                domain_registry=domain_registry,
-                prefix_registry=prefix_registry,
-            )
-        )
-        set_cli_context(config_path=cfg_file)
-
-        cfg = get_db_config_for_env("dev")
-
-        assert cfg["unix_socket_dir"] == "/tmp/from-config"
-
-    @pytest.mark.usefixtures("_yaml_config")
-    def test_aurora_env_does_not_expose_unix_socket_dir(self):
-        from daylily_tapdb.cli.db_config import get_db_config_for_env
-
-        cfg = get_db_config_for_env("aurora_dev")
-        assert "unix_socket_dir" not in cfg
+    assert cfg["engine_type"] == "aurora"
+    assert cfg["region"] == "us-west-2"
+    assert cfg["cluster_identifier"] == "my-cluster"
+    assert cfg["iam_auth"] == "True"
+    assert cfg["ssl"] == "True"
+    assert "unix_socket_dir" not in cfg
 
 
 class TestConfigPathScoping:
-    def test_explicit_config_path_used_directly(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
+    def test_explicit_config_path_used_directly(self, tmp_path: Path):
         from daylily_tapdb.cli.db_config import get_config_paths
 
         override = tmp_path / "custom.yaml"
-        paths = get_config_paths(config_path=override)
-        assert paths == [override]
+        assert get_config_paths(config_path=override) == [override]
 
-    def test_missing_config_raises(self, monkeypatch: pytest.MonkeyPatch):
-        """Without a config path, get_config_paths must error — no silent fallback."""
+    def test_missing_config_raises(self):
         from daylily_tapdb.cli.context import set_cli_context
         from daylily_tapdb.cli.db_config import get_config_paths
 
-        # Clear any ambient config
         set_cli_context(config_path="")
 
         with pytest.raises(RuntimeError, match="config path is required"):
@@ -360,16 +208,16 @@ class TestDatabaseNameNormalization:
         from daylily_tapdb.cli.db_config import default_database_name_for_namespace
 
         assert (
-            default_database_name_for_namespace("auruse1-daylily-tapdb", "dev")
-            == "tapdb_auruse1_daylily_tapdb_dev"
+            default_database_name_for_namespace("auruse1-daylily-tapdb")
+            == "tapdb_auruse1_daylily_tapdb"
         )
 
     def test_default_schema_name_for_database_normalizes_hyphens(self):
         from daylily_tapdb.cli.db_config import default_schema_name_for_database
 
         assert (
-            default_schema_name_for_database("auruse1-daylily-tapdb", "dev")
-            == "tapdb_auruse1_daylily_tapdb_dev"
+            default_schema_name_for_database("auruse1-daylily-tapdb")
+            == "tapdb_auruse1_daylily_tapdb"
         )
 
     @pytest.mark.parametrize(
@@ -404,26 +252,14 @@ class TestDatabaseNameNormalization:
                 field_name="schema_name",
             )
 
-    def test_get_db_config_requires_explicit_schema_name(self, _yaml_config: Path):
-        import yaml
+    def test_get_db_config_requires_explicit_schema_name(self, tmp_path: Path):
+        _write_config(tmp_path, _local_target(schema_name=""))
 
-        from daylily_tapdb.cli.db_config import get_db_config_for_env
+        with pytest.raises(RuntimeError, match="target.schema_name"):
+            get_db_config()
 
-        payload = yaml.safe_load(_yaml_config.read_text(encoding="utf-8"))
-        del payload["environments"]["dev"]["schema_name"]
-        _yaml_config.write_text(yaml.safe_dump(payload), encoding="utf-8")
+    def test_get_db_config_rejects_unsafe_schema_name(self, tmp_path: Path):
+        _write_config(tmp_path, _local_target(schema_name="tapdb-dev"))
 
-        with pytest.raises(RuntimeError, match="environments.dev.schema_name"):
-            get_db_config_for_env("dev")
-
-    def test_get_db_config_rejects_unsafe_schema_name(self, _yaml_config: Path):
-        import yaml
-
-        from daylily_tapdb.cli.db_config import get_db_config_for_env
-
-        payload = yaml.safe_load(_yaml_config.read_text(encoding="utf-8"))
-        payload["environments"]["dev"]["schema_name"] = "tapdb-dev"
-        _yaml_config.write_text(yaml.safe_dump(payload), encoding="utf-8")
-
-        with pytest.raises(RuntimeError, match="environments.dev.schema_name"):
-            get_db_config_for_env("dev")
+        with pytest.raises(RuntimeError, match="target.schema_name"):
+            get_db_config()

--- a/tests/test_aurora_schema_deployer.py
+++ b/tests/test_aurora_schema_deployer.py
@@ -241,7 +241,7 @@ class TestDbRunPsqlAuroraBranch:
                     stdout="42\n",
                     stderr="",
                 )
-                ok, out = _run_psql(Environment.dev, sql="SELECT 42")
+                ok, out = _run_psql(Environment.target, sql="SELECT 42")
 
         assert ok is True
         assert out == "42"
@@ -269,7 +269,7 @@ class TestDbRunPsqlAuroraBranch:
                     stdout="1\n",
                     stderr="",
                 )
-                ok, out = _run_psql(Environment.dev, sql="SELECT 1")
+                ok, out = _run_psql(Environment.target, sql="SELECT 1")
 
         assert ok is True
         # Verify PGSSLMODE was NOT set (local mode)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,10 @@
-"""Integration tests for TAPDB CLI commands."""
+"""CLI contract tests for the explicit-target TapDB model."""
+
+from __future__ import annotations
 
 import json
 import os
 import re
-import shlex
-import subprocess
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -14,46 +13,24 @@ import yaml
 from typer.testing import CliRunner
 
 import daylily_tapdb.cli as cli_mod
-from daylily_tapdb.cli import app
+from daylily_tapdb.cli import app, build_app
 from daylily_tapdb.cli.context import clear_cli_context, set_cli_context
-from daylily_tapdb.cli.db import (
-    Environment,
-    _ensure_dirs,
-    _find_config_dir,
-    _find_duplicate_template_keys,
-    _find_schema_file,
-    _find_tapdb_core_config_dir,
-    _get_db_config,
-    _load_template_configs,
-    _resolve_seed_config_dirs,
-)
-from daylily_tapdb.cli.db_config import get_config_path
-from daylily_tapdb.templates import (
-    validate_template_configs as _validate_template_configs,
-)
+from daylily_tapdb.cli.db import Environment, _get_db_config
 
 runner = CliRunner()
 
-
-_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
-
-
-def _strip_ansi(s: str) -> str:
-    """Remove ANSI color/style escape sequences from CLI output.
-
-    CI uses Typer+Rich which may emit ANSI escapes; tests should assert against the
-    semantic text, not terminal formatting.
-    """
-
-    return _ANSI_ESCAPE_RE.sub("", s)
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
-def _write_test_registries(base_dir: Path) -> tuple[Path, Path]:
+def _strip(s: str) -> str:
+    return _ANSI_RE.sub("", s)
+
+
+def _write_registries(base_dir: Path) -> tuple[Path, Path]:
     domain_registry = base_dir / "domain_code_registry.json"
     prefix_registry = base_dir / "prefix_ownership_registry.json"
     domain_registry.write_text(
-        json.dumps({"version": "0.4.0", "domains": {"Z": {"name": "test-localhost"}}})
-        + "\n",
+        json.dumps({"version": "0.4.0", "domains": {"Z": {"name": "test"}}}) + "\n",
         encoding="utf-8",
     )
     prefix_registry.write_text(
@@ -77,2450 +54,365 @@ def _write_test_registries(base_dir: Path) -> tuple[Path, Path]:
     return domain_registry, prefix_registry
 
 
-@pytest.fixture(autouse=True)
-def _isolate_cli_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Keep CLI tests hermetic.
-
-    - Avoid touching the user's real ~/.tapdb PID/log files.
-    - Avoid probing unexpected environments.
-    """
-    monkeypatch.setenv("HOME", str(tmp_path))
-    cfg_path = (
-        tmp_path / ".config" / "tapdb" / "testclient" / "testdb" / "tapdb-config.yaml"
-    )
-    cfg_path.parent.mkdir(parents=True, exist_ok=True)
-    domain_registry, prefix_registry = _write_test_registries(tmp_path)
-    cfg_path.write_text(
+def _write_config(
+    path: Path,
+    *,
+    client_id: str = "testclient",
+    database_name: str = "testdb",
+    database: str = "tapdb_shared",
+    schema_name: str = "tapdb_testdb",
+    safety_tier: str = "shared",
+    destructive_operations: str = "confirm_required",
+) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    domain_registry, prefix_registry = _write_registries(path.parent)
+    path.write_text(
         "meta:\n"
-        "  config_version: 3\n"
-        "  client_id: testclient\n"
-        "  database_name: testdb\n"
+        "  config_version: 4\n"
+        f"  client_id: {client_id}\n"
+        f"  database_name: {database_name}\n"
         "  owner_repo_name: daylily-tapdb\n"
         f"  domain_registry_path: {domain_registry}\n"
         f"  prefix_ownership_registry_path: {prefix_registry}\n"
-        "environments:\n"
-        "  dev:\n"
-        "    engine_type: local\n"
-        "    host: localhost\n"
-        "    port: 5533\n"
-        "    ui_port: 8911\n"
-        "    domain_code: Z\n"
-        "    user: test\n"
-        '    password: ""\n'
-        "    database: tapdb_dev\n"
-        "    schema_name: tapdb_testdb_dev\n"
-        "  test:\n"
-        "    engine_type: local\n"
-        "    host: localhost\n"
-        "    port: 5534\n"
-        "    ui_port: 8912\n"
-        "    domain_code: Z\n"
-        "    user: test\n"
-        '    password: ""\n'
-        "    database: tapdb_test\n"
-        "    schema_name: tapdb_testdb_test\n"
-        "  prod:\n"
-        "    engine_type: local\n"
-        "    host: localhost\n"
-        "    port: 5535\n"
-        "    ui_port: 8913\n"
-        "    domain_code: Z\n"
-        "    user: test\n"
-        '    password: ""\n'
-        "    database: tapdb_prod\n"
-        "    schema_name: tapdb_testdb_prod\n",
+        "admin:\n"
+        "  footer:\n"
+        "    repo_url: https://example.com/tapdb\n"
+        "  session:\n"
+        "    secret: secret123\n"
+        "  auth:\n"
+        "    mode: tapdb\n"
+        "    disabled_user:\n"
+        "      email: tapdb-admin@localhost\n"
+        "      role: admin\n"
+        "    shared_host:\n"
+        "      session_secret: shared-secret\n"
+        "      session_cookie: session\n"
+        "      session_max_age_seconds: 1209600\n"
+        "  cors:\n"
+        "    allowed_origins: []\n"
+        "  ui:\n"
+        "    tls:\n"
+        "      cert_path: ''\n"
+        "      key_path: ''\n"
+        "  metrics:\n"
+        "    enabled: true\n"
+        "    queue_max: 20000\n"
+        "    flush_seconds: 1.0\n"
+        "target:\n"
+        "  engine_type: local\n"
+        "  host: localhost\n"
+        "  port: '5533'\n"
+        "  ui_port: '8911'\n"
+        "  domain_code: Z\n"
+        "  user: tapdb\n"
+        "  password: filepw\n"
+        f"  database: {database}\n"
+        f"  schema_name: {schema_name}\n"
+        "safety:\n"
+        f"  safety_tier: {safety_tier}\n"
+        f"  destructive_operations: {destructive_operations}\n",
         encoding="utf-8",
     )
-    os.chmod(cfg_path, 0o600)
-    clear_cli_context()
-    set_cli_context(
-        client_id="testclient",
-        database_name="testdb",
-        env_name="dev",
-        config_path=cfg_path,
+    os.chmod(path, 0o600)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cli_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    cfg_path = _write_config(
+        tmp_path / ".config" / "tapdb" / "testclient" / "testdb" / "tapdb-config.yaml"
     )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    clear_cli_context()
+    set_cli_context(config_path=cfg_path)
     monkeypatch.setattr(cli_mod, "PID_FILE", tmp_path / "ui.pid")
     monkeypatch.setattr(cli_mod, "LOG_FILE", tmp_path / "ui.log")
-    yield
+    yield cfg_path
     clear_cli_context()
 
 
-class TestCLIMain:
-    """Tests for main CLI commands."""
-
-    def test_help(self):
-        """Test --help shows all command groups."""
+class TestRootCLI:
+    def test_help_shows_command_groups_without_env_selector(self):
         result = runner.invoke(app, ["--help"])
+
         assert result.exit_code == 0
-        assert "TAPDB" in result.output
-        assert "bootstrap" in result.output
-        assert "ui" in result.output
-        assert "db" in result.output
-        assert "pg" in result.output
-        assert "cognito" in result.output
+        out = _strip(result.output)
+        assert "TAPDB" in out
+        assert "bootstrap" in out
+        assert "ui" in out
+        assert "db" in out
+        assert "pg" in out
+        assert "cognito" in out
+        assert "--env" not in out
 
     def test_version(self):
-        """Test version command."""
         result = runner.invoke(app, ["version"])
-        assert result.exit_code == 0
-        assert "daylily-tapdb" in result.output or "0." in result.output
 
-    def test_info(self):
-        """Test info command."""
-        # Ensure we don't attempt real psql connections during unit tests.
-        with patch("shutil.which", return_value=None):
-            result = runner.invoke(app, ["info"])
         assert result.exit_code == 0
-        assert "Version" in result.output
-        assert "Python" in result.output
-        assert "DB probes" in result.output
+        assert "daylily-tapdb" in result.output
 
-    def test_info_json(self):
-        """Test info --json output is valid JSON and has stable keys."""
-        # Ensure we don't attempt real psql connections during unit tests.
+    def test_info_json_reports_single_explicit_target(self):
         with patch("shutil.which", return_value=None):
             result = runner.invoke(app, ["info", "--json"])
-        assert result.exit_code == 0
-        payload = json.loads(result.output)
-        assert "version" in payload
-        assert "python" in payload
-        assert "tapdb_env" in payload
-        assert "paths" in payload
-        assert "postgres" in payload
 
-    def test_info_check_all_envs_json(self):
-        """Test info --check-all-envs --json shape."""
-        with patch("shutil.which", return_value=None):
-            result = runner.invoke(app, ["info", "--check-all-envs", "--json"])
         assert result.exit_code == 0
         payload = json.loads(result.output)
-        assert payload.get("check_all_envs") is True
-        pg = payload.get("postgres")
-        assert isinstance(pg, dict)
-        for env_name in ["dev", "test", "prod"]:
-            assert env_name in pg
-
-    def test_database_name_option_does_not_override_explicit_config_metadata(self):
-        """Test config metadata stays authoritative once --config is resolved."""
-        with patch("shutil.which", return_value=None):
-            result = runner.invoke(app, ["--database-name", "atlas", "info", "--json"])
-        assert result.exit_code == 0
-        payload = json.loads(result.output)
+        assert payload["target"] == "explicit"
+        assert payload["client_id"] == "testclient"
         assert payload["database_name"] == "testdb"
-        assert (
-            "/testclient/testdb/tapdb-config.yaml"
-            in payload["paths"]["effective_config"]["path"]
-        )
+        assert payload["schema_name"] == "tapdb_testdb"
+        assert payload["postgres"]["target"] == "explicit"
+        assert payload["postgres"]["schema_name"] == "tapdb_testdb"
+        assert "tapdb_env" not in payload
+        assert "check_all_envs" not in payload
 
-    def test_runtime_command_without_config_fails(self):
-        clear_cli_context()
-        result = runner.invoke(app, ["db", "create", "dev"])
-        clear_cli_context()
-        assert result.exit_code != 0
-        assert "TapDB config path is required. Set --config." in _strip_ansi(
-            result.output
-        )
+    def test_info_human_reports_target_and_schema(self):
+        with patch("shutil.which", return_value=None):
+            result = runner.invoke(app, ["info"])
 
-    def test_runtime_command_without_config_for_ui_fails(self):
+        assert result.exit_code == 0
+        out = _strip(result.output)
+        assert "Target" in out
+        assert "explicit" in out
+        assert "tapdb_testdb" in out
+        assert "DB probes" not in out
+
+    def test_root_env_option_is_removed(self, tmp_path: Path):
+        cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+
+        result = runner.invoke(app, ["--config", str(cfg_path), "--env", "dev", "info"])
+
+        assert result.exit_code == 2
+        assert "No such option" in result.output
+
+    def test_runtime_command_requires_explicit_config(self):
         clear_cli_context()
-        result = runner.invoke(app, ["ui", "status"])
-        clear_cli_context()
+
+        result = runner.invoke(app, ["info"])
+
         assert result.exit_code != 0
         assert isinstance(result.exception, RuntimeError)
         assert str(result.exception) == "TapDB config path is required. Set --config."
 
 
-class TestCLIUI:
-    """Tests for UI management commands."""
+class TestConfigCLI:
+    def test_config_init_requires_explicit_config_path(self):
+        clear_cli_context()
 
-    def test_ui_help(self):
-        """Test ui --help."""
-        result = runner.invoke(app, ["ui", "--help"])
-        assert result.exit_code == 0
-        assert "start" in result.output
-        assert "mkcert" in result.output
-        assert "stop" in result.output
-        assert "status" in result.output
-        assert "logs" in result.output
-
-    def test_ui_mkcert_missing_binary(self, monkeypatch):
-        """Test ui mkcert fails clearly when mkcert is not installed."""
-        monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: None)
-        result = runner.invoke(app, ["ui", "mkcert"])
-        assert result.exit_code == 1
-        assert "mkcert is required" in _strip_ansi(result.output)
-
-    def test_ui_mkcert_generates_cert_files(self, tmp_path, monkeypatch):
-        """Test ui mkcert installs CA and generates cert/key files."""
-        cert = tmp_path / "tls" / "localhost.crt"
-        key = tmp_path / "tls" / "localhost.key"
-        commands: list[list[str]] = []
-
-        def _fake_run(cmd, capture_output=True, text=True):
-            commands.append(list(cmd))
-            if "-cert-file" in cmd:
-                cert_idx = cmd.index("-cert-file") + 1
-                key_idx = cmd.index("-key-file") + 1
-                cert_path = Path(cmd[cert_idx])
-                key_path = Path(cmd[key_idx])
-                cert_path.parent.mkdir(parents=True, exist_ok=True)
-                key_path.parent.mkdir(parents=True, exist_ok=True)
-                cert_path.write_text("fake-cert", encoding="utf-8")
-                key_path.write_text("fake-key", encoding="utf-8")
-            return subprocess.CompletedProcess(cmd, 0, "", "")
-
-        monkeypatch.setattr(
-            cli_mod.shutil, "which", lambda name: "/opt/homebrew/bin/mkcert"
-        )
-        monkeypatch.setattr(cli_mod.subprocess, "run", _fake_run)
-
-        result = runner.invoke(
-            app,
-            [
-                "ui",
-                "mkcert",
-                "--cert-file",
-                str(cert),
-                "--key-file",
-                str(key),
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert cert.exists()
-        assert key.exists()
-        assert commands[0] == ["/opt/homebrew/bin/mkcert", "-install"]
-        assert commands[1][:5] == [
-            "/opt/homebrew/bin/mkcert",
-            "-cert-file",
-            str(cert),
-            "-key-file",
-            str(key),
-        ]
-        assert "localhost" in commands[1]
-
-    def test_ui_status_not_running(self):
-        """Test ui status when server is not running."""
-        result = runner.invoke(app, ["ui", "status"])
-        assert result.exit_code == 0
-        assert "not running" in result.output
-
-    def test_ui_stop_not_running(self):
-        """Test ui stop when server is not running."""
-        result = runner.invoke(app, ["ui", "stop"])
-        assert result.exit_code == 0
-        assert "No UI server running" in result.output or "not running" in result.output
-
-    def test_ui_logs_no_file(self):
-        """Test ui logs when no log file exists."""
-        result = runner.invoke(app, ["ui", "logs"])
-        assert result.exit_code == 0
-        assert "No log file" in result.output or "not found" in result.output.lower()
-
-
-class TestConfigUpdate:
-    """Tests for namespaced config mutation commands."""
-
-    def test_config_update_writes_selected_fields(self):
         result = runner.invoke(
             app,
             [
                 "config",
-                "update",
-                "--env",
-                "dev",
-                "--host",
-                "db.internal",
-                "--port",
-                "6001",
-                "--ui-port",
-                "9443",
-                "--cognito-client-name",
-                "atlas",
-                "--support-email",
-                "support@example.com",
-            ],
-        )
-
-        assert result.exit_code == 0
-        config_path = (
-            Path(os.environ["HOME"])
-            / ".config"
-            / "tapdb"
-            / "testclient"
-            / "testdb"
-            / "tapdb-config.yaml"
-        )
-        payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-        env_cfg = payload["environments"]["dev"]
-        assert env_cfg["host"] == "db.internal"
-        assert env_cfg["port"] == "6001"
-        assert env_cfg["ui_port"] == "9443"
-        assert env_cfg["cognito_client_name"] == "atlas"
-        assert env_cfg["support_email"] == "support@example.com"
-
-    def test_config_update_can_clear_fields(self):
-        result = runner.invoke(
-            app,
-            [
-                "config",
-                "update",
-                "--env",
-                "dev",
-                "--support-email",
-                "support@example.com",
-            ],
-        )
-        assert result.exit_code == 0
-
-        result = runner.invoke(
-            app, ["config", "update", "--env", "dev", "--clear", "support_email"]
-        )
-        assert result.exit_code == 0
-
-        config_path = (
-            Path(os.environ["HOME"])
-            / ".config"
-            / "tapdb"
-            / "testclient"
-            / "testdb"
-            / "tapdb-config.yaml"
-        )
-        payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-        assert payload["environments"]["dev"]["support_email"] == ""
-
-
-class TestCLICognito:
-    """Tests for Cognito integration commands."""
-
-    def test_cognito_help(self):
-        result = runner.invoke(app, ["cognito", "--help"])
-        assert result.exit_code == 0
-        out = _strip_ansi(result.output)
-        assert "setup" in out
-        assert "setup-with-google" in out
-        assert "bind" in out
-        assert "status" in out
-        assert "list-pools" in out
-        assert "add-user" in out
-        assert "list-apps" in out
-        assert "add-app" in out
-        assert "edit-app" in out
-        assert "remove-app" in out
-        assert "add-google-idp" in out
-        assert "fix-auth-flows" in out
-        assert "config" in out
-
-    def test_cognito_bind_writes_pool_id(self, tmp_path, monkeypatch):
-        cfg_path = tmp_path / "tapdb-config.yaml"
-        domain_registry, prefix_registry = _write_test_registries(tmp_path)
-        cfg_path.write_text(
-            "meta:\n"
-            "  config_version: 3\n"
-            "  client_id: testclient\n"
-            "  database_name: testdb\n"
-            "  owner_repo_name: daylily-tapdb\n"
-            f"  domain_registry_path: {domain_registry}\n"
-            f"  prefix_ownership_registry_path: {prefix_registry}\n"
-            "environments:\n"
-            "  dev:\n"
-            "    engine_type: local\n"
-            "    host: localhost\n"
-            "    port: 5432\n"
-            "    ui_port: 8911\n"
-            "    domain_code: Z\n"
-            "    user: test\n"
-            "    database: tapdb_dev\n"
-            "    schema_name: tapdb_testdb_dev\n",
-            encoding="utf-8",
-        )
-        result = runner.invoke(
-            app,
-            [
-                "--config",
-                str(cfg_path),
-                "--env",
-                "dev",
-                "cognito",
-                "bind",
-                "dev",
-                "--pool-id",
-                "us-east-1_TESTPOOL",
-            ],
-        )
-        assert result.exit_code == 0
-        content = cfg_path.read_text(encoding="utf-8")
-        assert "cognito_user_pool_id" in content
-        assert "us-east-1_TESTPOOL" in content
-
-    def test_cognito_setup_uses_daycog_024_flags(self, tmp_path, monkeypatch):
-        pool_name = "tapdb-dev-users"
-        captured: dict[str, list[str]] = {}
-
-        def _fake_run_daycog(args, env=None):
-            captured["args"] = list(args)
-            return ""
-
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._finalize_setup_binding",
-            lambda **_kwargs: None,
-        )
-        monkeypatch.setattr("daylily_tapdb.cli.cognito._run_daycog", _fake_run_daycog)
-
-        result = runner.invoke(
-            app,
-            [
-                "cognito",
-                "setup",
-                "dev",
-                "--pool-name",
-                pool_name,
-                "--profile",
-                "test-profile",
-                "--region",
-                "us-east-1",
-            ],
-        )
-
-        assert result.exit_code == 0
-        args = captured["args"]
-        assert args[:2] == ["setup", "--name"]
-        assert "--autoprovision" in args
-        assert "--client-name" in args
-        assert "tapdb" in args
-        assert "--callback-path" in args
-        assert "--attach-domain" in args
-        assert "--domain-prefix" not in args
-        assert "--oauth-flows" in args
-        assert "--scopes" in args
-        assert "--idp" in args
-
-    def test_cognito_setup_with_domain_flags_routes_to_daycog(
-        self, tmp_path, monkeypatch
-    ):
-        pool_name = "tapdb-dev-users"
-        captured: dict[str, list[str]] = {}
-
-        def _fake_run_daycog(args, env=None):
-            captured["args"] = list(args)
-            return ""
-
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._finalize_setup_binding",
-            lambda **_kwargs: None,
-        )
-        monkeypatch.setattr("daylily_tapdb.cli.cognito._run_daycog", _fake_run_daycog)
-
-        result = runner.invoke(
-            app,
-            [
-                "cognito",
-                "setup",
-                "dev",
-                "--pool-name",
-                pool_name,
-                "--region",
-                "us-east-1",
-                "--domain-prefix",
-                "tapdb-dev-domain",
-                "--no-attach-domain",
-            ],
-        )
-        assert result.exit_code == 0
-        args = captured["args"]
-        assert "--domain-prefix" in args
-        assert "tapdb-dev-domain" in args
-        assert "--no-attach-domain" in args
-
-    def test_cognito_setup_with_google_routes_to_daycog(self, tmp_path, monkeypatch):
-        pool_name = "tapdb-dev-users"
-        captured: dict[str, list[str]] = {}
-
-        def _fake_run_daycog(args, env=None):
-            captured["args"] = list(args)
-            return ""
-
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._finalize_setup_binding",
-            lambda **_kwargs: None,
-        )
-        monkeypatch.setattr("daylily_tapdb.cli.cognito._run_daycog", _fake_run_daycog)
-
-        result = runner.invoke(
-            app,
-            [
-                "cognito",
-                "setup-with-google",
-                "dev",
-                "--pool-name",
-                pool_name,
-                "--profile",
-                "test-profile",
-                "--region",
-                "us-east-1",
-                "--google-client-id",
-                "gid",
-                "--google-client-secret",
-                "gsecret",
-            ],
-        )
-
-        assert result.exit_code == 0
-        args = captured["args"]
-        assert args[:2] == ["setup-with-google", "--name"]
-        assert "--google-client-id" in args
-        assert "--google-client-secret" in args
-        assert "--callback-path" in args
-
-    def test_cognito_list_apps_routes_to_daycog(self, monkeypatch):
-        captured: dict[str, list[str]] = {}
-
-        def _fake_run_daycog(args, env=None):
-            captured["args"] = list(args)
-            return ""
-
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._resolve_pool_command_context",
-            lambda *_args, **_kwargs: (
-                "tapdb-dev-users",
-                {"AWS_PROFILE": "test-profile"},
-                "us-east-1",
-                "test-profile",
-            ),
-        )
-        monkeypatch.setattr("daylily_tapdb.cli.cognito._run_daycog", _fake_run_daycog)
-
-        result = runner.invoke(app, ["cognito", "list-apps", "dev"])
-        assert result.exit_code == 0
-        args = captured["args"]
-        assert args[:2] == ["list-apps", "--pool-name"]
-        assert "--region" in args
-        assert "--profile" in args
-
-    def test_cognito_list_pools_routes_to_daycog(self, monkeypatch):
-        captured: dict[str, list[str]] = {}
-
-        def _fake_run_daycog(args, env=None):
-            captured["args"] = list(args)
-            return ""
-
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._resolve_pool_command_context",
-            lambda *_args, **_kwargs: (
-                "tapdb-dev-users",
-                {"AWS_PROFILE": "test-profile"},
-                "us-east-1",
-                "test-profile",
-            ),
-        )
-        monkeypatch.setattr("daylily_tapdb.cli.cognito._run_daycog", _fake_run_daycog)
-
-        result = runner.invoke(app, ["cognito", "list-pools", "dev"])
-        assert result.exit_code == 0
-        args = captured["args"]
-        assert args[:2] == ["list-pools", "--region"]
-        assert "--profile" in args
-
-    def test_cognito_add_app_routes_to_daycog(self, monkeypatch):
-        captured: dict[str, list[str]] = {}
-
-        def _fake_run_daycog(args, env=None):
-            captured["args"] = list(args)
-            return ""
-
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._resolve_pool_command_context",
-            lambda *_args, **_kwargs: (
-                "tapdb-dev-users",
-                {"AWS_PROFILE": "test-profile"},
-                "us-east-1",
-                "test-profile",
-            ),
-        )
-        monkeypatch.setattr("daylily_tapdb.cli.cognito._run_daycog", _fake_run_daycog)
-
-        result = runner.invoke(
-            app,
-            [
-                "cognito",
-                "add-app",
-                "dev",
-                "--app-name",
-                "web-app",
-                "--callback-url",
-                "https://localhost:8911/auth/callback",
-                "--set-default",
-            ],
-        )
-        assert result.exit_code == 0
-        args = captured["args"]
-        assert args[:2] == ["add-app", "--pool-name"]
-        assert "--app-name" in args
-        assert "--callback-url" in args
-        assert "--set-default" in args
-
-    def test_cognito_config_update_routes_to_daycog(self, monkeypatch):
-        captured: dict[str, list[str]] = {}
-
-        def _fake_run_daycog(args, env=None):
-            captured["args"] = list(args)
-            return ""
-
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._resolve_pool_command_context",
-            lambda *_args, **_kwargs: (
-                "tapdb-dev-users",
-                {"AWS_PROFILE": "test-profile"},
-                "us-east-1",
-                "test-profile",
-            ),
-        )
-        monkeypatch.setattr("daylily_tapdb.cli.cognito._run_daycog", _fake_run_daycog)
-
-        result = runner.invoke(app, ["cognito", "config", "update", "dev"])
-        assert result.exit_code == 0
-        args = captured["args"]
-        assert args[:3] == ["config", "update", "--pool-name"]
-        assert "--region" in args
-        assert "--profile" in args
-
-    def test_cognito_status_shows_daycog_024_fields(self, monkeypatch):
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito.get_db_config_for_env",
-            lambda _env: {"cognito_user_pool_id": "us-east-1_TESTPOOL"},
-        )
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._find_pool_context_by_id",
-            lambda _pool_id, **_kwargs: (
-                "tapdb-dev-users.us-east-1",
-                {
-                    "AWS_PROFILE": "test",
-                    "AWS_REGION": "us-east-1",
-                    "COGNITO_REGION": "us-east-1",
-                    "COGNITO_USER_POOL_ID": "us-east-1_TESTPOOL",
-                    "COGNITO_APP_CLIENT_ID": "cid123",
-                    "COGNITO_CLIENT_NAME": "tapdb",
-                    "COGNITO_DOMAIN": (
-                        "tapdb-dev-users.auth.us-east-1.amazoncognito.com"
-                    ),
-                    "COGNITO_CALLBACK_URL": "https://localhost:8911/auth/callback",
-                    "COGNITO_LOGOUT_URL": "https://localhost:8911/",
-                },
-            ),
-        )
-
-        result = runner.invoke(app, ["cognito", "status", "dev"])
-        assert result.exit_code == 0
-        out = _strip_ansi(result.output)
-        assert "Client:" in out
-        assert "Domain:" in out
-        assert "Callback:" in out
-        assert "Logout:" in out
-
-    def test_cognito_status_fails_on_local_uri_port_mismatch(self, monkeypatch):
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito.get_db_config_for_env",
-            lambda _env: {"cognito_user_pool_id": "us-east-1_TESTPOOL"},
-        )
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._find_pool_context_by_id",
-            lambda _pool_id, **_kwargs: (
-                "tapdb-dev-users.us-east-1",
-                {
-                    "AWS_PROFILE": "test",
-                    "AWS_REGION": "us-east-1",
-                    "COGNITO_REGION": "us-east-1",
-                    "COGNITO_USER_POOL_ID": "us-east-1_TESTPOOL",
-                    "COGNITO_APP_CLIENT_ID": "cid123",
-                    "COGNITO_CLIENT_NAME": "tapdb",
-                    "COGNITO_CALLBACK_URL": "https://localhost:9999/auth/callback",
-                    "COGNITO_LOGOUT_URL": "https://localhost:9999/",
-                },
-            ),
-        )
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._resolve_expected_ui_port",
-            lambda _env: (8911, "test"),
-        )
-
-        result = runner.invoke(app, ["cognito", "status", "dev"])
-        assert result.exit_code != 0
-        out = _strip_ansi(result.output)
-        assert "Cognito URI validation failed" in out
-        assert "does not match TAPDB UI port 8911" in out
-
-    def test_cognito_status_fails_on_non_https_uri(self, monkeypatch):
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito.get_db_config_for_env",
-            lambda _env: {"cognito_user_pool_id": "us-east-1_TESTPOOL"},
-        )
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._find_pool_context_by_id",
-            lambda _pool_id, **_kwargs: (
-                "tapdb-dev-users.us-east-1",
-                {
-                    "AWS_PROFILE": "test",
-                    "AWS_REGION": "us-east-1",
-                    "COGNITO_REGION": "us-east-1",
-                    "COGNITO_USER_POOL_ID": "us-east-1_TESTPOOL",
-                    "COGNITO_APP_CLIENT_ID": "cid123",
-                    "COGNITO_CLIENT_NAME": "tapdb",
-                    "COGNITO_CALLBACK_URL": "http://localhost:8911/auth/callback",
-                    "COGNITO_LOGOUT_URL": "https://localhost:8911/",
-                },
-            ),
-        )
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._resolve_expected_ui_port",
-            lambda _env: (8911, "test"),
-        )
-
-        result = runner.invoke(app, ["cognito", "status", "dev"])
-        assert result.exit_code != 0
-        out = _strip_ansi(result.output)
-        assert "Cognito URI validation failed" in out
-        assert "must use https" in out
-
-    def test_cognito_status_fails_if_client_name_not_tapdb(self, monkeypatch):
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito.get_db_config_for_env",
-            lambda _env: {"cognito_user_pool_id": "us-east-1_TESTPOOL"},
-        )
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._find_pool_context_by_id",
-            lambda _pool_id, **_kwargs: (
-                "tapdb-dev-users.us-east-1",
-                {
-                    "AWS_PROFILE": "test",
-                    "AWS_REGION": "us-east-1",
-                    "COGNITO_REGION": "us-east-1",
-                    "COGNITO_USER_POOL_ID": "us-east-1_TESTPOOL",
-                    "COGNITO_APP_CLIENT_ID": "cid123",
-                    "COGNITO_CLIENT_NAME": "wrong-client",
-                    "COGNITO_CALLBACK_URL": "https://localhost:8911/auth/callback",
-                    "COGNITO_LOGOUT_URL": "https://localhost:8911/",
-                },
-            ),
-        )
-
-        result = runner.invoke(app, ["cognito", "status", "dev"])
-        assert result.exit_code != 0
-        out = _strip_ansi(result.output)
-        assert "must select Cognito app client name 'tapdb'" in out
-
-    def test_cognito_setup_rejects_non_tapdb_client_name(self):
-        result = runner.invoke(
-            app,
-            [
-                "cognito",
-                "setup",
-                "dev",
-                "--pool-name",
-                "tapdb-dev-users",
-                "--client-name",
-                "custom-client",
-            ],
-        )
-        assert result.exit_code != 0
-        out = _strip_ansi(result.output)
-        assert "requires Cognito app client name 'tapdb'" in out
-
-    def test_cognito_add_user_provisions_actor_user(self, monkeypatch):
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito.get_db_config_for_env",
-            lambda _env: {
-                "cognito_user_pool_id": "us-east-1_TESTPOOL",
-                "engine_type": "local",
-                "host": "localhost",
-                "port": "5533",
-                "user": "test",
-                "password": "",
-                "database": "tapdb_dev",
-                "schema_name": "tapdb_testdb_dev",
-                "domain_code": "Z",
-                "owner_repo_name": "daylily-tapdb",
-            },
-        )
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._find_pool_context_by_id",
-            lambda _pool_id, **_kwargs: (
-                "tapdb-dev-users.us-east-1",
-                {
-                    "AWS_PROFILE": "test",
-                    "AWS_REGION": "us-east-1",
-                    "COGNITO_REGION": "us-east-1",
-                    "COGNITO_USER_POOL_ID": "us-east-1_TESTPOOL",
-                    "COGNITO_APP_CLIENT_ID": "cid123",
-                    "COGNITO_CLIENT_NAME": "tapdb",
-                },
-            ),
-        )
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito._run_daycog",
-            lambda *_args, **_kwargs: "",
-        )
-
-        class _FakeConn:
-            def __init__(self, *args, **kwargs):
-                _ = (args, kwargs)
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-            class _Scope:
-                def __enter__(self):
-                    return object()
-
-                def __exit__(self, exc_type, exc, tb):
-                    return False
-
-            def session_scope(self, commit=False):
-                _ = commit
-                return self._Scope()
-
-        monkeypatch.setattr("daylily_tapdb.cli.cognito.TAPDBConnection", _FakeConn)
-
-        class _FakeUser:
-            is_active = True
-
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.cognito.create_or_get",
-            lambda *_args, **_kwargs: (_FakeUser(), True),
-        )
-
-        result = runner.invoke(
-            app,
-            [
-                "cognito",
-                "add-user",
-                "dev",
-                "johnm@lsmc.bio",
-                "--password",
-                "TestPass123",
-                "--no-verify",
-            ],
-        )
-        assert result.exit_code == 0
-        assert "Created Cognito user" in result.output
-
-
-class TestCLIBootstrap:
-    """Tests for bootstrap commands."""
-
-    def test_bootstrap_help(self):
-        result = runner.invoke(app, ["bootstrap", "--help"])
-        assert result.exit_code == 0
-        out = _strip_ansi(result.output)
-        assert "local" in out
-        assert "aurora" in out
-
-    def test_bootstrap_local_requires_explicit_runtime_context(self):
-        clear_cli_context()
-        fresh_app = cli_mod.build_app()
-        result = runner.invoke(fresh_app, ["bootstrap", "local", "--no-gui"])
-        clear_cli_context()
-        assert result.exit_code != 0
-        assert "TapDB bootstrap requires an explicit --env value." in _strip_ansi(
-            result.output
-        )
-
-    def test_bootstrap_local_no_gui(self, monkeypatch):
-        monkeypatch.setenv("TAPDB_ENV", "dev")
-        monkeypatch.setenv("TAPDB_DEV_ENGINE_TYPE", "local")
-        monkeypatch.setattr("daylily_tapdb.cli.db.create_database", lambda **_: None)
-        monkeypatch.setattr("daylily_tapdb.cli.db.apply_schema", lambda **_: None)
-        monkeypatch.setattr("daylily_tapdb.cli.db.run_migrations", lambda **_: None)
-        monkeypatch.setattr("daylily_tapdb.cli.db.seed_templates", lambda **_: None)
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.db._create_default_admin",
-            lambda **_: False,
-        )
-        monkeypatch.setattr("daylily_tapdb.cli.pg.pg_init", lambda **_: None)
-        monkeypatch.setattr("daylily_tapdb.cli.pg.pg_start_local", lambda **_: None)
-
-        fresh_app = cli_mod.build_app()
-        result = runner.invoke(fresh_app, ["bootstrap", "local", "--no-gui"])
-        assert result.exit_code == 0
-        assert "bootstrap complete" in result.output.lower()
-
-    def test_bootstrap_aurora_requires_cluster(self, monkeypatch):
-        monkeypatch.setenv("TAPDB_ENV", "dev")
-        fresh_app = cli_mod.build_app()
-        result = runner.invoke(fresh_app, ["bootstrap", "aurora"])
-        assert result.exit_code != 0
-        assert "--cluster" in result.output or "Missing option" in result.output
-
-    def test_bootstrap_aurora_creates_namespaced_config(self, tmp_path, monkeypatch):
-        domain_registry, prefix_registry = _write_test_registries(tmp_path)
-        cfg_path = (
-            tmp_path
-            / ".config"
-            / "tapdb"
-            / "daylily-tapdb"
-            / "auruse1-daylily-tapdb"
-            / "tapdb-config.yaml"
-        )
-
-        class _FakeAuroraStackManager:
-            def __init__(self, *args, **kwargs):
-                pass
-
-            def get_stack_status(self, stack_name):
-                return {
-                    "stack_name": stack_name,
-                    "status": "CREATE_COMPLETE",
-                    "outputs": {
-                        "ClusterEndpoint": "auruse1.cluster.us-east-1.rds.amazonaws.com",
-                        "ClusterPort": "5432",
-                        "SecretArn": "arn:aws:secretsmanager:us-east-1:123:secret:auruse1",
-                    },
-                }
-
-            def update_stack(self, config):
-                return self.get_stack_status(f"tapdb-{config.cluster_identifier}")
-
-        monkeypatch.setenv("HOME", str(tmp_path))
-        monkeypatch.setattr("daylily_tapdb.cli.aurora._ensure_boto3", lambda: None)
-        monkeypatch.setattr(
-            "daylily_tapdb.aurora.stack_manager.AuroraStackManager",
-            _FakeAuroraStackManager,
-        )
-        monkeypatch.setattr("daylily_tapdb.cli.db.create_database", lambda **_: None)
-        monkeypatch.setattr("daylily_tapdb.cli.db.apply_schema", lambda **_: None)
-        monkeypatch.setattr("daylily_tapdb.cli.db.run_migrations", lambda **_: None)
-        monkeypatch.setattr("daylily_tapdb.cli.db.seed_templates", lambda **_: None)
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.db._create_default_admin",
-            lambda **_: False,
-        )
-
-        clear_cli_context()
-        fresh_app = cli_mod.build_app()
-        result = runner.invoke(
-            fresh_app,
-            [
-                "--config",
-                str(cfg_path),
+                "init",
                 "--client-id",
-                "daylily-tapdb",
+                "atlas",
                 "--database-name",
-                "auruse1-daylily-tapdb",
-                "--env",
-                "dev",
-                "bootstrap",
-                "aurora",
-                "--cluster",
-                "auruse1",
-                "--region",
-                "us-east-1",
+                "atlas-dayfly5",
                 "--owner-repo-name",
-                "daylily-tapdb",
+                "lsmc-atlas",
                 "--domain-code",
-                "dev=Z",
+                "Z",
+                "--engine-type",
+                "local",
+                "--host",
+                "localhost",
+                "--port",
+                "5533",
                 "--ui-port",
-                "dev=8910",
-                "--domain-registry-path",
-                str(domain_registry),
-                "--prefix-ownership-registry-path",
-                str(prefix_registry),
-                "--no-gui",
+                "8911",
+                "--user",
+                "tapdb",
+                "--database",
+                "tapdb_dayfly5",
+                "--schema-name",
+                "tapdb_atlas_dayfly5",
             ],
         )
 
-        assert result.exit_code == 0
-        payload = yaml.safe_load(cfg_path.read_text())
-        assert payload["meta"]["client_id"] == "daylily-tapdb"
-        assert payload["meta"]["database_name"] == "auruse1-daylily-tapdb"
-        assert payload["meta"]["owner_repo_name"] == "daylily-tapdb"
-        assert payload["environments"]["dev"]["engine_type"] == "aurora"
-        assert payload["environments"]["dev"]["database"] == (
-            "tapdb_auruse1_daylily_tapdb_dev"
-        )
-        assert payload["environments"]["dev"]["iam_auth"] == "false"
-        assert payload["environments"]["dev"]["secret_arn"].endswith(":secret:auruse1")
-        assert payload["environments"]["dev"]["ui_port"] == "8910"
-        assert payload["environments"]["dev"]["cluster_identifier"] == "auruse1"
+        assert result.exit_code != 0
+        assert "TapDB config commands require --config" in str(result.exception)
 
-    def test_bootstrap_aurora_preserves_database_and_ui_port(
-        self, tmp_path, monkeypatch
+    def test_config_init_writes_single_target_and_removes_legacy_environments(
+        self, tmp_path: Path
     ):
-        domain_registry, prefix_registry = _write_test_registries(tmp_path)
         cfg_path = tmp_path / "tapdb-config.yaml"
-        cfg_path.write_text(
-            yaml.safe_dump(
-                {
-                    "meta": {
-                        "config_version": 3,
-                        "client_id": "daylily-tapdb",
-                        "database_name": "auruse1-daylily-tapdb",
-                        "owner_repo_name": "daylily-tapdb",
-                        "domain_registry_path": str(domain_registry),
-                        "prefix_ownership_registry_path": str(prefix_registry),
-                    },
-                    "environments": {
-                        "dev": {
-                            "engine_type": "local",
-                            "host": "localhost",
-                            "port": "5432",
-                            "ui_port": "8910",
-                            "domain_code": "Z",
-                            "user": "test",
-                            "password": "",
-                            "database": "tapdb_auruse1_daylily_tapdb_dev",
-                            "schema_name": "tapdb_auruse1_daylily_tapdb_dev",
-                        }
-                    },
-                },
-                sort_keys=False,
-            ),
-            encoding="utf-8",
-        )
-
-        class _FakeAuroraStackManager:
-            def __init__(self, *args, **kwargs):
-                pass
-
-            def get_stack_status(self, stack_name):
-                return {
-                    "stack_name": stack_name,
-                    "status": "CREATE_COMPLETE",
-                    "outputs": {
-                        "ClusterEndpoint": "auruse1.cluster.us-east-1.rds.amazonaws.com",
-                        "ClusterPort": "5432",
-                        "SecretArn": "arn:aws:secretsmanager:us-east-1:123:secret:auruse1",
-                    },
-                }
-
-            def update_stack(self, config):
-                return self.get_stack_status(f"tapdb-{config.cluster_identifier}")
-
-        monkeypatch.setenv("HOME", str(tmp_path))
-        monkeypatch.setattr("daylily_tapdb.cli.aurora._ensure_boto3", lambda: None)
-        monkeypatch.setattr(
-            "daylily_tapdb.aurora.stack_manager.AuroraStackManager",
-            _FakeAuroraStackManager,
-        )
-        monkeypatch.setattr("daylily_tapdb.cli.db.create_database", lambda **_: None)
-        monkeypatch.setattr("daylily_tapdb.cli.db.apply_schema", lambda **_: None)
-        monkeypatch.setattr("daylily_tapdb.cli.db.run_migrations", lambda **_: None)
-        monkeypatch.setattr("daylily_tapdb.cli.db.seed_templates", lambda **_: None)
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.db._create_default_admin",
-            lambda **_: False,
-        )
-
-        clear_cli_context()
-        fresh_app = cli_mod.build_app()
-        result = runner.invoke(
-            fresh_app,
-            [
-                "--config",
-                str(cfg_path),
-                "--env",
-                "dev",
-                "bootstrap",
-                "aurora",
-                "--cluster",
-                "auruse1",
-                "--region",
-                "us-east-1",
-                "--no-gui",
-            ],
-        )
-
-        assert result.exit_code == 0
-        payload = yaml.safe_load(cfg_path.read_text())
-        assert payload["environments"]["dev"]["database"] == (
-            "tapdb_auruse1_daylily_tapdb_dev"
-        )
-        assert payload["environments"]["dev"]["ui_port"] == "8910"
-        assert payload["environments"]["dev"]["iam_auth"] == "false"
-        assert payload["environments"]["dev"]["host"] == (
-            "auruse1.cluster.us-east-1.rds.amazonaws.com"
-        )
-        assert payload["environments"]["dev"]["engine_type"] == "aurora"
-
-    def test_bootstrap_aurora_public_access_resolves_current_ip(
-        self, tmp_path, monkeypatch
-    ):
-        domain_registry, prefix_registry = _write_test_registries(tmp_path)
-        cfg_path = tmp_path / "tapdb-config.yaml"
-        cfg_path.write_text(
-            yaml.safe_dump(
-                {
-                    "meta": {
-                        "config_version": 3,
-                        "client_id": "daylily-tapdb",
-                        "database_name": "auruse1-daylily-tapdb",
-                        "owner_repo_name": "daylily-tapdb",
-                        "domain_registry_path": str(domain_registry),
-                        "prefix_ownership_registry_path": str(prefix_registry),
-                    },
-                    "environments": {
-                        "dev": {
-                            "engine_type": "local",
-                            "host": "localhost",
-                            "port": "5432",
-                            "ui_port": "8910",
-                            "domain_code": "Z",
-                            "user": "test",
-                            "password": "",
-                            "database": "tapdb_auruse1_daylily_tapdb_dev",
-                            "schema_name": "tapdb_auruse1_daylily_tapdb_dev",
-                        }
-                    },
-                },
-                sort_keys=False,
-            ),
-            encoding="utf-8",
-        )
-
-        class _FakeAuroraStackManager:
-            last_config = None
-
-            def __init__(self, *args, **kwargs):
-                pass
-
-            def get_stack_status(self, stack_name):
-                return {
-                    "stack_name": stack_name,
-                    "status": "CREATE_COMPLETE",
-                    "outputs": {
-                        "ClusterEndpoint": "auruse1.cluster.us-east-1.rds.amazonaws.com",
-                        "ClusterPort": "5432",
-                        "SecretArn": "arn:aws:secretsmanager:us-east-1:123:secret:auruse1",
-                    },
-                }
-
-            def update_stack(self, config):
-                _FakeAuroraStackManager.last_config = config
-                return self.get_stack_status(f"tapdb-{config.cluster_identifier}")
-
-        monkeypatch.setenv("HOME", str(tmp_path))
-        monkeypatch.setattr("daylily_tapdb.cli.aurora._ensure_boto3", lambda: None)
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.aurora._detect_caller_public_ip",
-            lambda: "24.7.124.62",
-        )
-        monkeypatch.setattr(
-            "daylily_tapdb.aurora.stack_manager.AuroraStackManager",
-            _FakeAuroraStackManager,
-        )
-        monkeypatch.setattr("daylily_tapdb.cli.db.create_database", lambda **_: None)
-        monkeypatch.setattr("daylily_tapdb.cli.db.apply_schema", lambda **_: None)
-        monkeypatch.setattr("daylily_tapdb.cli.db.run_migrations", lambda **_: None)
-        monkeypatch.setattr("daylily_tapdb.cli.db.seed_templates", lambda **_: None)
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.db._create_default_admin",
-            lambda **_: False,
-        )
-
-        clear_cli_context()
-        fresh_app = cli_mod.build_app()
-        result = runner.invoke(
-            fresh_app,
-            [
-                "--config",
-                str(cfg_path),
-                "--env",
-                "dev",
-                "bootstrap",
-                "aurora",
-                "--cluster",
-                "auruse1",
-                "--region",
-                "us-east-1",
-                "--publicly-accessible",
-                "--no-gui",
-            ],
-        )
-
-        assert result.exit_code == 0
-        assert _FakeAuroraStackManager.last_config is not None
-        assert _FakeAuroraStackManager.last_config.cidr == "24.7.124.62/32"
-        assert _FakeAuroraStackManager.last_config.publicly_accessible is True
-        assert "Ingress CIDR: 24.7.124.62/32" in _strip_ansi(result.output)
-
-
-class TestCLIDB:
-    """Tests for database management commands."""
-
-    def test_db_help(self):
-        """Test db --help."""
-        result = runner.invoke(app, ["db", "--help"])
-        assert result.exit_code == 0
-        assert "create" in result.output
-        assert "delete" in result.output
-        assert "schema" in result.output
-        assert "data" in result.output
-        assert "config" in result.output
-
-    def test_db_create_help(self):
-        """Test db create --help."""
-        result = runner.invoke(app, ["db", "create", "--help"])
-        assert result.exit_code == 0
-        assert "dev" in result.output
-        assert "test" in result.output
-        assert "prod" in result.output
-
-    def test_db_schema_reset_help(self):
-        """Test db schema reset --help shows safety warnings."""
-        result = runner.invoke(app, ["db", "schema", "reset", "--help"])
-        assert result.exit_code == 0
-        assert "DESTRUCTIVE" in result.output or "force" in result.output
-
-    def test_db_schema_drift_check_help(self):
-        """Test db schema drift-check --help."""
-        result = runner.invoke(app, ["db", "schema", "drift-check", "--help"])
-        assert result.exit_code == 0
-        out = _strip_ansi(result.output)
-        assert "--json" in out
-        assert "--strict" in out
-
-    def test_db_schema_drift_check_json_clean(self, monkeypatch):
-        """Clean drift-check emits JSON and exits 0."""
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.db._check_db_exists",
-            lambda _env, _db: True,
-        )
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.db._run_schema_drift_check",
-            lambda _env, strict: (
-                {
-                    "status": "clean",
-                    "env": "dev",
-                    "database": "tapdb_dev",
-                    "schema_name": "public",
-                    "strict": strict,
-                    "expected_asset_paths": ["/tmp/schema/tapdb_schema.sql"],
-                    "counts": {
-                        "expected": {"tables": 1},
-                        "live": {"tables": 1},
-                        "missing": {"tables": 0},
-                        "unexpected": {"tables": 0},
-                    },
-                    "missing": {
-                        "tables": [],
-                        "columns": [],
-                        "sequences": [],
-                        "functions": [],
-                        "triggers": [],
-                        "indexes": [],
-                    },
-                    "unexpected": {
-                        "tables": [],
-                        "columns": [],
-                        "sequences": [],
-                        "functions": [],
-                        "triggers": [],
-                        "indexes": [],
-                    },
-                },
-                False,
-            ),
-        )
-
-        result = runner.invoke(app, ["db", "schema", "drift-check", "dev", "--json"])
-        assert result.exit_code == 0
-        payload = json.loads(result.output)
-        assert payload["status"] == "clean"
-        assert payload["schema_name"] == "public"
-        assert "counts" in payload
-        assert "missing" in payload
-        assert "unexpected" in payload
-
-    def test_db_schema_drift_check_json_drift_exit_one(self, monkeypatch):
-        """Drift-check exits 1 on detected drift."""
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.db._check_db_exists",
-            lambda _env, _db: True,
-        )
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.db._run_schema_drift_check",
-            lambda _env, strict: (
-                {
-                    "status": "drift",
-                    "env": "dev",
-                    "database": "tapdb_dev",
-                    "schema_name": "public",
-                    "strict": strict,
-                    "expected_asset_paths": ["/tmp/schema/tapdb_schema.sql"],
-                    "counts": {
-                        "expected": {"tables": 1},
-                        "live": {"tables": 0},
-                        "missing": {"tables": 1},
-                        "unexpected": {"tables": 0},
-                    },
-                    "missing": {
-                        "tables": ["generic_template"],
-                        "columns": [],
-                        "sequences": [],
-                        "functions": [],
-                        "triggers": [],
-                        "indexes": [],
-                    },
-                    "unexpected": {
-                        "tables": [],
-                        "columns": [],
-                        "sequences": [],
-                        "functions": [],
-                        "triggers": [],
-                        "indexes": [],
-                    },
-                },
-                True,
-            ),
-        )
 
         result = runner.invoke(
             app,
-            ["db", "schema", "drift-check", "dev", "--json", "--strict"],
-        )
-        assert result.exit_code == 1
-        payload = json.loads(result.output)
-        assert payload["status"] == "drift"
-        assert payload["strict"] is True
-        assert payload["missing"]["tables"] == ["generic_template"]
-
-    def test_db_schema_drift_check_json_operational_error_exit_two(self, monkeypatch):
-        """Drift-check exits 2 for operational errors."""
-        monkeypatch.setattr(
-            "daylily_tapdb.cli.db._check_db_exists",
-            lambda _env, _db: False,
-        )
-        result = runner.invoke(app, ["db", "schema", "drift-check", "dev", "--json"])
-        assert result.exit_code == 2
-        payload = json.loads(result.output)
-        assert payload["status"] == "error"
-        assert "does not exist" in payload["error"]
-
-    def test_get_db_config_defaults(self):
-        """Test _get_db_config returns correct defaults when no config file exists."""
-        # Mock load_config so the real ~/.config/tapdb/tapdb-config.yaml is ignored.
-        # Also clear PG* env vars that would override the hard defaults.
-        env_clear = {
-            k: v
-            for k, v in os.environ.items()
-            if not k.startswith("PGHOST")
-            and not k.startswith("PGPORT")
-            and not k.startswith("TAPDB_DEV_")
-        }
-        with (
-            patch("daylily_tapdb.cli.db_config.load_config", return_value={}),
-            patch.dict(os.environ, env_clear, clear=True),
-        ):
-            config = _get_db_config(Environment.dev)
-            assert config["database"] == "tapdb_dev"
-            assert config["host"] == "localhost"
-            assert config["port"] == "5533"
-
-    def test_get_db_config_ignores_removed_env_overrides(self):
-        """Test removed TAPDB_<ENV>_* overrides no longer affect config resolution."""
-        # Mock load_config to isolate from real config file.
-        with (
-            patch("daylily_tapdb.cli.db_config.load_config", return_value={}),
-            patch.dict(
-                os.environ,
-                {
-                    "TAPDB_TEST_HOST": "testhost",
-                    "TAPDB_TEST_PORT": "5433",
-                    "TAPDB_TEST_DATABASE": "my_test_db",
-                },
-            ),
-        ):
-            config = _get_db_config(Environment.test)
-            assert config["host"] == "localhost"
-            assert config["port"] == "5534"
-            assert config["database"] == "tapdb_test"
-
-    def test_find_schema_file(self):
-        """Test _find_schema_file locates the schema."""
-        schema_path = _find_schema_file()
-        assert schema_path.exists()
-        assert schema_path.name == "tapdb_schema.sql"
-
-    def test_find_schema_file_falls_back_to_installed_data_dir(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Use installed data-dir schema when repo-relative schema is absent."""
-        import daylily_tapdb.cli.db as m
-
-        fake_cli_dir = tmp_path / "site-packages" / "daylily_tapdb" / "cli"
-        fake_cli_dir.mkdir(parents=True)
-        fake_db_py = fake_cli_dir / "db.py"
-        fake_db_py.write_text("# fake module path\n")
-        monkeypatch.setattr(m, "__file__", str(fake_db_py))
-
-        data_root = tmp_path / "py-data"
-        expected_schema = data_root / "schema" / "tapdb_schema.sql"
-        expected_schema.parent.mkdir(parents=True)
-        expected_schema.write_text("-- installed schema\n")
-
-        cwd_schema = tmp_path / "cwd" / "schema" / "tapdb_schema.sql"
-        cwd_schema.parent.mkdir(parents=True)
-        cwd_schema.write_text("-- cwd schema\n")
-        monkeypatch.chdir(cwd_schema.parent.parent)
-
-        monkeypatch.setattr(m.sysconfig, "get_paths", lambda: {"data": str(data_root)})
-
-        schema_path = m._find_schema_file()
-        assert schema_path == expected_schema
-        assert schema_path.read_text() == "-- installed schema\n"
-
-    def test_ensure_dirs_creates_config(self):
-        """Test _ensure_dirs creates config directory."""
-        _ensure_dirs()
-        assert get_config_path().parent.exists()
-
-    def test_db_status_no_psql(self):
-        """Test db status handles missing psql gracefully."""
-        with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = FileNotFoundError("psql not found")
-            result = runner.invoke(app, ["db", "schema", "status", "dev"])
-            # Should handle error gracefully
-            assert (
-                result.exit_code != 0
-                or "psql" in result.output.lower()
-                or "error" in result.output.lower()
-            )
-
-    def test_db_schema_reset_requires_confirmation(self):
-        """Test db schema reset aborts without confirmation."""
-        result = runner.invoke(app, ["db", "schema", "reset", "dev"], input="n\n")
-        # Should abort, or exit early if db doesn't exist (which is also safe)
-        output_lower = result.output.lower()
-        assert (
-            "abort" in output_lower
-            or "does not exist" in output_lower
-            or result.exit_code != 0
-        )
-
-    def test_db_backup_creates_file(self):
-        """Test db backup command structure."""
-        result = runner.invoke(app, ["db", "data", "backup", "--help"])
-        assert result.exit_code == 0
-        assert "--output" in result.output or "-o" in result.output
-
-    def test_db_restore_requires_input(self):
-        """Test db restore requires --input file."""
-        result = runner.invoke(app, ["db", "data", "restore", "dev"])
-        # Should fail without --input
-        assert result.exit_code != 0 or "input" in result.output.lower()
-
-
-class TestCLIPG:
-    """Tests for PostgreSQL service commands."""
-
-    def test_pg_help(self):
-        """Test pg --help."""
-        result = runner.invoke(app, ["pg", "--help"])
-        assert result.exit_code == 0
-        assert "start" in result.output
-        assert "stop" in result.output
-        assert "status" in result.output
-        assert "logs" in result.output
-        assert "init" in result.output
-        assert "start-local" in result.output
-
-    def test_pg_status_handles_missing_pg(self):
-        """Test pg status handles missing PostgreSQL gracefully."""
-        result = runner.invoke(app, ["pg", "status"])
-        assert result.exit_code == 0
-        # Should show status regardless of PostgreSQL availability
-        assert "PostgreSQL" in result.output
-
-    def test_pg_logs_help(self):
-        """Test pg logs --help."""
-        result = runner.invoke(app, ["pg", "logs", "--help"])
-        assert result.exit_code == 0
-        assert "--follow" in result.output or "-f" in result.output
-        assert "--lines" in result.output or "-n" in result.output
-
-    def test_pg_create_removed(self):
-        """Test pg create was removed."""
-        result = runner.invoke(app, ["pg", "create", "dev"])
-        assert result.exit_code != 0
-        assert "No such command" in result.output or "no such option" in result.output
-
-    def test_pg_delete_removed(self):
-        """Test pg delete was removed."""
-        result = runner.invoke(app, ["pg", "delete", "dev"])
-        assert result.exit_code != 0
-        assert "No such command" in result.output or "no such option" in result.output
-
-    def test_pg_init_help(self):
-        """Test pg init --help."""
-        result = runner.invoke(app, ["pg", "init", "--help"])
-        assert result.exit_code == 0
-        assert "dev" in result.output
-        assert "test" in result.output
-        assert "--force" in result.output or "-f" in result.output
-
-    def test_pg_init_rejects_prod(self):
-        """Test pg init rejects prod environment."""
-        result = runner.invoke(app, ["pg", "init", "prod"])
-        assert result.exit_code != 0
-        assert "prod" in result.output.lower() or "cannot" in result.output.lower()
-
-    def test_pg_init_uses_configured_superuser(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test pg init creates the local cluster with the configured DB user."""
-        import daylily_tapdb.cli.pg as pg_mod
-
-        data_dir = tmp_path / "pgdata"
-        calls: list[list[str]] = []
-
-        def _fake_run(cmd, capture_output=True, text=True, timeout=60):
-            calls.append(list(cmd))
-            return subprocess.CompletedProcess(cmd, 0, "", "")
-
-        monkeypatch.setattr(pg_mod, "_get_postgres_data_dir", lambda _env: data_dir)
-        monkeypatch.setattr(pg_mod.shutil, "which", lambda _name: "/usr/bin/initdb")
-        monkeypatch.setattr(
-            pg_mod,
-            "get_db_config_for_env",
-            lambda _env: {
-                "user": "postgres",
-                "host": "localhost",
-                "port": "5533",
-            },
-        )
-        monkeypatch.setattr(pg_mod.subprocess, "run", _fake_run)
-
-        result = runner.invoke(app, ["pg", "init", "dev"])
-
-        assert result.exit_code == 0
-        assert calls == [
             [
-                "/usr/bin/initdb",
-                "-D",
-                str(data_dir),
-                "--no-locale",
-                "-E",
-                "UTF8",
-                "-U",
-                "postgres",
-            ]
-        ]
-
-    def test_pg_start_local_help(self):
-        """Test pg start-local --help."""
-        result = runner.invoke(app, ["pg", "start-local", "--help"])
-        assert result.exit_code == 0
-        assert "--port" in result.output or "-p" in result.output
-
-    def test_pg_stop_local_help(self):
-        """Test pg stop-local --help."""
-        result = runner.invoke(app, ["pg", "stop-local", "--help"])
-        assert result.exit_code == 0
-        assert "dev" in result.output
-
-    def test_pg_start_local_uses_namespaced_socket_dir(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test local startup passes explicit socket dir and localhost binding."""
-        import daylily_tapdb.cli.pg as pg_mod
-
-        data_dir = tmp_path / "pgdata"
-        data_dir.mkdir()
-        (data_dir / "PG_VERSION").write_text("16\n", encoding="utf-8")
-        (data_dir / "postgresql.conf").write_text(
-            "#shared_memory_type = mmap\ndynamic_shared_memory_type = posix\n",
-            encoding="utf-8",
-        )
-        log_file = tmp_path / "postgresql.log"
-        lock_file = tmp_path / "instance.lock"
-        socket_dir = tmp_path / "socket dir"
-
-        calls: list[list[str]] = []
-
-        def _fake_run(cmd, capture_output=True, text=True, timeout=30):
-            calls.append(list(cmd))
-            return subprocess.CompletedProcess(cmd, 0, "", "")
-
-        monkeypatch.setattr(pg_mod, "_get_postgres_data_dir", lambda _env: data_dir)
-        monkeypatch.setattr(pg_mod, "_get_postgres_log_file", lambda _env: log_file)
-        monkeypatch.setattr(pg_mod, "_get_instance_lock_file", lambda _env: lock_file)
-        monkeypatch.setattr(pg_mod, "_get_postgres_socket_dir", lambda _env: socket_dir)
-        monkeypatch.setattr(
-            pg_mod,
-            "get_db_config_for_env",
-            lambda _env: {
-                "port": "5533",
-                "host": "localhost",
-                "user": "test",
-                "unix_socket_dir": str(socket_dir),
-            },
-        )
-        monkeypatch.setattr(pg_mod, "_is_port_available", lambda _port: True)
-        monkeypatch.setattr(pg_mod.shutil, "which", lambda _name: "/usr/bin/pg_ctl")
-        monkeypatch.setattr(pg_mod.subprocess, "run", _fake_run)
-
-        result = runner.invoke(app, ["pg", "start-local", "dev"])
-
-        assert result.exit_code == 0
-        assert socket_dir.exists()
-        assert "Socket dir:" in result.output
-        assert calls
-        cmd = calls[0]
-        opts = cmd[cmd.index("-o") + 1]
-        assert "-p 5533" in opts
-        assert "-h localhost" in opts
-        assert f"-k '{socket_dir}'" in opts
-
-        lock_payload = json.loads(lock_file.read_text(encoding="utf-8"))
-        assert lock_payload["socket_dir"] == str(socket_dir)
-
-    def test_pg_start_local_sets_linux_shared_memory_to_mmap(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test Linux local startup forces mmap shared-memory settings."""
-        import daylily_tapdb.cli.pg as pg_mod
-
-        data_dir = tmp_path / "pgdata"
-        data_dir.mkdir()
-        (data_dir / "PG_VERSION").write_text("16\n", encoding="utf-8")
-        conf_path = data_dir / "postgresql.conf"
-        conf_path.write_text(
-            "#shared_memory_type = mmap\ndynamic_shared_memory_type = posix\n",
-            encoding="utf-8",
-        )
-        log_file = tmp_path / "postgresql.log"
-        lock_file = tmp_path / "instance.lock"
-        socket_dir = tmp_path / "socket-dir"
-
-        calls: list[list[str]] = []
-
-        def _fake_run(cmd, capture_output=True, text=True, timeout=30):
-            calls.append(list(cmd))
-            return subprocess.CompletedProcess(cmd, 0, "", "")
-
-        monkeypatch.setattr(pg_mod.platform, "system", lambda: "Linux")
-        monkeypatch.setattr(pg_mod, "_get_postgres_data_dir", lambda _env: data_dir)
-        monkeypatch.setattr(pg_mod, "_get_postgres_log_file", lambda _env: log_file)
-        monkeypatch.setattr(pg_mod, "_get_instance_lock_file", lambda _env: lock_file)
-        monkeypatch.setattr(pg_mod, "_get_postgres_socket_dir", lambda _env: socket_dir)
-        monkeypatch.setattr(
-            pg_mod,
-            "get_db_config_for_env",
-            lambda _env: {
-                "port": "5533",
-                "host": "localhost",
-                "user": "test",
-                "unix_socket_dir": str(socket_dir),
-            },
-        )
-        monkeypatch.setattr(pg_mod, "_is_port_available", lambda _port: True)
-        monkeypatch.setattr(pg_mod.shutil, "which", lambda _name: "/usr/bin/pg_ctl")
-        monkeypatch.setattr(pg_mod.subprocess, "run", _fake_run)
-
-        result = runner.invoke(app, ["pg", "start-local", "dev"])
-
-        assert result.exit_code == 0
-        assert calls
-        opts = calls[0][calls[0].index("-o") + 1]
-        assert "-p 5533" in opts
-        assert "-h localhost" in opts
-        assert f"-k {shlex.quote(str(socket_dir))}" in opts
-        conf_text = conf_path.read_text(encoding="utf-8")
-        assert "shared_memory_type = mmap" in conf_text
-        assert "dynamic_shared_memory_type = mmap" in conf_text
-
-    def test_pg_status_shows_effective_socket_dir(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Test pg status shows the local socket dir in operator-facing output."""
-        import daylily_tapdb.cli.pg as pg_mod
-
-        socket_dir = tmp_path / "pg-run"
-        monkeypatch.setattr(
-            pg_mod,
-            "get_db_config_for_env",
-            lambda _env: {
-                "host": "localhost",
-                "port": "5533",
-                "user": "test",
-                "unix_socket_dir": str(socket_dir),
-            },
-        )
-        monkeypatch.setattr(
-            pg_mod, "_get_postgres_data_dir", lambda _env: tmp_path / "data"
-        )
-        monkeypatch.setattr(
-            pg_mod, "_get_postgres_log_file", lambda _env: tmp_path / "postgresql.log"
-        )
-        monkeypatch.setattr(
-            pg_mod, "_get_instance_lock_file", lambda _env: tmp_path / "instance.lock"
-        )
-        monkeypatch.setattr(pg_mod, "_get_postgres_socket_dir", lambda _env: socket_dir)
-
-        def _fake_run(cmd, capture_output=True, timeout=5):
-            return subprocess.CompletedProcess(cmd, 1, b"", b"")
-
-        monkeypatch.setattr(pg_mod.subprocess, "run", _fake_run)
-
-        result = runner.invoke(app, ["pg", "status"])
-
-        assert result.exit_code == 0
-        out = _strip_ansi(result.output)
-        assert "Socket dir:" in out
-        assert "pg-run" in out
-
-
-class TestCLIDBSeed:
-    """Tests for database seeding commands."""
-
-    def test_db_seed_help(self):
-        """Test db seed --help."""
-        result = runner.invoke(app, ["db", "data", "seed", "--help"])
-        assert result.exit_code == 0
-        out = _strip_ansi(result.output)
-        assert "--config" in out or "-c" in out
-        assert "--dry-run" in out
-        assert "--skip-existing" in out or "--overwrite" in out
-
-    def test_db_validate_config_help(self):
-        """Test db validate-config --help."""
-        result = runner.invoke(app, ["db", "config", "validate", "--help"])
-        assert result.exit_code == 0
-        out = _strip_ansi(result.output)
-        assert "--config" in out or "-c" in out
-        assert "--strict" in out
-        assert "--json" in out
-
-    def test_db_validate_config_valid_minimal(self, tmp_path: Path):
-        """A minimal two-template config with a valid reference should pass."""
-        (tmp_path / "generic").mkdir()
-        (tmp_path / "action").mkdir()
-
-        (tmp_path / "action" / "core.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Create Note",
-                            "polymorphic_discriminator": "action_template",
-                            "category": "ACT",
-                            "type": "core",
-                            "subtype": "create-note",
-                            "version": "1.0",
-                            "instance_prefix": "ACT",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {},
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
+                "--config",
+                str(cfg_path),
+                "config",
+                "init",
+                "--client-id",
+                "atlas",
+                "--database-name",
+                "atlas-dayfly5",
+                "--owner-repo-name",
+                "lsmc-atlas",
+                "--domain-code",
+                "Z",
+                "--engine-type",
+                "local",
+                "--host",
+                "localhost",
+                "--port",
+                "5533",
+                "--ui-port",
+                "8911",
+                "--user",
+                "tapdb",
+                "--database",
+                "tapdb_dayfly5",
+                "--schema-name",
+                "tapdb_atlas_dayfly5",
+                "--safety-tier",
+                "shared",
+                "--destructive-operations",
+                "blocked",
+            ],
         )
 
-        (tmp_path / "generic" / "generic.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Generic Object",
-                            "polymorphic_discriminator": "generic_template",
-                            "category": "AGX",
-                            "type": "generic",
-                            "subtype": "client-generic-valid-minimal",
-                            "version": "1.0",
-                            "instance_prefix": "AGX",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {
-                                "action_imports": {
-                                    "create_note": "ACT/core/create-note/1.0"
-                                },
-                                "expected_inputs": [],
-                                "expected_outputs": [],
-                                "instantiation_layouts": [],
-                            },
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
+        assert result.exit_code == 0, result.output
+        root = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+        assert root["meta"]["config_version"] == 4
+        assert root["meta"]["client_id"] == "atlas"
+        assert root["target"]["database"] == "tapdb_dayfly5"
+        assert root["target"]["schema_name"] == "tapdb_atlas_dayfly5"
+        assert root["safety"] == {
+            "safety_tier": "shared",
+            "destructive_operations": "blocked",
+        }
+        assert "environments" not in root
+
+    def test_config_update_targets_single_target_and_safety_fields(self):
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "update",
+                "--host",
+                "localhost",
+                "--port",
+                "5544",
+                "--schema-name",
+                "tapdb_changed",
+                "--support-email",
+                "support@example.com",
+                "--safety-tier",
+                "production",
+                "--destructive-operations",
+                "blocked",
+            ],
         )
 
-        templates, issues = _validate_template_configs(tmp_path, strict=True)
-        errors = [i for i in issues if i.level == "error"]
-        assert not errors, f"Unexpected errors: {errors}"
-        assert len(templates) >= 2
-
-    def test_db_validate_config_valid_instantiation_layouts_child_templates_dict(
-        self, tmp_path: Path
-    ):
-        """Dict-format child_templates entries validate and ref-check."""
-        (tmp_path / "generic").mkdir()
-        (tmp_path / "action").mkdir()
-
-        (tmp_path / "action" / "core.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Create Note",
-                            "polymorphic_discriminator": "action_template",
-                            "category": "ACT",
-                            "type": "core",
-                            "subtype": "create-note",
-                            "version": "1.0",
-                            "instance_prefix": "ACT",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {},
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        (tmp_path / "generic" / "generic.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Generic Object",
-                            "polymorphic_discriminator": "generic_template",
-                            "category": "AGX",
-                            "type": "generic",
-                            "subtype": "client-generic-valid-layouts",
-                            "version": "1.0",
-                            "instance_prefix": "AGX",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {
-                                "instantiation_layouts": [
-                                    {
-                                        "relationship_type": "contains",
-                                        "child_templates": [
-                                            {
-                                                "template_code": "ACT/core/create-note/1.0",  # noqa: E501
-                                                "count": 2,
-                                                "name_pattern": "{parent_name}_child_{index}",  # noqa: E501
-                                            }
-                                        ],
-                                    }
-                                ]
-                            },
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        templates, issues = _validate_template_configs(tmp_path, strict=True)
-        errors = [i for i in issues if i.level == "error"]
-        assert not errors, f"Unexpected errors: {errors}"
-
-    def test_db_validate_config_missing_reference_in_instantiation_layouts_dict_strict_fails(  # noqa: E501
-        self, tmp_path: Path
-    ):
-        """Strict mode fails for missing refs in child_templates dicts."""
-        (tmp_path / "generic").mkdir()
-
-        (tmp_path / "generic" / "generic.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Generic Object",
-                            "polymorphic_discriminator": "generic_template",
-                            "category": "AGX",
-                            "type": "generic",
-                            "subtype": "client-generic-missing-ref-layouts",
-                            "version": "1.0",
-                            "instance_prefix": "AGX",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {
-                                "instantiation_layouts": [
-                                    {
-                                        "child_templates": [
-                                            {
-                                                "template_code": "ACT/core/create-note/1.0"  # noqa: E501
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        _templates, issues = _validate_template_configs(tmp_path, strict=True)
-        errors = [i for i in issues if i.level == "error"]
-        assert errors
-        msgs = " ".join(i.message.lower() for i in errors)
-        assert "referenced template" in msgs or "not found" in msgs
-
-    def test_db_validate_config_invalid_instantiation_layouts_bad_count(
-        self, tmp_path: Path
-    ):
-        """count must be >= 1 for dict-format child_templates entries."""
-        (tmp_path / "generic").mkdir()
-        (tmp_path / "action").mkdir()
-
-        (tmp_path / "action" / "core.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Create Note",
-                            "polymorphic_discriminator": "action_template",
-                            "category": "ACT",
-                            "type": "core",
-                            "subtype": "create-note",
-                            "version": "1.0",
-                            "instance_prefix": "ACT",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {},
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        (tmp_path / "generic" / "generic.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Generic Object",
-                            "polymorphic_discriminator": "generic_template",
-                            "category": "AGX",
-                            "type": "generic",
-                            "subtype": "client-generic-invalid-count",
-                            "version": "1.0",
-                            "instance_prefix": "AGX",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {
-                                "instantiation_layouts": [
-                                    {
-                                        "child_templates": [
-                                            {
-                                                "template_code": "ACT/core/create-note/1.0",  # noqa: E501
-                                                "count": 0,
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        _templates, issues = _validate_template_configs(tmp_path, strict=True)
-        errors = [i for i in issues if i.level == "error"]
-        assert errors
-        msgs = "\n".join(i.message.lower() for i in errors)
-        assert "instantiation_layouts" in msgs
-        assert "count" in msgs
-
-    def test_db_validate_config_invalid_instantiation_layouts_missing_template_code(
-        self, tmp_path: Path
-    ):
-        """Dict-format child_templates must include template_code."""
-        (tmp_path / "generic").mkdir()
-
-        (tmp_path / "generic" / "generic.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Generic Object",
-                            "polymorphic_discriminator": "generic_template",
-                            "category": "AGX",
-                            "type": "generic",
-                            "subtype": "client-generic-missing-template-code",
-                            "version": "1.0",
-                            "instance_prefix": "AGX",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {
-                                "instantiation_layouts": [
-                                    {"child_templates": [{"count": 1}]}
-                                ]
-                            },
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        _templates, issues = _validate_template_configs(tmp_path, strict=True)
-        errors = [i for i in issues if i.level == "error"]
-        assert errors
-        msgs = "\n".join(i.message.lower() for i in errors)
-        assert "instantiation_layouts" in msgs
-        assert "template_code" in msgs
-
-    def test_db_validate_config_missing_reference_strict_fails(self, tmp_path: Path):
-        """Strict mode should fail if a referenced template is not present."""
-        (tmp_path / "generic").mkdir()
-        (tmp_path / "generic" / "generic.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Generic Object",
-                            "polymorphic_discriminator": "generic_template",
-                            "category": "AGX",
-                            "type": "generic",
-                            "subtype": "client-generic-missing-ref-strict",
-                            "version": "1.0",
-                            "instance_prefix": "AGX",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {
-                                "action_imports": {
-                                    "create_note": "ACT/core/create-note/1.0"
-                                }
-                            },
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        _templates, issues = _validate_template_configs(tmp_path, strict=True)
-        errors = [i for i in issues if i.level == "error"]
-        assert errors
-        msgs = " ".join(i.message.lower() for i in errors)
-        assert "referenced template" in msgs or "not found" in msgs
-
-    def test_db_validate_config_missing_reference_non_strict_warns(
-        self, tmp_path: Path
-    ):
-        """Non-strict mode should warn but not error for missing references."""
-        (tmp_path / "generic").mkdir()
-        (tmp_path / "generic" / "generic.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Generic Object",
-                            "polymorphic_discriminator": "generic_template",
-                            "category": "AGX",
-                            "type": "generic",
-                            "subtype": "client-generic-missing-ref-nonstrict",
-                            "version": "1.0",
-                            "instance_prefix": "AGX",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {
-                                "action_imports": {
-                                    "create_note": "ACT/core/create-note/1.0"
-                                }
-                            },
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        _templates, issues = _validate_template_configs(tmp_path, strict=False)
-        errors = [i for i in issues if i.level == "error"]
-        warnings = [i for i in issues if i.level == "warning"]
-        assert not errors, f"Unexpected errors: {errors}"
-        assert warnings  # missing ref is a warning in non-strict
-
-    def test_db_validate_config_invalid_instance_prefix_fails(self, tmp_path: Path):
-        """Validation should reject invalid TapDB instance prefixes."""
-        (tmp_path / "generic").mkdir()
-        (tmp_path / "generic" / "generic.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Generic Object",
-                            "polymorphic_discriminator": "generic_template",
-                            "category": "LS",
-                            "type": "generic",
-                            "subtype": "client-generic-invalid-prefix",
-                            "version": "1.0",
-                            "instance_prefix": "LS",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {},
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        _templates, issues = _validate_template_configs(tmp_path, strict=True)
-        errors = [i for i in issues if i.level == "error"]
-        assert errors
-        msgs = "\n".join(i.message for i in errors)
-        assert "Invalid TAPDB instance prefix" in msgs
-
-    def test_db_validate_config_merged_core_then_client_strict_ok(self, tmp_path: Path):
-        """Strict validate should consider TAPDB core templates with client config."""
-        (tmp_path / "generic").mkdir()
-        (tmp_path / "generic" / "custom.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Client Probe",
-                            "polymorphic_discriminator": "generic_template",
-                            "category": "AGX",
-                            "type": "generic",
-                            "subtype": "client-probe",
-                            "version": "1.0",
-                            "instance_prefix": "AGX",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {
-                                "action_imports": {
-                                    "uses_core_actor": "SYS/actor/system_user/1.0"
-                                }
-                            },
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        config_dirs = _resolve_seed_config_dirs(tmp_path)
-        templates, issues = _validate_template_configs(config_dirs, strict=True)
-        # Filter to only client-config errors (ignore pre-existing core config issues)
-        client_errors = [
-            i
-            for i in issues
-            if i.level == "error" and str(tmp_path) in (i.source_file or "")
-        ]
-        core_dir = _find_tapdb_core_config_dir().resolve()
-        assert not client_errors, f"Unexpected client errors: {client_errors}"
-        assert core_dir in [d.resolve() for d in config_dirs]
-
-    def test_db_validate_config_json_includes_ordered_config_dirs(self, tmp_path: Path):
-        """Merged config dirs should include core first, then client."""
-        (tmp_path / "generic").mkdir()
-        (tmp_path / "generic" / "custom.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Custom Generic",
-                            "polymorphic_discriminator": "generic_template",
-                            "category": "AGX",
-                            "type": "generic",
-                            "subtype": "custom-generic",
-                            "version": "1.0",
-                            "instance_prefix": "AGX",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {},
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        config_dirs = _resolve_seed_config_dirs(tmp_path)
-        templates, issues = _validate_template_configs(config_dirs, strict=False)
-        client_errors = [
-            i
-            for i in issues
-            if i.level == "error" and str(tmp_path) in (i.source_file or "")
-        ]
-        core_dir = _find_tapdb_core_config_dir().resolve()
-        assert not client_errors, f"Unexpected client errors: {client_errors}"
-        resolved = [d.resolve() for d in config_dirs]
-        assert resolved[0] == core_dir
-        assert tmp_path.resolve() in resolved
-
-    def test_db_validate_config_fails_on_core_client_duplicate_key(
-        self, tmp_path: Path
-    ):
-        """Validation should hard-fail on duplicate template keys across sources."""
-        (tmp_path / "actor").mkdir()
-        client_file = tmp_path / "actor" / "actor.json"
-        client_file.write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Client Duplicate System User",
-                            "polymorphic_discriminator": "actor_template",
-                            "category": "SYS",
-                            "type": "actor",
-                            "subtype": "system_user",
-                            "version": "1.0",
-                            "instance_prefix": "SYS",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {},
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        config_dirs = _resolve_seed_config_dirs(tmp_path)
-        _templates, issues = _validate_template_configs(config_dirs, strict=True)
-        dup_errors = [
-            i
-            for i in issues
-            if i.level == "error" and "duplicate template key" in i.message.lower()
-        ]
-        assert dup_errors
-        # The duplicate error message references the first definition (core file)
-        core_generic = str(
-            _find_tapdb_core_config_dir().resolve() / "actor" / "actor.json"
-        ).lower()
-        all_messages = " ".join(i.message.lower() for i in dup_errors)
-        assert core_generic in all_messages
-
-    def test_db_setup_help(self):
-        """Test db setup --help."""
-        result = runner.invoke(app, ["db", "setup", "--help"])
-        assert result.exit_code == 0
-        assert "dev" in result.output
-        assert "--force" in result.output or "-f" in result.output
-
-    def test_find_config_dir(self):
-        """Test _find_config_dir locates the config directory."""
-        config_dir = _find_config_dir()
-        assert config_dir.exists()
-        assert (config_dir / "_metadata.json").exists() or len(
-            list(config_dir.glob("*.json"))
-        ) > 0
-
-    def test_find_tapdb_core_config_dir(self):
-        """Core TAPDB seed config should always be resolvable."""
-        core_dir = _find_tapdb_core_config_dir()
-        assert core_dir.exists()
-        assert (core_dir / "actor" / "actor.json").exists()
-        assert (core_dir / "generic" / "generic.json").exists()
-
-    def test_resolve_seed_config_dirs_includes_core(self, tmp_path: Path):
-        """Seed config resolution should include core + custom dirs without duplication."""
-        custom_dir = tmp_path / "custom-config"
-        custom_dir.mkdir()
-        dirs = _resolve_seed_config_dirs(custom_dir)
-        core_dir = _find_tapdb_core_config_dir().resolve()
-        assert dirs[0] == core_dir
-        assert custom_dir.resolve() in dirs
-        assert len(dirs) == len(set(dirs))
-
-    def test_resolve_seed_config_dirs_default_is_core_only(self):
-        """Without a client config override, only core seed config should load."""
-        dirs = _resolve_seed_config_dirs(None)
-        core_dir = _find_tapdb_core_config_dir().resolve()
-        assert dirs == [core_dir]
-
-    def test_load_template_configs(self):
-        """Test _load_template_configs loads templates from config files."""
-        config_dir = _find_config_dir()
-        templates = _load_template_configs(config_dir)
-        assert len(templates) > 0
-
-        # Check template structure
-        for t in templates:
-            assert "name" in t
-            assert "polymorphic_discriminator" in t
-            assert "category" in t
-            assert "type" in t
-            assert "subtype" in t
-            assert "version" in t
-
-    def test_load_template_configs_has_expected_types(self):
-        """Test loaded templates include expected categories."""
-        config_dir = _find_config_dir()
-        templates = _load_template_configs(config_dir)
-        categories = {t["category"] for t in templates}
-
-        assert categories == {"SYS", "MSG"}
-
-    def test_find_duplicate_template_keys(self):
-        """Duplicate template keys should be detected as hard errors."""
-        templates = [
-            {
-                "category": "generic",
-                "type": "generic",
-                "subtype": "generic",
-                "version": "1.0",
-                "_source_file": "/tmp/a.json",
-            },
-            {
-                "category": "generic",
-                "type": "generic",
-                "subtype": "generic",
-                "version": "1.0",
-                "_source_file": "/tmp/b.json",
-            },
-        ]
-        duplicates = _find_duplicate_template_keys(templates)
-        assert ("generic", "generic", "generic", "1.0") in duplicates
-        assert len(duplicates[("generic", "generic", "generic", "1.0")]) == 2
-
-    def test_db_seed_dry_run_fails_on_duplicate_template_keys(self, tmp_path: Path):
-        """db data seed should hard-fail when merged config sources clash."""
-        custom_generic_dir = tmp_path / "actor"
-        custom_generic_dir.mkdir(parents=True)
-        (custom_generic_dir / "actor.json").write_text(
-            json.dumps(
-                {
-                    "templates": [
-                        {
-                            "name": "Duplicate System User Actor",
-                            "polymorphic_discriminator": "actor_template",
-                            "category": "SYS",
-                            "type": "actor",
-                            "subtype": "system_user",
-                            "version": "1.0",
-                            "instance_prefix": "SYS",
-                            "is_singleton": False,
-                            "bstatus": "active",
-                            "json_addl": {},
-                        }
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        with (
-            patch("daylily_tapdb.cli.db._check_db_exists", return_value=True),
-            patch("daylily_tapdb.cli.db._schema_exists", return_value=True),
-        ):
-            result = runner.invoke(
-                app,
-                [
-                    "db",
-                    "data",
-                    "seed",
-                    "dev",
-                    "--dry-run",
-                    "--config",
-                    str(tmp_path),
-                ],
+        assert result.exit_code == 0, result.output
+        active_cfg = yaml.safe_load(
+            Path(cli_mod.active_context_overrides()["config_path"]).read_text(
+                encoding="utf-8"
             )
+        )
+        assert active_cfg["target"]["port"] == "5544"
+        assert active_cfg["target"]["schema_name"] == "tapdb_changed"
+        assert active_cfg["target"]["support_email"] == "support@example.com"
+        assert active_cfg["safety"]["safety_tier"] == "production"
+        assert active_cfg["safety"]["destructive_operations"] == "blocked"
+        assert "environments" not in active_cfg
+
+    def test_config_update_clear_is_limited_to_target_fields(self):
+        result = runner.invoke(app, ["config", "update", "--clear", "not_a_field"])
 
         assert result.exit_code != 0
-        output = _strip_ansi(result.output).lower()
-        assert "actor/actor.json" in output or "duplicate template" in output
-
-    def test_db_seed_dry_run(self):
-        """Test db seed --dry-run shows templates without inserting."""
-        result = runner.invoke(app, ["db", "data", "seed", "dev", "--dry-run"])
-        output_lower = result.output.lower()
-        # Should show templates or fail gracefully (no db)
-        assert (
-            "template" in output_lower
-            or "dry run" in output_lower
-            or "does not exist" in output_lower
-            or "not found" in output_lower
-        )
+        assert "Unknown target field" in str(result.exception)
 
 
-class TestEnvironmentEnum:
-    """Tests for Environment enum."""
+class TestExplicitTargetRuntime:
+    def test_environment_enum_has_only_explicit_target(self):
+        assert [item.value for item in Environment] == ["target"]
+        assert Environment("target") is Environment.target
 
-    def test_environment_values(self):
-        """Test Environment enum has expected values."""
-        assert Environment.dev.value == "dev"
-        assert Environment.test.value == "test"
-        assert Environment.prod.value == "prod"
+    def test_db_config_loader_ignores_ambient_legacy_env(self, monkeypatch):
+        monkeypatch.setenv("TAPDB_ENV", "prod")
+        monkeypatch.setenv("TAPDB_DEV_HOST", "wrong.example.com")
+        monkeypatch.setenv("PGPORT", "9999")
 
-    def test_environment_from_string(self):
-        """Test creating Environment from string."""
-        assert Environment("dev") == Environment.dev
-        assert Environment("test") == Environment.test
-        assert Environment("prod") == Environment.prod
+        cfg = _get_db_config(Environment.target)
 
+        assert cfg["client_id"] == "testclient"
+        assert cfg["database_name"] == "testdb"
+        assert cfg["host"] == "localhost"
+        assert cfg["port"] == "5533"
+        assert cfg["schema_name"] == "tapdb_testdb"
 
-class TestCLIIntegration:
-    """End-to-end integration tests (require PostgreSQL)."""
+    def test_db_create_rejects_old_positional_env(self):
+        result = runner.invoke(app, ["db", "create", "dev"])
 
-    @pytest.fixture
-    def skip_if_no_postgres(self):
-        """Skip test if PostgreSQL is not available."""
-        try:
-            result = subprocess.run(
-                ["pg_isready", "-q"],
-                capture_output=True,
-                timeout=5,
-            )
-            if result.returncode != 0:
-                pytest.skip("PostgreSQL is not running")
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            pytest.skip("PostgreSQL tools not available")
+        assert result.exit_code == 2
+        assert "unexpected extra argument" in result.output.lower()
 
-    def test_db_status_with_postgres(self, skip_if_no_postgres):
-        """Test db status with real PostgreSQL."""
-        result = runner.invoke(app, ["db", "schema", "status", "dev"])
-        # May succeed or fail depending on database existence
-        assert "tapdb_dev" in result.output or "error" in result.output.lower()
+    def test_db_help_has_no_dev_prod_target_selector(self):
+        result = runner.invoke(app, ["db", "--help"])
 
-    def test_pg_status_with_postgres(self, skip_if_no_postgres):
-        """Test pg status with real PostgreSQL."""
-        result = runner.invoke(app, ["pg", "status"])
         assert result.exit_code == 0
-        assert "running" in result.output
+        out = _strip(result.output).lower()
+        assert "--env" not in out
+        assert "dev|test|prod" not in out
+
+    def test_pg_help_has_no_env_target_selector(self):
+        result = runner.invoke(app, ["pg", "--help"])
+
+        assert result.exit_code == 0
+        out = _strip(result.output).lower()
+        assert "--env" not in out
+        assert "dev|test|prod" not in out
 
 
-class TestCLISubprocess:
-    """Tests that verify CLI works via subprocess (true integration)."""
+class TestBootstrapCLI:
+    def test_bootstrap_local_uses_explicit_target(self, tmp_path: Path):
+        cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+        calls: list[tuple[str, object]] = []
 
-    def test_cli_module_invocation(self):
-        """Test CLI can be invoked as module."""
-        result = subprocess.run(
-            [sys.executable, "-m", "daylily_tapdb.cli", "--help"],
-            capture_output=True,
-            text=True,
-            timeout=10,
+        def _record(name: str):
+            def inner(*args, **kwargs):
+                calls.append((name, kwargs.get("env")))
+
+            return inner
+
+        with (
+            patch("daylily_tapdb.cli.pg.pg_init", _record("pg_init")),
+            patch("daylily_tapdb.cli.pg.pg_start_local", _record("pg_start_local")),
+            patch("daylily_tapdb.cli.db.create_database", _record("create_database")),
+            patch("daylily_tapdb.cli.db.apply_schema", _record("apply_schema")),
+            patch("daylily_tapdb.cli.db.run_migrations", _record("run_migrations")),
+            patch("daylily_tapdb.cli.db.seed_templates", _record("seed_templates")),
+            patch(
+                "daylily_tapdb.cli.db._create_default_admin",
+                _record("create_default_admin"),
+            ),
+        ):
+            fresh_app = build_app()
+            result = runner.invoke(
+                fresh_app,
+                ["--config", str(cfg_path), "bootstrap", "local", "--no-gui"],
+            )
+
+        assert result.exit_code == 0, result.output
+        env_calls = {name: env for name, env in calls if env is not None}
+        assert env_calls == {
+            "create_database": Environment.target,
+            "apply_schema": Environment.target,
+            "run_migrations": Environment.target,
+            "seed_templates": Environment.target,
+            "create_default_admin": Environment.target,
+        }
+
+    def test_bootstrap_local_rejects_old_env_option(self, tmp_path: Path):
+        cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+
+        result = runner.invoke(
+            app,
+            ["--config", str(cfg_path), "bootstrap", "local", "--env", "dev"],
         )
-        assert result.returncode == 0
-        assert "TAPDB" in result.stdout
 
-    def test_cli_db_help_subprocess(self):
-        """Test db subcommand via subprocess."""
-        result = subprocess.run(
-            [sys.executable, "-m", "daylily_tapdb.cli", "db", "--help"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        assert result.returncode == 0
-        assert "create" in result.stdout
-        assert "schema" in result.stdout
-
-    def test_cli_pg_help_subprocess(self):
-        """Test pg subcommand via subprocess."""
-        result = subprocess.run(
-            [sys.executable, "-m", "daylily_tapdb.cli", "pg", "--help"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        assert result.returncode == 0
-        assert "start" in result.stdout
-        assert "status" in result.stdout
+        assert result.exit_code == 2
+        assert "No such option" in result.output

--- a/tests/test_cli_cognito_floor_lift.py
+++ b/tests/test_cli_cognito_floor_lift.py
@@ -1,15 +1,18 @@
+"""Cognito CLI coverage for the explicit-target TapDB contract."""
+
 from __future__ import annotations
 
-import builtins
-import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-import typer
+import yaml
 from typer.testing import CliRunner
 
 import daylily_tapdb.cli.cognito as cognito_mod
+from daylily_tapdb.cli import app
+from daylily_tapdb.cli.context import clear_cli_context, set_cli_context
 from daylily_tapdb.cli.db import Environment
 
 runner = CliRunner()
@@ -38,16 +41,70 @@ class _FakeConn:
         return _Scope()
 
 
-def test_cognito_detect_running_ui_port_branches(
+def _write_config(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    domain_registry = path.parent / "domain_code_registry.json"
+    prefix_registry = path.parent / "prefix_ownership_registry.json"
+    domain_registry.write_text(
+        '{"version":"0.4.0","domains":{"Z":{"name":"test"}}}\n',
+        encoding="utf-8",
+    )
+    prefix_registry.write_text(
+        (
+            '{"version":"0.4.0","ownership":{"Z":{'
+            '"TPX":{"issuer_app_code":"daylily-tapdb"},'
+            '"EDG":{"issuer_app_code":"daylily-tapdb"},'
+            '"ADT":{"issuer_app_code":"daylily-tapdb"},'
+            '"SYS":{"issuer_app_code":"daylily-tapdb"},'
+            '"MSG":{"issuer_app_code":"daylily-tapdb"}}}}\n'
+        ),
+        encoding="utf-8",
+    )
+    path.write_text(
+        "meta:\n"
+        "  config_version: 4\n"
+        "  client_id: testclient\n"
+        "  database_name: testdb\n"
+        "  owner_repo_name: daylily-tapdb\n"
+        f"  domain_registry_path: {domain_registry}\n"
+        f"  prefix_ownership_registry_path: {prefix_registry}\n"
+        "target:\n"
+        "  engine_type: local\n"
+        "  host: localhost\n"
+        "  port: '5533'\n"
+        "  ui_port: '8911'\n"
+        "  domain_code: Z\n"
+        "  user: tapdb\n"
+        "  password: filepw\n"
+        "  database: tapdb_shared\n"
+        "  schema_name: tapdb_testdb\n"
+        "  cognito_user_pool_id: ''\n"
+        "safety:\n"
+        "  safety_tier: shared\n"
+        "  destructive_operations: confirm_required\n",
+        encoding="utf-8",
+    )
+    os.chmod(path, 0o600)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _explicit_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+    clear_cli_context()
+    set_cli_context(config_path=cfg_path)
+    yield cfg_path
+    clear_cli_context()
+
+
+def test_detect_running_ui_port_branches(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     pid_file = tmp_path / "ui.pid"
-    monkeypatch.setattr(cognito_mod, "_ui_pid_file_for_env", lambda _env: pid_file)
+    monkeypatch.setattr(cognito_mod, "_ui_pid_file", lambda: pid_file)
 
-    assert cognito_mod._detect_running_ui_port(Environment.dev) == (
-        None,
-        "ui not running",
-    )
+    assert cognito_mod._detect_running_ui_port() == (None, "ui not running")
 
     pid_file.write_text("1234\n", encoding="utf-8")
     monkeypatch.setattr(
@@ -55,44 +112,9 @@ def test_cognito_detect_running_ui_port_branches(
         "kill",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(ProcessLookupError()),
     )
-    assert cognito_mod._detect_running_ui_port(Environment.dev) == (
-        None,
-        "ui pid missing/stale",
-    )
+    assert cognito_mod._detect_running_ui_port() == (None, "ui pid missing/stale")
 
     monkeypatch.setattr(cognito_mod.os, "kill", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        cognito_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("ps unavailable")),
-    )
-    assert cognito_mod._detect_running_ui_port(Environment.dev) == (
-        None,
-        "could not inspect ui process",
-    )
-
-    monkeypatch.setattr(
-        cognito_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="", stderr=""),
-    )
-    assert cognito_mod._detect_running_ui_port(Environment.dev) == (
-        None,
-        "could not inspect ui process",
-    )
-
-    monkeypatch.setattr(
-        cognito_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(
-            returncode=0, stdout="python -m uvicorn", stderr=""
-        ),
-    )
-    assert cognito_mod._detect_running_ui_port(Environment.dev) == (
-        None,
-        "ui process port not detected",
-    )
-
     monkeypatch.setattr(
         cognito_mod.subprocess,
         "run",
@@ -100,748 +122,191 @@ def test_cognito_detect_running_ui_port_branches(
             returncode=0, stdout="uvicorn --port 9443", stderr=""
         ),
     )
-    assert cognito_mod._detect_running_ui_port(Environment.dev) == (
-        9443,
-        "running ui process",
-    )
+    assert cognito_mod._detect_running_ui_port() == (9443, "running ui process")
 
 
-def test_cognito_resolve_expected_ui_port(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_expected_ui_port_uses_target_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert cognito_mod._resolve_expected_ui_port() == (8911, "config target.ui_port")
+
+    monkeypatch.setattr(cognito_mod, "get_db_config", lambda: {"ui_port": ""})
     monkeypatch.setattr(
-        cognito_mod, "get_db_config_for_env", lambda _env: {"ui_port": "9443"}
+        cognito_mod, "_detect_running_ui_port", lambda: (9555, "ui process")
     )
-    assert cognito_mod._resolve_expected_ui_port(Environment.dev) == (
-        9443,
-        "config environments.dev.ui_port",
-    )
+    assert cognito_mod._resolve_expected_ui_port() == (9555, "ui process")
 
+
+def test_validate_bound_cognito_uris_uses_explicit_target_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(
-        cognito_mod, "get_db_config_for_env", lambda _env: {"ui_port": ""}
-    )
-    monkeypatch.setattr(
-        cognito_mod, "_detect_running_ui_port", lambda _env: (9555, "ui process")
-    )
-    assert cognito_mod._resolve_expected_ui_port(Environment.dev) == (
-        9555,
-        "ui process",
+        cognito_mod,
+        "_resolve_expected_ui_port",
+        lambda: (8911, "config target.ui_port"),
     )
 
-    monkeypatch.setattr(
-        cognito_mod, "_detect_running_ui_port", lambda _env: (None, "ui not running")
-    )
-    assert cognito_mod._resolve_expected_ui_port(Environment.dev) == (
-        cognito_mod.DEFAULT_COGNITO_CALLBACK_PORT,
-        "default (ui not running)",
-    )
-
-
-def test_cognito_validate_bound_cognito_uris(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        cognito_mod, "_resolve_expected_ui_port", lambda _env: (8911, "config")
+    expected_port, source, errors, notices = cognito_mod._validate_bound_cognito_uris(
+        {
+            "COGNITO_CALLBACK_URL": "https://localhost:8911/auth/callback",
+            "COGNITO_LOGOUT_URL": "https://localhost:9443/",
+            "COGNITO_REDIRECT_URI": "http://localhost:8911/auth/callback",
+        }
     )
 
-    expected_port, port_source, errors, notices = (
-        cognito_mod._validate_bound_cognito_uris(
-            Environment.dev,
-            {},
-        )
-    )
-    assert (expected_port, port_source, errors, notices) == (8911, "config", [], [])
-
-    values = {
-        "COGNITO_CALLBACK_URL": "not-a-uri",
-        "COGNITO_LOGOUT_URL": "http://localhost:8911/logout",
-        "COGNITO_REDIRECT_URIS": "https://localhost:9443/auth/callback https://example.com/ok",
-    }
-    _, _, errors, notices = cognito_mod._validate_bound_cognito_uris(
-        Environment.dev, values
-    )
-    assert any("invalid URI" in msg for msg in errors)
+    assert expected_port == 8911
+    assert source == "config target.ui_port"
+    assert any("port 9443" in msg for msg in errors)
     assert any("must use https" in msg for msg in errors)
-    assert any("does not match TAPDB UI port 8911" in msg for msg in errors)
-    assert notices == ["COGNITO_REDIRECT_URIS: https://example.com/ok"]
+    assert notices == ["COGNITO_CALLBACK_URL: https://localhost:8911/auth/callback"]
 
 
-def test_cognito_filename_pool_and_context_helpers(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    assert cognito_mod._sanitize_filename_part("TapDB App!") == "TapDB-App"
-    monkeypatch.setattr(
-        cognito_mod, "get_db_config_for_env", lambda _env: {"database": "TapDB Dev"}
-    )
-    assert cognito_mod._default_pool_name(Environment.dev) == "tapdb-tapdb-dev-users"
-    assert cognito_mod._parse_daycog_context_name("pool.us-east-1.app") == (
-        "pool",
-        "us-east-1",
-        "app",
-    )
-    assert cognito_mod._parse_daycog_context_name("invalid") == ("", "", "")
+def test_default_pool_name_uses_target_database() -> None:
+    assert cognito_mod._default_pool_name() == "tapdb-tapdb-shared-users"
 
 
-def test_cognito_load_contexts_and_match_helpers(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    path = tmp_path / "daycog.yaml"
-    monkeypatch.setattr(cognito_mod, "_daycog_config_path", lambda: path)
+def test_write_pool_id_to_explicit_target_config(tmp_path: Path) -> None:
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+    set_cli_context(config_path=cfg_path)
 
-    with pytest.raises(RuntimeError, match="config store not found"):
-        cognito_mod._load_daycog_contexts()
+    written = cognito_mod._write_pool_id_to_tapdb_config("usw2_pool")
 
-    path.write_text("- bad\n", encoding="utf-8")
-    with pytest.raises(RuntimeError, match="invalid daycog config store"):
-        cognito_mod._load_daycog_contexts()
-
-    path.write_text(
-        "active_context: tapdb-dev.us-east-1.tapdb\n"
-        "contexts:\n"
-        "  tapdb-dev.us-east-1:\n"
-        "    COGNITO_USER_POOL_ID: pool-1\n"
-        "    AWS_REGION: us-east-1\n"
-        "  tapdb-dev.us-east-1.tapdb:\n"
-        "    COGNITO_USER_POOL_ID: pool-1\n"
-        "    COGNITO_REGION: us-east-1\n"
-        "    COGNITO_CLIENT_NAME: tapdb\n"
-        "  ignored:\n"
-        "    value: null\n"
-        "  broken: nope\n",
-        encoding="utf-8",
-    )
-    active_name, contexts = cognito_mod._load_daycog_contexts()
-    assert active_name == "tapdb-dev.us-east-1.tapdb"
-    assert contexts["ignored"] == {}
-
-    score = cognito_mod._score_daycog_context_match(
-        "tapdb-dev.us-east-1.tapdb",
-        {"COGNITO_REGION": "us-east-1", "COGNITO_CLIENT_NAME": "tapdb"},
-        active_name=active_name,
-        prefer_region="us-east-1",
-        prefer_client_name="tapdb",
-    )
-    assert score[0] > 0
-
-    context_name, values = cognito_mod._find_pool_context_by_id(
-        "pool-1",
-        prefer_region="us-east-1",
-        prefer_client_name="tapdb",
-    )
-    assert context_name == "tapdb-dev.us-east-1.tapdb"
-    assert values["COGNITO_USER_POOL_ID"] == "pool-1"
-
-    with pytest.raises(RuntimeError, match="No Daycog stored context maps"):
-        cognito_mod._find_pool_context_by_id("missing-pool")
+    assert written == cfg_path
+    root = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    assert root["meta"]["config_version"] == 4
+    assert root["target"]["cognito_user_pool_id"] == "usw2_pool"
+    assert "environments" not in root
 
 
-def test_cognito_validate_required_client_name_and_pool_resolution(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    assert (
-        cognito_mod._validate_required_client_name(
-            {"COGNITO_CLIENT_NAME": "tapdb"},
-            context_label="env dev",
-        )
-        == "tapdb"
-    )
-    with pytest.raises(RuntimeError, match="must select Cognito app client name"):
-        cognito_mod._validate_required_client_name(
-            {"COGNITO_CLIENT_NAME": "wrong"},
-            context_label="env dev",
-        )
-
-    path = tmp_path / "daycog.yaml"
-    path.write_text(
-        "active_context: tapdb-dev.us-east-1.tapdb\n"
-        "contexts:\n"
-        "  tapdb-dev.us-east-1:\n"
-        "    COGNITO_USER_POOL_ID: pool-1\n"
-        "  tapdb-dev.us-east-1.tapdb:\n"
-        "    COGNITO_USER_POOL_ID: pool-2\n",
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(cognito_mod, "_daycog_config_path", lambda: path)
-    assert cognito_mod._resolve_daycog_pool_id_after_setup(
-        pool_name="tapdb-dev",
-        region="us-east-1",
-        client_name="tapdb",
-    ) == ("pool-1", "tapdb-dev.us-east-1")
-
-    path.write_text("active_context: missing\ncontexts: {}\n", encoding="utf-8")
-    with pytest.raises(RuntimeError, match="pool ID was not found"):
-        cognito_mod._resolve_daycog_pool_id_after_setup(
-            pool_name="tapdb-dev",
-            region="us-east-1",
-            client_name="tapdb",
-        )
-
-
-def test_cognito_write_pool_id_to_tapdb_config_and_json_fallback(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    config_path = tmp_path / "tapdb-config.yaml"
-    config_path.write_text(
-        "meta:\n"
-        "  config_version: 3\n"
-        "  client_id: atlas\n"
-        "  database_name: app\n"
-        "environments:\n"
-        "  dev:\n"
-        "    host: localhost\n",
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(cognito_mod, "get_config_path", lambda: config_path)
-    monkeypatch.setattr(
-        cognito_mod,
-        "resolve_context",
-        lambda **_kwargs: SimpleNamespace(client_id="atlas", database_name="app"),
-    )
-
-    written = cognito_mod._write_pool_id_to_tapdb_config(Environment.dev, "pool-1")
-    assert written == config_path
-    assert "cognito_user_pool_id: pool-1" in config_path.read_text(encoding="utf-8")
-
-    json_path = tmp_path / "tapdb-config.json"
-    monkeypatch.setattr(cognito_mod, "get_config_path", lambda: json_path)
-    monkeypatch.setattr(
-        cognito_mod,
-        "resolve_context",
-        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("no context")),
-    )
-
-    real_import = builtins.__import__
-
-    def _fake_import(name, *args, **kwargs):
-        if name == "yaml":
-            raise ModuleNotFoundError("yaml unavailable")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", _fake_import)
-    written = cognito_mod._write_pool_id_to_tapdb_config(Environment.test, "pool-2")
-    payload = json.loads(json_path.read_text(encoding="utf-8"))
-    assert written == json_path
-    assert payload["environments"]["test"]["cognito_user_pool_id"] == "pool-2"
-
-
-def test_cognito_run_daycog_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        cognito_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="ok\n", stderr=""),
-    )
-    assert cognito_mod._run_daycog(["status"]) == "ok"
-
-    monkeypatch.setattr(
-        cognito_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=2, stdout="", stderr="boom"),
-    )
-    with pytest.raises(RuntimeError, match="boom"):
-        cognito_mod._run_daycog(["status"])
-
-    printed: list[str] = []
-    monkeypatch.setattr(cognito_mod, "_run_daycog", lambda args, env=None: "printed")
-    monkeypatch.setattr(
-        cognito_mod.ccyo_out, "print_text", lambda text: printed.append(text)
-    )
-    cognito_mod._run_daycog_printing(["status"])
-    assert printed == ["printed"]
-
-
-def test_cognito_build_setup_args_and_finalize_binding(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_build_daycog_setup_args_uses_required_callback_shape() -> None:
     args = cognito_mod._build_daycog_setup_args(
         command="setup",
-        selected_pool_name="tapdb-dev",
-        region="us-east-1",
-        domain_prefix="tapdb-dev",
-        attach_domain=False,
+        selected_pool_name="tapdb-users",
+        region="us-west-2",
+        domain_prefix="tapdb-login",
+        attach_domain=True,
         port=8911,
         callback_path="auth/callback",
         oauth_flows="code",
-        scopes="openid,email",
-        idps="COGNITO",
+        scopes="openid,email,profile",
+        idps="COGNITO,Google",
         password_min_length=12,
-        mfa="off",
-        profile="profile-1",
+        mfa="optional",
+        profile="lsmc",
         client_name="tapdb",
         callback_url=None,
         logout_url=None,
         autoprovision=True,
-        generate_secret=True,
-        require_uppercase=False,
-        require_lowercase=False,
-        require_numbers=False,
+        generate_secret=False,
+        require_uppercase=True,
+        require_lowercase=True,
+        require_numbers=True,
         require_symbols=False,
-        tags="team=platform",
+        tags="owner=tapdb",
     )
-    assert "--domain-prefix" in args
-    assert "--no-attach-domain" in args
-    assert "--autoprovision" in args
-    assert "--generate-secret" in args
-    assert "--no-require-uppercase" in args
-    assert "--no-require-lowercase" in args
-    assert "--no-require-numbers" in args
+
+    assert args[:2] == ["setup", "--name"]
+    assert "--callback-url" in args
+    assert "https://localhost:8911/auth/callback" in args
+    assert "--client-name" in args
+    assert "tapdb" in args
+    assert "--attach-domain" in args
     assert "--no-require-symbols" in args
-    assert "--tags" in args
-
-    monkeypatch.setattr(
-        cognito_mod,
-        "_resolve_daycog_pool_id_after_setup",
-        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("missing pool")),
-    )
-    with pytest.raises(typer.Exit):
-        cognito_mod._finalize_setup_binding(
-            env=Environment.dev,
-            selected_pool_name="tapdb-dev",
-            selected_client_name="tapdb",
-            region="us-east-1",
-        )
-
-    monkeypatch.setattr(
-        cognito_mod,
-        "_resolve_daycog_pool_id_after_setup",
-        lambda **_kwargs: ("pool-1", "tapdb-dev.us-east-1"),
-    )
-    monkeypatch.setattr(
-        cognito_mod,
-        "_find_pool_context_by_id",
-        lambda *args, **kwargs: (
-            "tapdb-dev.us-east-1",
-            {"COGNITO_CLIENT_NAME": "tapdb"},
-        ),
-    )
-    monkeypatch.setattr(
-        cognito_mod,
-        "_write_pool_id_to_tapdb_config",
-        lambda *_args: Path("/tmp/tapdb-config.yaml"),
-    )
-    cognito_mod._finalize_setup_binding(
-        env=Environment.dev,
-        selected_pool_name="tapdb-dev",
-        selected_client_name="tapdb",
-        region="us-east-1",
-    )
 
 
-def test_cognito_bound_context_resolution_and_actor_user_row(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(cognito_mod, "get_db_config_for_env", lambda _env: {})
-    with pytest.raises(RuntimeError, match="No cognito_user_pool_id set"):
-        cognito_mod._resolve_bound_daycog_context(Environment.dev)
-
-    monkeypatch.setattr(
-        cognito_mod,
-        "get_db_config_for_env",
-        lambda _env: {
-            "cognito_user_pool_id": "pool-1",
-            "host": "db.local",
-            "port": "5432",
-            "user": "tapdb",
-            "password": "",
-            "database": "tapdb_dev",
-            "engine_type": "local",
-            "domain_code": "Z",
-            "owner_repo_name": "daylily-tapdb",
-        },
-    )
-    monkeypatch.setattr(
-        cognito_mod,
-        "_find_pool_context_by_id",
-        lambda *args, **kwargs: (
-            "tapdb-dev.us-east-1.tapdb",
-            {"COGNITO_CLIENT_NAME": "tapdb", "COGNITO_REGION": "us-east-1"},
-        ),
-    )
-    pool_id, context_name, values, proc_env = cognito_mod._resolve_bound_daycog_context(
-        Environment.dev
-    )
-    assert pool_id == "pool-1"
-    assert context_name == "tapdb-dev.us-east-1.tapdb"
-    assert proc_env["COGNITO_CLIENT_NAME"] == "tapdb"
-    assert values["COGNITO_REGION"] == "us-east-1"
-
-    monkeypatch.setattr(
-        cognito_mod,
-        "_resolve_bound_daycog_context",
-        lambda _env: (_ for _ in ()).throw(RuntimeError("not bound")),
-    )
+def test_pool_command_context_can_run_before_binding() -> None:
     selected_pool, proc_env, region, profile = (
         cognito_mod._resolve_pool_command_context(
-            Environment.dev,
-            pool_name=None,
-            region=None,
-            profile=None,
+            Environment.target,
+            region="us-west-2",
+            profile="lsmc",
         )
     )
-    assert selected_pool
+
+    assert selected_pool == "tapdb-tapdb-shared-users"
     assert proc_env is None
-    assert region == "us-east-1"
-    assert profile is None
-
-    monkeypatch.setattr(
-        cognito_mod,
-        "_resolve_bound_daycog_context",
-        lambda _env: (
-            "pool-1",
-            "tapdb-dev.us-east-1.tapdb",
-            {"COGNITO_REGION": "us-west-2", "AWS_PROFILE": "dev-profile"},
-            {"COGNITO_REGION": "us-west-2", "AWS_PROFILE": "dev-profile"},
-        ),
-    )
-    _, proc_env, region, profile = cognito_mod._resolve_pool_command_context(
-        Environment.dev,
-        pool_name="tapdb-dev",
-        region=None,
-        profile=None,
-    )
-    assert proc_env["AWS_PROFILE"] == "dev-profile"
     assert region == "us-west-2"
-    assert profile == "dev-profile"
+    assert profile == "lsmc"
 
-    with pytest.raises(RuntimeError, match="email is required"):
-        cognito_mod._ensure_actor_user_row(Environment.dev, email="", role="user")
-    with pytest.raises(RuntimeError, match="invalid role"):
-        cognito_mod._ensure_actor_user_row(
-            Environment.dev, email="alice@example.com", role="owner"
-        )
 
-    monkeypatch.setattr(cognito_mod, "TAPDBConnection", _FakeConn)
-    monkeypatch.setattr(
-        cognito_mod,
-        "create_or_get",
-        lambda *_args, **_kwargs: (SimpleNamespace(is_active=False), True),
-    )
-    with pytest.raises(RuntimeError, match="is inactive"):
-        cognito_mod._ensure_actor_user_row(
-            Environment.dev,
-            email="alice@example.com",
-            role="admin",
-        )
+def test_ensure_actor_user_row_passes_schema_to_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: dict[str, object] = {}
 
-    monkeypatch.setattr(
-        cognito_mod,
-        "create_or_get",
-        lambda *_args, **_kwargs: (SimpleNamespace(is_active=True), True),
-    )
+    def _fake_create_or_get(session, **kwargs):
+        _ = session
+        created.update(kwargs)
+        return SimpleNamespace(is_active=True), True
+
+    fake_conn = _FakeConn
+    monkeypatch.setattr(cognito_mod, "TAPDBConnection", fake_conn)
+    monkeypatch.setattr(cognito_mod, "create_or_get", _fake_create_or_get)
+
     cognito_mod._ensure_actor_user_row(
-        Environment.dev,
-        email="alice@example.com",
+        Environment.target,
+        email="Alice@Example.com",
         role="admin",
         display_name="Alice",
     )
 
+    assert created["email"] == "alice@example.com"
+    assert created["role"] == "admin"
 
-def test_cognito_setup_and_setup_with_google_branches(
+    with pytest.raises(RuntimeError, match="invalid role"):
+        cognito_mod._ensure_actor_user_row(
+            Environment.target, email="a@b.com", role="x"
+        )
+
+
+def test_cognito_bind_cli_has_no_env_positional(tmp_path: Path) -> None:
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+
+    ok = runner.invoke(
+        app, ["--config", str(cfg_path), "cognito", "bind", "--pool-id", "pool-1"]
+    )
+    assert ok.exit_code == 0, ok.output
+
+    legacy = runner.invoke(app, ["--config", str(cfg_path), "cognito", "status", "dev"])
+    assert legacy.exit_code == 2
+    assert "unexpected extra argument" in legacy.output.lower()
+
+
+def test_cognito_management_commands_delegate_to_daycog_without_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        cognito_mod, "get_db_config_for_env", lambda _env: {"ui_port": "8911"}
-    )
+    calls: list[tuple[list[str], object]] = []
 
-    result = runner.invoke(cognito_mod.cognito_app, ["setup", "dev", "--port", "9000"])
-    assert result.exit_code == 1
+    def _fake_daycog(args, env=None):
+        calls.append((args, env))
+        return "ok"
+
+    monkeypatch.setattr(cognito_mod, "_run_daycog", _fake_daycog)
 
     result = runner.invoke(
-        cognito_mod.cognito_app,
-        ["setup", "dev", "--client-name", "custom"],
-    )
-    assert result.exit_code == 1
-
-    captured: list[list[str]] = []
-    monkeypatch.setattr(
-        cognito_mod,
-        "_run_daycog",
-        lambda args, env=None: captured.append(list(args)) or "",
-    )
-    monkeypatch.setattr(cognito_mod, "_finalize_setup_binding", lambda **_kwargs: None)
-    result = runner.invoke(
-        cognito_mod.cognito_app,
+        app,
         [
-            "setup-with-google",
-            "dev",
-            "--google-client-json",
-            "/tmp/google.json",
-            "--google-scopes",
-            "openid profile",
+            "cognito",
+            "list-apps",
+            "--pool-name",
+            "pool",
+            "--region",
+            "us-west-2",
+            "--profile",
+            "lsmc",
         ],
     )
-    assert result.exit_code == 0
-    assert "--google-client-json" in captured[0]
-    assert "--google-scopes" in captured[0]
 
-    result = runner.invoke(
-        cognito_mod.cognito_app, ["setup-with-google", "dev", "--port", "9000"]
-    )
-    assert result.exit_code == 1
-    result = runner.invoke(
-        cognito_mod.cognito_app,
-        ["setup-with-google", "dev", "--client-name", "custom"],
-    )
-    assert result.exit_code == 1
-
-
-def test_cognito_status_and_management_command_branches(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(cognito_mod, "get_db_config_for_env", lambda _env: {})
-    result = runner.invoke(cognito_mod.cognito_app, ["status", "dev"])
-    assert result.exit_code == 1
-
-    monkeypatch.setattr(
-        cognito_mod,
-        "get_db_config_for_env",
-        lambda _env: {"cognito_user_pool_id": "pool-1"},
-    )
-    monkeypatch.setattr(
-        cognito_mod,
-        "_find_pool_context_by_id",
-        lambda *_args, **_kwargs: ("ctx", {"COGNITO_CLIENT_NAME": "wrong"}),
-    )
-    result = runner.invoke(cognito_mod.cognito_app, ["status", "dev"])
-    assert result.exit_code == 1
-
-    monkeypatch.setattr(
-        cognito_mod,
-        "_find_pool_context_by_id",
-        lambda *_args, **_kwargs: (
-            "ctx",
-            {
-                "COGNITO_CLIENT_NAME": "tapdb",
-                "COGNITO_CALLBACK_URL": "https://localhost:9999/auth/callback",
-            },
-        ),
-    )
-    monkeypatch.setattr(
-        cognito_mod,
-        "_validate_bound_cognito_uris",
-        lambda *_args, **_kwargs: (8911, "config", ["bad uri"], []),
-    )
-    monkeypatch.setattr(
-        cognito_mod, "_ui_pid_file_for_env", lambda _env: Path("/tmp/ui.pid")
-    )
-    result = runner.invoke(cognito_mod.cognito_app, ["status", "dev"])
-    assert result.exit_code == 1
-
-    monkeypatch.setattr(
-        cognito_mod,
-        "_validate_bound_cognito_uris",
-        lambda *_args, **_kwargs: (8911, "config", [], ["ok"]),
-    )
-    result = runner.invoke(cognito_mod.cognito_app, ["status", "dev"])
-    assert result.exit_code == 0
-
-    captured: list[list[str]] = []
-    monkeypatch.setattr(
-        cognito_mod,
-        "_resolve_pool_command_context",
-        lambda *_args, **_kwargs: (
-            "tapdb-dev",
-            {"AWS_PROFILE": "dev-profile"},
-            "us-east-1",
-            "dev-profile",
-        ),
-    )
-    monkeypatch.setattr(
-        cognito_mod,
-        "_run_daycog_printing",
-        lambda args, env=None: captured.append(list(args)),
-    )
-    runner.invoke(
-        cognito_mod.cognito_app,
-        [
-            "add-app",
-            "dev",
-            "--app-name",
-            "web",
-            "--callback-url",
-            "https://localhost:8911/auth/callback",
-            "--logout-url",
-            "https://localhost:8911/",
-            "--generate-secret",
-            "--set-default",
-        ],
-    )
-    assert "--logout-url" in captured[-1]
-    assert "--generate-secret" in captured[-1]
-    assert "--set-default" in captured[-1]
-
-    result = runner.invoke(cognito_mod.cognito_app, ["edit-app", "dev"])
-    assert result.exit_code == 1
-    captured.clear()
-    result = runner.invoke(
-        cognito_mod.cognito_app,
-        [
-            "edit-app",
-            "dev",
-            "--app-name",
-            "web",
-            "--client-id",
-            "client-1",
-            "--new-app-name",
-            "web-next",
-            "--callback-url",
-            "https://localhost:8911/auth/callback",
-            "--logout-url",
-            "https://localhost:8911/",
-            "--oauth-flows",
-            "code",
-            "--scopes",
-            "openid,email",
-            "--idp",
-            "COGNITO",
-            "--set-default",
-        ],
-    )
-    assert result.exit_code == 0
-    assert "--client-id" in captured[-1]
-    assert "--new-app-name" in captured[-1]
-
-    result = runner.invoke(cognito_mod.cognito_app, ["remove-app", "dev"])
-    assert result.exit_code == 1
-    captured.clear()
-    result = runner.invoke(
-        cognito_mod.cognito_app,
-        [
-            "remove-app",
-            "dev",
-            "--client-id",
-            "client-1",
-            "--force",
-            "--keep-config",
-        ],
-    )
-    assert result.exit_code == 0
-    assert "--client-id" in captured[-1]
-    assert "--force" in captured[-1]
-    assert "--keep-config" in captured[-1]
-
-    result = runner.invoke(cognito_mod.cognito_app, ["add-google-idp", "dev"])
-    assert result.exit_code == 1
-    captured.clear()
-    result = runner.invoke(
-        cognito_mod.cognito_app,
-        [
-            "add-google-idp",
-            "dev",
-            "--app-name",
-            "web",
-            "--google-client-id",
-            "gid",
-            "--google-client-secret",
-            "gsecret",
-            "--google-client-json",
-            "/tmp/google.json",
-        ],
-    )
-    assert result.exit_code == 0
-    assert "--google-client-json" in captured[-1]
-
-
-def test_cognito_fix_auth_flows_config_commands_and_add_user(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        cognito_mod,
-        "_resolve_bound_daycog_context",
-        lambda _env: (_ for _ in ()).throw(RuntimeError("not bound")),
-    )
-    result = runner.invoke(cognito_mod.cognito_app, ["fix-auth-flows", "dev"])
-    assert result.exit_code == 1
-
-    printed: list[list[str]] = []
-    monkeypatch.setattr(
-        cognito_mod,
-        "_resolve_bound_daycog_context",
-        lambda _env: (
-            "pool-1",
-            "ctx",
-            {"COGNITO_CLIENT_NAME": "tapdb"},
-            {"COGNITO_CLIENT_NAME": "tapdb"},
-        ),
-    )
-    monkeypatch.setattr(
-        cognito_mod,
-        "_run_daycog_printing",
-        lambda args, env=None: printed.append(list(args)),
-    )
-    result = runner.invoke(cognito_mod.cognito_app, ["fix-auth-flows", "dev"])
-    assert result.exit_code == 0
-    assert printed[-1] == ["fix-auth-flows"]
-
-    monkeypatch.setattr(
-        cognito_mod,
-        "_resolve_pool_command_context",
-        lambda *_args, **_kwargs: (
-            "tapdb-dev",
-            {"AWS_PROFILE": "dev-profile"},
-            "us-east-1",
-            "dev-profile",
-        ),
-    )
-    printed.clear()
-    assert (
-        runner.invoke(cognito_mod.cognito_app, ["config", "print", "dev"]).exit_code
-        == 0
-    )
-    assert printed[-1][:3] == ["config", "print", "--pool-name"]
-    assert (
-        runner.invoke(cognito_mod.cognito_app, ["config", "create", "dev"]).exit_code
-        == 0
-    )
-    assert printed[-1][:3] == ["config", "create", "--pool-name"]
-    assert "--profile" in printed[-1]
-    assert (
-        runner.invoke(cognito_mod.cognito_app, ["config", "update", "dev"]).exit_code
-        == 0
-    )
-    assert printed[-1][:3] == ["config", "update", "--pool-name"]
-    assert "--profile" in printed[-1]
-
-    result = runner.invoke(
-        cognito_mod.cognito_app,
-        [
-            "add-user",
-            "dev",
-            "alice@example.com",
-            "--password",
-            "secret",
-            "--role",
-            "owner",
-        ],
-    )
-    assert result.exit_code == 1
-
-    monkeypatch.setattr(
-        cognito_mod,
-        "_resolve_bound_daycog_context",
-        lambda _env: (_ for _ in ()).throw(RuntimeError("not bound")),
-    )
-    result = runner.invoke(
-        cognito_mod.cognito_app,
-        ["add-user", "dev", "alice@example.com", "--password", "secret"],
-    )
-    assert result.exit_code == 1
-
-    monkeypatch.setattr(
-        cognito_mod,
-        "_resolve_bound_daycog_context",
-        lambda _env: (
-            "pool-1",
-            "ctx",
-            {"COGNITO_CLIENT_NAME": "tapdb"},
-            {"COGNITO_CLIENT_NAME": "tapdb"},
-        ),
-    )
-    monkeypatch.setattr(cognito_mod, "_run_daycog", lambda args, env=None: "")
-    monkeypatch.setattr(
-        cognito_mod,
-        "_ensure_actor_user_row",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            RuntimeError("actor sync failed")
-        ),
-    )
-    result = runner.invoke(
-        cognito_mod.cognito_app,
-        ["add-user", "dev", "alice@example.com", "--password", "secret"],
-    )
-    assert result.exit_code == 1
+    assert result.exit_code == 0, result.output
+    assert calls
+    args, proc_env = calls[0]
+    assert args == [
+        "list-apps",
+        "--pool-name",
+        "pool",
+        "--region",
+        "us-west-2",
+        "--profile",
+        "lsmc",
+    ]
+    assert proc_env is None

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -1,7 +1,4 @@
-"""Coverage tests for CLI modules: __init__.py, pg.py, db.py, user.py.
-
-Uses the same hermetic test infrastructure as test_cli.py (set_cli_context + app).
-"""
+"""Focused CLI utility coverage for the explicit-target contract."""
 
 from __future__ import annotations
 
@@ -9,8 +6,7 @@ import os
 import re
 import socket
 from pathlib import Path
-from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
@@ -18,6 +14,7 @@ from typer.testing import CliRunner
 import daylily_tapdb.cli as cli_mod
 from daylily_tapdb.cli import app
 from daylily_tapdb.cli.context import clear_cli_context, set_cli_context
+from daylily_tapdb.cli.db import Environment
 
 runner = CliRunner()
 
@@ -28,16 +25,18 @@ def _strip(s: str) -> str:
     return _ANSI_RE.sub("", s)
 
 
-def _write_test_registries(base_dir: Path) -> tuple[Path, Path]:
-    domain_registry = base_dir / "domain_code_registry.json"
-    prefix_registry = base_dir / "prefix_ownership_registry.json"
+def _write_config(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    domain_registry = path.parent / "domain_code_registry.json"
+    prefix_registry = path.parent / "prefix_ownership_registry.json"
     domain_registry.write_text(
-        '{"version":"0.4.0","domains":{"Z":{"name":"test-localhost"}}}\n',
+        '{"version":"0.4.0","domains":{"Z":{"name":"test"}}}\n',
         encoding="utf-8",
     )
     prefix_registry.write_text(
         (
-            '{"version":"0.4.0","ownership":{"Z":{"TPX":{"issuer_app_code":"daylily-tapdb"},'
+            '{"version":"0.4.0","ownership":{"Z":{'
+            '"TPX":{"issuer_app_code":"daylily-tapdb"},'
             '"EDG":{"issuer_app_code":"daylily-tapdb"},'
             '"ADT":{"issuer_app_code":"daylily-tapdb"},'
             '"SYS":{"issuer_app_code":"daylily-tapdb"},'
@@ -45,386 +44,174 @@ def _write_test_registries(base_dir: Path) -> tuple[Path, Path]:
         ),
         encoding="utf-8",
     )
-    return domain_registry, prefix_registry
-
-
-@pytest.fixture(autouse=True)
-def _isolate_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Hermetic CLI environment matching test_cli.py pattern."""
-    monkeypatch.setenv("HOME", str(tmp_path))
-    cfg_path = (
-        tmp_path / ".config" / "tapdb" / "testclient" / "testdb" / "tapdb-config.yaml"
-    )
-    cfg_path.parent.mkdir(parents=True, exist_ok=True)
-    domain_registry, prefix_registry = _write_test_registries(tmp_path)
-    cfg_path.write_text(
+    path.write_text(
         "meta:\n"
-        "  config_version: 3\n"
+        "  config_version: 4\n"
         "  client_id: testclient\n"
         "  database_name: testdb\n"
         "  owner_repo_name: daylily-tapdb\n"
         f"  domain_registry_path: {domain_registry}\n"
         f"  prefix_ownership_registry_path: {prefix_registry}\n"
-        "environments:\n"
-        "  dev:\n"
-        "    engine_type: local\n"
-        "    host: localhost\n"
-        "    port: 5533\n"
-        "    ui_port: 8911\n"
-        "    domain_code: Z\n"
-        "    user: test\n"
-        '    password: ""\n'
-        "    database: tapdb_dev\n"
-        "    schema_name: tapdb_testdb_dev\n",
+        "target:\n"
+        "  engine_type: local\n"
+        "  host: localhost\n"
+        "  port: '5533'\n"
+        "  ui_port: '8911'\n"
+        "  domain_code: Z\n"
+        "  user: tapdb\n"
+        "  password: ''\n"
+        "  database: tapdb_shared\n"
+        "  schema_name: tapdb_testdb\n"
+        "safety:\n"
+        "  safety_tier: shared\n"
+        "  destructive_operations: confirm_required\n",
         encoding="utf-8",
     )
-    os.chmod(cfg_path, 0o600)
-    clear_cli_context()
-    set_cli_context(
-        client_id="testclient",
-        database_name="testdb",
-        env_name="dev",
-        config_path=cfg_path,
+    os.chmod(path, 0o600)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _explicit_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg_path = _write_config(
+        tmp_path / ".config" / "tapdb" / "testclient" / "testdb" / "tapdb-config.yaml"
     )
+    clear_cli_context()
+    set_cli_context(config_path=cfg_path)
     monkeypatch.setattr(cli_mod, "PID_FILE", tmp_path / "ui.pid")
     monkeypatch.setattr(cli_mod, "LOG_FILE", tmp_path / "ui.log")
-    yield
+    yield cfg_path
     clear_cli_context()
 
 
-# ────────────────────────────────────────────────────────────────────
-# cli/__init__.py — module-level utility functions
-# ────────────────────────────────────────────────────────────────────
+def test_port_is_available_detects_free_and_bound_ports():
+    from daylily_tapdb.cli import _port_is_available
+
+    assert _port_is_available("localhost", 59999) is True
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("localhost", 0))
+        port = sock.getsockname()[1]
+        sock.listen(1)
+        assert _port_is_available("localhost", port) is False
 
 
-class TestCliUtilFunctions:
-    def test_port_is_available_open(self):
-        from daylily_tapdb.cli import _port_is_available
+def test_pid_file_handling(tmp_path: Path):
+    from daylily_tapdb.cli import _get_pid
 
-        assert _port_is_available("localhost", 59999) is True
+    missing = tmp_path / "missing.pid"
+    assert _get_pid(missing) is None
 
-    def test_port_is_not_available(self):
-        from daylily_tapdb.cli import _port_is_available
+    current = tmp_path / "current.pid"
+    current.write_text(str(os.getpid()), encoding="utf-8")
+    assert _get_pid(current) == os.getpid()
 
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("localhost", 0))
-            port = s.getsockname()[1]
-            s.listen(1)
-            assert _port_is_available("localhost", port) is False
+    stale = tmp_path / "stale.pid"
+    stale.write_text("999999999", encoding="utf-8")
+    assert _get_pid(stale) is None
+    assert not stale.exists()
 
-    def test_get_pid_no_file(self, tmp_path):
-        from daylily_tapdb.cli import _get_pid
 
-        assert _get_pid(tmp_path / "nonexistent.pid") is None
+def test_admin_module_and_extras_are_discoverable(monkeypatch: pytest.MonkeyPatch):
+    from daylily_tapdb.cli import _find_admin_module, _require_admin_extras
 
-    def test_get_pid_valid_running(self, tmp_path):
-        from daylily_tapdb.cli import _get_pid
+    assert _find_admin_module() == "admin.main:app"
+    monkeypatch.setattr(cli_mod.importlib.util, "find_spec", lambda name: object())
+    _require_admin_extras()
 
-        pid_file = tmp_path / "test.pid"
-        pid_file.write_text(str(os.getpid()))
-        assert _get_pid(pid_file) == os.getpid()
 
-    def test_get_pid_stale(self, tmp_path):
-        from daylily_tapdb.cli import _get_pid
+def test_admin_extras_missing_reports_required_install(monkeypatch: pytest.MonkeyPatch):
+    from daylily_tapdb.cli import _require_admin_extras
 
-        pid_file = tmp_path / "test.pid"
-        pid_file.write_text("999999999")
-        assert _get_pid(pid_file) is None
-        assert not pid_file.exists()
+    monkeypatch.setattr(cli_mod.importlib.util, "find_spec", lambda name: None)
 
-    def test_get_pid_invalid_text(self, tmp_path):
-        from daylily_tapdb.cli import _get_pid
-
-        pid_file = tmp_path / "test.pid"
-        pid_file.write_text("not_a_number")
-        assert _get_pid(pid_file) is None
-
-    def test_port_conflict_details(self):
-        from daylily_tapdb.cli import _port_conflict_details
-
-        result = _port_conflict_details(99999)
-        assert isinstance(result, str)
-
-    def test_find_admin_module(self):
-        from daylily_tapdb.cli import _find_admin_module
-
-        result = _find_admin_module()
-        assert "admin" in result
-
-    def test_require_admin_extras_installed(self):
-        from daylily_tapdb.cli import _require_admin_extras
-
+    with pytest.raises(SystemExit):
         _require_admin_extras()
 
-    def test_require_admin_extras_missing(self):
-        from daylily_tapdb.cli import _require_admin_extras
-
-        with mock.patch.dict("sys.modules", {"fastapi": None}):
-            with mock.patch("importlib.util.find_spec", return_value=None):
-                with pytest.raises(SystemExit):
-                    _require_admin_extras()
-
-
-# ────────────────────────────────────────────────────────────────────
-# CLI commands via runner (context pre-set by _isolate_cli)
-# ────────────────────────────────────────────────────────────────────
-
-
-class TestCliCommandsWithContext:
-    """Tests that exercise CLI commands with context already set."""
-
-    def test_pg_help(self):
-        result = runner.invoke(app, ["pg", "--help"])
-        assert result.exit_code == 0
-
-    def test_db_help(self):
-        result = runner.invoke(app, ["db", "--help"])
-        assert result.exit_code == 0
 
-    def test_pg_init_no_pg(self):
-        with patch("shutil.which", return_value=None):
-            result = runner.invoke(app, ["pg", "init", "dev"])
-        assert result.exit_code in (0, 1)
-
-    def test_pg_status(self):
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="running")
-            result = runner.invoke(app, ["pg", "status"])
-        assert result.exit_code in (0, 1)
+def test_pg_paths_are_derived_from_explicit_context():
+    from daylily_tapdb.cli import active_context_overrides
+    from daylily_tapdb.cli.pg import (
+        _active_env,
+        _get_instance_lock_file,
+        _get_postgres_data_dir,
+        _get_postgres_log_file,
+        _get_postgres_socket_dir,
+    )
 
-    def test_pg_start(self):
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="")
-            result = runner.invoke(app, ["pg", "start"])
-        assert result.exit_code in (0, 1)
+    cfg_path = Path(active_context_overrides()["config_path"])
+    assert _active_env() is Environment.target
+    assert (
+        _get_postgres_data_dir(Environment.target)
+        == cfg_path.parent / "runtime" / "postgres" / "data"
+    )
+    assert (
+        _get_postgres_log_file(Environment.target)
+        == cfg_path.parent / "runtime" / "postgres" / "postgresql.log"
+    )
+    socket_dir = _get_postgres_socket_dir(Environment.target)
+    assert socket_dir.name.startswith("tapdb-pg-")
+    assert (
+        _get_instance_lock_file(Environment.target)
+        == cfg_path.parent / "runtime" / "locks" / "instance.lock"
+    )
 
-    def test_pg_stop(self):
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="")
-            result = runner.invoke(app, ["pg", "stop"])
-        assert result.exit_code in (0, 1)
 
-    def test_db_create(self):
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="")
-            result = runner.invoke(app, ["db", "create", "dev"])
-        assert result.exit_code in (0, 1)
+def test_ui_status_uses_explicit_runtime_paths():
+    result = runner.invoke(app, ["ui", "status"])
 
-    def test_db_delete_force(self):
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="")
-            result = runner.invoke(app, ["db", "delete", "dev", "--force"])
-        assert result.exit_code in (0, 1)
+    assert result.exit_code == 0
+    out = _strip(result.output)
+    assert "not running" in out
 
-    def test_db_schema_apply(self):
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="")
-            result = runner.invoke(app, ["db", "schema", "apply", "dev"])
-        assert result.exit_code in (0, 1)
 
-    def test_db_schema_status(self):
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="")
-            result = runner.invoke(app, ["db", "schema", "status", "dev"])
-        assert result.exit_code in (0, 1)
+def test_ui_stop_not_running_is_successful():
+    result = runner.invoke(app, ["ui", "stop"])
 
-    def test_db_config_validate(self):
-        result = runner.invoke(app, ["db", "config", "validate"])
-        assert result.exit_code in (0, 1)
+    assert result.exit_code == 0
+    assert "no ui server running" in _strip(result.output).lower()
 
-    def test_ui_status(self):
-        result = runner.invoke(app, ["ui", "status"])
-        assert result.exit_code in (0, 1)
 
-    def test_ui_stop_not_running(self):
-        result = runner.invoke(app, ["ui", "stop"])
-        assert result.exit_code in (0, 1)
+def test_db_and_pg_commands_require_config_when_context_cleared():
+    clear_cli_context()
 
-    def test_bootstrap_help(self):
-        result = runner.invoke(app, ["bootstrap", "--help"])
-        assert result.exit_code == 0
+    db_result = runner.invoke(app, ["db", "create"])
+    pg_result = runner.invoke(app, ["pg", "start-local"])
 
+    assert db_result.exit_code == 1
+    assert "TapDB config path is required" in _strip(db_result.output)
+    assert pg_result.exit_code != 0
+    assert "TapDB config path is required" in _strip(pg_result.output) or isinstance(
+        pg_result.exception, RuntimeError
+    )
 
-class TestCliCommandsNoContext:
-    """Tests verifying help surfaces remain available without runtime context."""
 
-    def test_pg_requires_config(self):
-        clear_cli_context()
-        result = runner.invoke(app, ["pg", "--help"])
-        assert result.exit_code == 0
-        assert "start-local" in _strip(result.output)
+def test_db_config_validate_remains_config_directory_only(tmp_path: Path):
+    cfg_dir = tmp_path / "templates"
+    cfg_dir.mkdir()
 
-    def test_db_requires_config(self):
-        clear_cli_context()
-        result = runner.invoke(app, ["db", "--help"])
-        assert result.exit_code == 0
-        assert "schema" in _strip(result.output)
+    with patch(
+        "daylily_tapdb.cli.db._validate_template_configs",
+        return_value=([], []),
+    ):
+        result = runner.invoke(
+            app,
+            ["db", "config", "validate", "--config", str(cfg_dir), "--json"],
+        )
 
+    assert result.exit_code == 0, result.output
+    assert '"templates": 0' in result.output
 
-# ────────────────────────────────────────────────────────────────────
-# cli/pg.py — helper functions tested directly
-# ────────────────────────────────────────────────────────────────────
 
+def test_pg_help_has_no_env_selector():
+    result = runner.invoke(app, ["pg", "--help"])
 
-class TestPgHelpers:
-    def test_get_postgres_data_dir_dev(self):
-        from daylily_tapdb.cli.pg import Environment, _get_postgres_data_dir
+    assert result.exit_code == 0
+    assert "--env" not in _strip(result.output)
 
-        result = _get_postgres_data_dir(Environment.dev)
-        assert "postgres" in str(result)
-        assert "data" in str(result)
 
-    def test_get_postgres_data_dir_prod(self):
-        from daylily_tapdb.cli.pg import Environment, _get_postgres_data_dir
+def test_db_help_has_no_env_selector():
+    result = runner.invoke(app, ["db", "--help"])
 
-        result = _get_postgres_data_dir(Environment.prod)
-        assert isinstance(result, Path)
-
-    def test_get_postgres_log_file_dev(self):
-        from daylily_tapdb.cli.pg import Environment, _get_postgres_log_file
-
-        result = _get_postgres_log_file(Environment.dev)
-        assert "postgresql.log" in str(result)
-
-    def test_get_postgres_log_file_prod(self):
-        from daylily_tapdb.cli.pg import Environment, _get_postgres_log_file
-
-        result = _get_postgres_log_file(Environment.prod)
-        assert "postgresql.log" in str(result)
-
-    def test_get_postgres_socket_dir_dev(self):
-        from daylily_tapdb.cli.pg import Environment, _get_postgres_socket_dir
-
-        result = _get_postgres_socket_dir(Environment.dev)
-        assert isinstance(result, Path)
-
-    def test_get_postgres_socket_dir_prod(self):
-        from daylily_tapdb.cli.pg import Environment, _get_postgres_socket_dir
-
-        result = _get_postgres_socket_dir(Environment.prod)
-        assert str(result) == "/var/run/postgresql"
-
-    def test_get_instance_lock_file_dev(self):
-        from daylily_tapdb.cli.pg import Environment, _get_instance_lock_file
-
-        result = _get_instance_lock_file(Environment.dev)
-        assert "instance.lock" in str(result)
-
-    def test_get_instance_lock_file_prod(self):
-        from daylily_tapdb.cli.pg import Environment, _get_instance_lock_file
-
-        result = _get_instance_lock_file(Environment.prod)
-        assert "prod" in str(result)
-
-    def test_build_pg_ctl_options(self):
-        from daylily_tapdb.cli.pg import _build_pg_ctl_options
-
-        result = _build_pg_ctl_options(5432, Path("/tmp/sockets"))
-        assert "-p 5432" in result
-        assert "localhost" in result
-
-    def test_port_conflict_details(self):
-        from daylily_tapdb.cli.pg import _port_conflict_details
-
-        result = _port_conflict_details(99999)
-        assert "port 99999" in result
-
-    def test_is_port_available_open(self):
-        from daylily_tapdb.cli.pg import _is_port_available
-
-        assert _is_port_available(59999) is True
-
-    def test_is_port_available_exception(self):
-        from daylily_tapdb.cli.pg import _is_port_available
-
-        with patch("subprocess.run", side_effect=Exception("fail")):
-            assert _is_port_available(5432) is True
-
-    def test_active_env_default(self):
-        from daylily_tapdb.cli.pg import Environment, _active_env
-
-        result = _active_env()
-        assert isinstance(result, Environment)
-
-    def test_get_pg_service_cmd(self):
-        from daylily_tapdb.cli.pg import _get_pg_service_cmd
-
-        method, start_cmd, stop_cmd, log_path = _get_pg_service_cmd()
-        assert isinstance(method, str)
-
-    def test_is_pg_running_not_found(self):
-        from daylily_tapdb.cli.pg import _is_pg_running
-
-        with patch("subprocess.run", side_effect=FileNotFoundError):
-            running, detail = _is_pg_running()
-            assert running is False
-            assert "not found" in detail
-
-    def test_is_pg_running_timeout(self):
-        import subprocess as sp
-
-        from daylily_tapdb.cli.pg import _is_pg_running
-
-        with patch("subprocess.run", side_effect=sp.TimeoutExpired("pg_isready", 5)):
-            running, detail = _is_pg_running()
-            assert running is False
-            assert "timeout" in detail
-
-    def test_pg_init_prod_rejected(self):
-        result = runner.invoke(app, ["pg", "init", "prod"])
-        assert result.exit_code == 1
-        assert "prod" in _strip(result.output).lower()
-
-    def test_pg_start_local_prod_rejected(self):
-        result = runner.invoke(app, ["pg", "start-local", "prod"])
-        assert result.exit_code == 1
-
-    def test_pg_stop_local_prod_rejected(self):
-        result = runner.invoke(app, ["pg", "stop-local", "prod"])
-        assert result.exit_code == 1
-
-
-# ────────────────────────────────────────────────────────────────────
-# cli/db.py — helper functions tested directly
-# ────────────────────────────────────────────────────────────────────
-
-
-class TestDbHelpers:
-    def test_ensure_dirs(self):
-        from daylily_tapdb.cli.db import _ensure_dirs
-
-        # _ensure_dirs() takes no args — uses get_config_path() internally
-        _ensure_dirs()
-
-    def test_find_schema_file(self):
-        from daylily_tapdb.cli.db import _find_schema_file
-
-        result = _find_schema_file()
-        assert result.name == "tapdb_schema.sql" or result is not None
-
-    def test_find_config_dir(self):
-        from daylily_tapdb.cli.db import _find_config_dir
-
-        result = _find_config_dir()
-        assert result is not None
-
-    def test_find_tapdb_core_config_dir(self):
-        from daylily_tapdb.cli.db import _find_tapdb_core_config_dir
-
-        result = _find_tapdb_core_config_dir()
-        assert result is not None
-
-    def test_get_db_config_dev(self):
-        from daylily_tapdb.cli.db import Environment, _get_db_config
-
-        cfg = _get_db_config(Environment.dev)
-        assert "host" in cfg
-        assert "port" in cfg
-
-    def test_db_delete_prod_without_force(self):
-        result = runner.invoke(app, ["db", "delete", "prod"])
-        assert result.exit_code in (0, 1)
-
-    def test_db_config_validate(self):
-        result = runner.invoke(app, ["db", "config", "validate"])
-        assert result.exit_code in (0, 1)
+    assert result.exit_code == 0
+    assert "--env" not in _strip(result.output)

--- a/tests/test_cli_db_floor_lift.py
+++ b/tests/test_cli_db_floor_lift.py
@@ -1,1052 +1,203 @@
+"""DB CLI unit coverage for the explicit-target model."""
+
 from __future__ import annotations
 
+import os
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 import typer
+from typer.testing import CliRunner
 
 import daylily_tapdb.cli.db as db_mod
+from daylily_tapdb.cli import app
+from daylily_tapdb.cli.context import clear_cli_context, set_cli_context
+
+runner = CliRunner()
 
 
-def _base_cfg(**overrides):
-    cfg = {
-        "engine_type": "local",
-        "host": "localhost",
-        "port": "5533",
-        "database": "tapdb_dev",
-        "schema_name": "tapdb_app",
-        "user": "tapdb",
-        "password": "",
-        "domain_code": "Z",
-        "owner_repo_name": "daylily-tapdb",
-        "domain_registry_path": "/tmp/domain_code_registry.json",
-        "prefix_ownership_registry_path": "/tmp/prefix_ownership_registry.json",
-        "region": "us-west-2",
-        "iam_auth": "true",
-    }
-    cfg.update(overrides)
-    return cfg
-
-
-class _FakeConn:
-    def __init__(self, session):
-        self.session = session
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        return False
-
-    def session_scope(self, commit: bool = False):
-        _ = commit
-        session = self.session
-
-        class _Scope:
-            def __enter__(self):
-                return session
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-        return _Scope()
-
-
-def test_db_normalization_and_schema_lookup_branches(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    with pytest.raises(ValueError, match="instance_prefix cannot be None"):
-        db_mod._normalize_instance_prefix(None)
-
-    with pytest.raises(ValueError, match="cannot be None"):
-        db_mod._normalize_meridian_prefix(None, "audit_log_euid_prefix")
-
-    assert db_mod._required_identity_prefixes(db_mod.Environment.dev) == {
-        "generic_template": "TPX",
-        "generic_instance_lineage": "EDG",
-        "audit_log": "ADT",
-    }
-
-    monkeypatch.setattr(db_mod, "_schema_root_candidates", lambda: [])
-    with pytest.raises(FileNotFoundError, match="Cannot find TAPDB schema root.$"):
-        db_mod._find_schema_root()
-    with pytest.raises(FileNotFoundError, match="schema/tapdb_schema.sql"):
-        db_mod._find_schema_file()
-
-
-def test_db_sequence_baseline_and_run_psql_branches(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    real_run_psql = db_mod._run_psql
-    monkeypatch.setattr(db_mod, "_normalize_instance_prefix", lambda _prefix: "ABCDE")
-    with pytest.raises(ValueError, match="Meridian-safe"):
-        db_mod._ensure_instance_prefix_sequence(db_mod.Environment.dev, "A1")
-
-    monkeypatch.setattr(
-        db_mod,
-        "_find_schema_root",
-        lambda **_kwargs: (_ for _ in ()).throw(FileNotFoundError()),
+def _write_config(path: Path, *, safety: str = "confirm_required") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    domain_registry = path.parent / "domain_code_registry.json"
+    prefix_registry = path.parent / "prefix_ownership_registry.json"
+    domain_registry.write_text(
+        '{"version":"0.4.0","domains":{"Z":{"name":"test"}}}\n',
+        encoding="utf-8",
     )
-    db_mod._write_migration_baseline(db_mod.Environment.dev)
-
-    migrations_root = tmp_path / "schema"
-    (migrations_root / "migrations").mkdir(parents=True)
-    monkeypatch.setattr(db_mod, "_find_schema_root", lambda **_kwargs: migrations_root)
-    db_mod._write_migration_baseline(db_mod.Environment.dev)
-
-    (migrations_root / "migrations" / "20260407_init.sql").write_text(
-        "-- migration\n", encoding="utf-8"
+    prefix_registry.write_text(
+        (
+            '{"version":"0.4.0","ownership":{"Z":{'
+            '"TPX":{"issuer_app_code":"daylily-tapdb"},'
+            '"EDG":{"issuer_app_code":"daylily-tapdb"},'
+            '"ADT":{"issuer_app_code":"daylily-tapdb"},'
+            '"SYS":{"issuer_app_code":"daylily-tapdb"},'
+            '"MSG":{"issuer_app_code":"daylily-tapdb"}}}}\n'
+        ),
+        encoding="utf-8",
     )
-    calls: list[str] = []
-
-    def _run_create_fail(_env, sql=None, file=None, database=None, user=None):
-        _ = (file, database, user)
-        calls.append(sql or "")
-        if "CREATE TABLE IF NOT EXISTS _tapdb_migrations" in (sql or ""):
-            return False, "create failed"
-        return True, ""
-
-    monkeypatch.setattr(db_mod, "_run_psql", _run_create_fail)
-    with pytest.raises(RuntimeError, match="create failed"):
-        db_mod._write_migration_baseline(db_mod.Environment.dev)
-
-    def _run_insert_fail(_env, sql=None, file=None, database=None, user=None):
-        _ = (file, database, user)
-        calls.append(sql or "")
-        if "INSERT INTO _tapdb_migrations" in (sql or ""):
-            return False, "insert failed"
-        return True, ""
-
-    monkeypatch.setattr(db_mod, "_run_psql", _run_insert_fail)
-    with pytest.raises(RuntimeError, match="insert failed"):
-        db_mod._write_migration_baseline(db_mod.Environment.dev)
-
-    monkeypatch.setattr(
-        db_mod, "_get_db_config", lambda _env: _base_cfg(password="secret")
+    path.write_text(
+        "meta:\n"
+        "  config_version: 4\n"
+        "  client_id: testclient\n"
+        "  database_name: testdb\n"
+        "  owner_repo_name: daylily-tapdb\n"
+        f"  domain_registry_path: {domain_registry}\n"
+        f"  prefix_ownership_registry_path: {prefix_registry}\n"
+        "target:\n"
+        "  engine_type: local\n"
+        "  host: localhost\n"
+        "  port: '5533'\n"
+        "  ui_port: '8911'\n"
+        "  domain_code: Z\n"
+        "  user: tapdb\n"
+        "  password: ''\n"
+        "  database: tapdb_shared\n"
+        "  schema_name: tapdb_testdb\n"
+        "safety:\n"
+        "  safety_tier: shared\n"
+        f"  destructive_operations: {safety}\n",
+        encoding="utf-8",
     )
-    captured_envs: list[dict[str, str]] = []
-    captured_cmds: list[list[str]] = []
+    os.chmod(path, 0o600)
+    return path
 
-    def _fake_run(cmd, capture_output=True, text=True, env=None):
-        _ = (cmd, capture_output, text)
-        captured_cmds.append(cmd)
-        captured_envs.append(env)
-        return SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
 
-    monkeypatch.setattr(db_mod.subprocess, "run", _fake_run)
-    ok, out = real_run_psql(db_mod.Environment.dev, sql="SELECT 1")
-    assert ok is True
-    assert captured_envs[-1]["PGPASSWORD"] == "secret"
-    assert "-c" in captured_cmds[-1]
-    assert 'SET search_path TO "tapdb_app"' in captured_cmds[-1]
+@pytest.fixture(autouse=True)
+def _explicit_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+    clear_cli_context()
+    set_cli_context(config_path=cfg_path)
+    yield cfg_path
+    clear_cli_context()
 
-    monkeypatch.setattr(
-        db_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("psql boom")),
+
+def test_environment_and_config_are_single_target() -> None:
+    assert [item.value for item in db_mod.Environment] == ["target"]
+
+    cfg = db_mod._get_db_config(db_mod.Environment.target)
+
+    assert cfg["client_id"] == "testclient"
+    assert cfg["database_name"] == "testdb"
+    assert cfg["database"] == "tapdb_shared"
+    assert db_mod._get_schema_name(db_mod.Environment.target) == "tapdb_testdb"
+
+
+def test_required_identity_prefixes_are_governance_backed() -> None:
+    prefixes = db_mod._required_identity_prefixes(db_mod.Environment.target)
+
+    assert prefixes["generic_template"] == "TPX"
+    assert prefixes["generic_instance_lineage"] == "EDG"
+    assert prefixes["audit_log"] == "ADT"
+
+
+def test_connection_string_uses_target_database_and_schema_policy() -> None:
+    assert (
+        db_mod._get_connection_string(db_mod.Environment.target)
+        == "postgresql://tapdb@localhost:5533/tapdb_shared"
     )
-    ok, out = real_run_psql(db_mod.Environment.dev, sql="SELECT 1")
-    assert (ok, out) == (False, "psql boom")
-
-
-def test_db_role_counts_schema_and_drift_helpers(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(
-        db_mod, "_get_db_config", lambda _env: _base_cfg(engine_type="aurora")
-    )
-    db_mod._ensure_local_role(db_mod.Environment.dev, "tapdb")
-    db_mod._ensure_local_role(db_mod.Environment.prod, "tapdb")
-    db_mod._ensure_local_role(db_mod.Environment.dev, "")
-
-    monkeypatch.setattr(db_mod, "_get_db_config", lambda _env: _base_cfg())
-    monkeypatch.setattr(db_mod, "_bootstrap_user_candidates", lambda _user: ["alice"])
-    monkeypatch.setattr(db_mod, "_quoted_sql_literal", lambda value: f"'{value}'")
-    monkeypatch.setattr(db_mod, "_quoted_sql_ident", lambda value: f'"{value}"')
-
-    def _local_role_failure(_env, sql=None, file=None, database=None, user=None):
-        _ = (file, database)
-        if sql == "SELECT 1" and user == "tapdb":
-            return False, 'psql: error: FATAL:  role "tapdb" does not exist'
-        if sql == "SELECT 1" and user == "alice":
-            return True, "1"
-        if sql and "CREATE ROLE" in sql:
-            return False, "create failed"
-        return True, ""
-
-    monkeypatch.setattr(db_mod, "_run_psql", _local_role_failure)
-    with pytest.raises(
-        RuntimeError, match="Failed to create missing local PostgreSQL role"
-    ):
-        db_mod._ensure_local_role(db_mod.Environment.dev, "tapdb")
-
-    responses = iter(
-        [
-            (True, "bad-int"),
-            (False, ""),
-            (True, "5"),
-            (True, "7"),
-            (True, "9"),
-        ]
-    )
-    monkeypatch.setattr(db_mod, "_run_psql", lambda *_args, **_kwargs: next(responses))
-    counts = db_mod._get_table_counts(db_mod.Environment.dev)
-    assert counts["generic_template"] == "?"
-    assert counts["generic_instance"] is None
-
-    schema_sqls: list[str] = []
-    monkeypatch.setattr(
-        db_mod,
-        "_run_psql",
-        lambda _env, sql=None, **_kwargs: (
-            schema_sqls.append(sql or ""),
-            (True, ""),
-        )[1],
-    )
-    db_mod._ensure_schema_exists(db_mod.Environment.dev)
-    assert 'CREATE SCHEMA IF NOT EXISTS "tapdb_app"' in schema_sqls[-1]
-
-    monkeypatch.setattr(db_mod, "_run_psql", lambda *_args, **_kwargs: (False, "boom"))
-    assert db_mod._schema_exists(db_mod.Environment.dev) is False
-    monkeypatch.setattr(
-        db_mod, "_run_psql", lambda *_args, **_kwargs: (True, "bad-int")
-    )
-    assert db_mod._schema_exists(db_mod.Environment.dev) is False
-
-    monkeypatch.setattr(db_mod, "_get_db_config", lambda _env: _base_cfg())
-    monkeypatch.setattr(db_mod, "_find_schema_root", lambda **_kwargs: tmp_path)
-    monkeypatch.setattr(
-        db_mod, "schema_asset_files", lambda _root: [tmp_path / "tapdb_schema.sql"]
-    )
-    monkeypatch.setattr(
-        db_mod,
-        "_required_identity_prefixes",
-        lambda _env: {"generic_template": "AGX"},
-    )
-    monkeypatch.setattr(
-        db_mod, "_shared_sequence_name", lambda prefix: f"{prefix.lower()}_instance_seq"
-    )
-    monkeypatch.setattr(
-        db_mod,
-        "build_expected_schema_inventory",
-        lambda paths, dynamic_sequence_name: {
-            "expected": paths,
-            "seq": dynamic_sequence_name,
-        },
-    )
-    live_inventory_calls: list[str | None] = []
-
-    def _fake_load_live_schema_inventory(session, schema_name=None):
-        live_inventory_calls.append(schema_name)
-        return {"live": True, "session": session, "schema_name": schema_name}
-
-    monkeypatch.setattr(
-        db_mod,
-        "load_live_schema_inventory",
-        _fake_load_live_schema_inventory,
+    assert (
+        db_mod._get_connection_string(db_mod.Environment.target, database="postgres")
+        == "postgresql://tapdb@localhost:5533/postgres"
     )
 
-    class _Result:
-        has_drift = True
-        expected = {"tables": ["generic_template"]}
-        live = {"tables": []}
-        missing = {"tables": ["generic_template"]}
-        unexpected = {"tables": []}
 
-        def to_payload(self):
-            return {
-                "status": "drift",
-                "database": "tapdb_dev",
-                "schema_name": "public",
-                "strict": True,
-                "missing": {"tables": ["generic_template"]},
-                "unexpected": {"tables": []},
-            }
+def test_destructive_confirmation_uses_resolved_target_label() -> None:
+    cfg = db_mod._get_db_config(db_mod.Environment.target)
+    label = "testclient/testdb/tapdb_testdb@tapdb_shared"
 
-    monkeypatch.setattr(
-        db_mod, "diff_schema_inventory", lambda *args, **kwargs: _Result()
-    )
-    monkeypatch.setattr(
-        db_mod,
-        "inventory_counts",
-        lambda value: {"count": len(value.get("tables", []))},
-    )
-    monkeypatch.setattr(
-        db_mod,
-        "drift_entry_counts",
-        lambda value: {"count": len(value.get("tables", []))},
-    )
-    monkeypatch.setattr(
-        db_mod,
-        "_tapdb_connection_for_env",
-        lambda _env, app_username: _FakeConn(session="session"),
-    )
-
-    payload, has_drift = db_mod._run_schema_drift_check(
-        db_mod.Environment.dev, strict=True
-    )
-    assert has_drift is True
-    assert payload["counts"]["expected"]["count"] == 1
-    assert payload["counts"]["missing"]["count"] == 1
-    assert payload["schema_name"] == "public"
-    assert live_inventory_calls == ["tapdb_app"]
-
-
-def test_db_callback_create_and_delete_branches(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    db_mod._db_callback(
-        SimpleNamespace(resilient_parsing=True, invoked_subcommand="schema")
-    )
-    db_mod._db_callback(
-        SimpleNamespace(resilient_parsing=False, invoked_subcommand="config")
-    )
-
-    monkeypatch.setattr(
-        "daylily_tapdb.cli._require_context",
-        lambda: (_ for _ in ()).throw(RuntimeError("missing context")),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod._db_callback(
-            SimpleNamespace(resilient_parsing=False, invoked_subcommand="schema")
+    with pytest.raises(typer.Exit):
+        db_mod._require_destructive_confirmation(
+            cfg, operation="delete database", confirm_target=None
         )
-    assert exc.value.exit_code == 1
 
-    monkeypatch.setattr(db_mod, "_get_db_config", lambda _env: _base_cfg())
-    monkeypatch.setattr(
-        db_mod,
-        "_ensure_local_role",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            RuntimeError("role bootstrap failed")
-        ),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_create(db_mod.Environment.dev, owner=None)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_ensure_local_role", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        db_mod, "_run_psql", lambda *_args, **_kwargs: (False, "cannot connect")
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_create(db_mod.Environment.dev, owner=None)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_run_psql", lambda *_args, **_kwargs: (True, "1"))
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: True)
-    db_mod.db_create(db_mod.Environment.dev, owner=None)
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: False)
-    create_sqls: list[str] = []
-
-    def _create_fail(_env, sql=None, file=None, database=None, user=None):
-        _ = (file, user)
-        create_sqls.append(sql or "")
-        if database == "postgres" and sql == "SELECT 1":
-            return True, "1"
-        return False, "create failed"
-
-    monkeypatch.setattr(db_mod, "_run_psql", _create_fail)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_create(db_mod.Environment.dev, owner=None)
-    assert exc.value.exit_code == 1
-    assert any(
-        'CREATE DATABASE "tapdb_dev" OWNER "tapdb"' in sql for sql in create_sqls
+    db_mod._require_destructive_confirmation(
+        cfg, operation="delete database", confirm_target=label
     )
 
-    monkeypatch.setattr(
-        db_mod,
-        "_run_psql",
-        lambda _env, sql=None, file=None, database=None, user=None: (
-            (True, "1") if database == "postgres" and sql == "SELECT 1" else (True, "")
-        ),
+    cfg["destructive_operations"] = "blocked"
+    with pytest.raises(RuntimeError, match="blocked"):
+        db_mod._require_destructive_confirmation(
+            cfg, operation="delete database", confirm_target=label
+        )
+
+    cfg["destructive_operations"] = "allowed"
+    db_mod._require_destructive_confirmation(
+        cfg, operation="delete database", confirm_target=None
     )
-    db_mod.db_create(db_mod.Environment.dev, owner="owner1")
-
-    monkeypatch.setattr(
-        db_mod, "_run_psql", lambda *_args, **_kwargs: (False, "cannot connect")
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_delete(db_mod.Environment.dev, force=False)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_run_psql", lambda *_args, **_kwargs: (True, "1"))
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: False)
-    db_mod.db_delete(db_mod.Environment.dev, force=False)
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(db_mod.Confirm, "ask", lambda *args, **kwargs: False)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_delete(db_mod.Environment.dev, force=False)
-    assert exc.value.exit_code == 0
-
-    monkeypatch.setattr(db_mod.Confirm, "ask", lambda *args, **kwargs: True)
-    monkeypatch.setattr(db_mod.typer, "prompt", lambda _msg: "wrong-name")
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_delete(db_mod.Environment.prod, force=False)
-    assert exc.value.exit_code == 1
-
-    ops: list[tuple[str | None, str | None]] = []
-
-    def _drop_fail(_env, sql=None, file=None, database=None, user=None):
-        _ = (file, user)
-        ops.append((database, sql))
-        if database == "postgres" and sql == "SELECT 1":
-            return True, "1"
-        if sql and "DROP DATABASE" in sql:
-            return False, "drop failed"
-        return True, ""
-
-    monkeypatch.setattr(db_mod, "_run_psql", _drop_fail)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_delete(db_mod.Environment.dev, force=True)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(
-        db_mod,
-        "_run_psql",
-        lambda _env, sql=None, file=None, database=None, user=None: (
-            (True, "1") if database == "postgres" and sql == "SELECT 1" else (True, "")
-        ),
-    )
-    db_mod.db_delete(db_mod.Environment.dev, force=True)
 
 
-def test_db_schema_apply_status_and_drift_command_branches(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    schema_file = tmp_path / "tapdb_schema.sql"
-    schema_file.write_text("-- schema\n", encoding="utf-8")
+def test_db_schema_apply_uses_explicit_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, object]] = []
 
     monkeypatch.setattr(db_mod, "_ensure_dirs", lambda: None)
-    monkeypatch.setattr(db_mod, "_get_db_config", lambda _env: _base_cfg())
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: False)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_schema_apply(db_mod.Environment.dev, reinitialize=False)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(db_mod, "_check_db_exists", lambda env, db: True)
+    monkeypatch.setattr(db_mod, "_find_schema_file", lambda: Path("schema.sql"))
     monkeypatch.setattr(
-        db_mod,
-        "_find_schema_file",
-        lambda: (_ for _ in ()).throw(FileNotFoundError("missing schema")),
+        db_mod, "_ensure_schema_exists", lambda env: calls.append(("ensure", env))
     )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_schema_apply(db_mod.Environment.dev, reinitialize=False)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_find_schema_file", lambda: schema_file)
-    monkeypatch.setattr(db_mod, "_schema_exists", lambda _env: True)
-    ensure_schema_calls: list[db_mod.Environment] = []
+    monkeypatch.setattr(db_mod, "_schema_exists", lambda env: False)
+    monkeypatch.setattr(db_mod, "_run_psql", lambda env, **kwargs: (True, ""))
+    monkeypatch.setattr(db_mod, "_log_operation", lambda *args, **kwargs: None)
     monkeypatch.setattr(
-        db_mod, "_ensure_schema_exists", lambda env: ensure_schema_calls.append(env)
+        db_mod, "_sync_identity_prefix_config", lambda env: calls.append(("sync", env))
     )
     monkeypatch.setattr(
-        db_mod, "_run_psql", lambda *_args, **_kwargs: (False, "schema apply failed")
-    )
-    log_calls: list[tuple[object, ...]] = []
-    monkeypatch.setattr(db_mod, "_log_operation", lambda *args: log_calls.append(args))
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_schema_apply(db_mod.Environment.dev, reinitialize=False)
-    assert exc.value.exit_code == 1
-    assert log_calls[-1][1] == "SCHEMA_APPLY_FAILED"
-    assert ensure_schema_calls == [db_mod.Environment.dev]
-
-    monkeypatch.setattr(db_mod, "_run_psql", lambda *_args, **_kwargs: (True, ""))
-    monkeypatch.setattr(
-        db_mod,
-        "_sync_identity_prefix_config",
-        lambda _env: (_ for _ in ()).throw(RuntimeError("sync failed")),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_schema_apply(db_mod.Environment.dev, reinitialize=False)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_sync_identity_prefix_config", lambda _env: None)
-    monkeypatch.setattr(
-        db_mod,
-        "_write_migration_baseline",
-        lambda _env: (_ for _ in ()).throw(RuntimeError("baseline failed")),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_schema_apply(db_mod.Environment.dev, reinitialize=False)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: False)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_status(db_mod.Environment.dev)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(db_mod, "_schema_exists", lambda _env: False)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_status(db_mod.Environment.dev)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(
-        db_mod,
-        "_get_db_config",
-        lambda _env: _base_cfg(
-            engine_type="aurora", region="us-east-1", iam_auth="false"
-        ),
-    )
-    monkeypatch.setattr(db_mod, "_schema_exists", lambda _env: True)
-    monkeypatch.setattr(
-        db_mod,
-        "_get_table_counts",
-        lambda _env: {
-            "generic_template": None,
-            "generic_instance": 1,
-            "generic_instance_lineage": 2,
-            "audit_log": 3,
-            "tapdb_identity_prefix_config": 4,
-        },
-    )
-    db_mod.db_status(db_mod.Environment.dev)
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: False)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_schema_drift_check(
-            db_mod.Environment.dev, json_output=False, strict=False
-        )
-    assert exc.value.exit_code == 2
-
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_schema_drift_check(
-            db_mod.Environment.dev, json_output=True, strict=False
-        )
-    assert exc.value.exit_code == 2
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(
-        db_mod,
-        "_run_schema_drift_check",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("drift exploded")),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_schema_drift_check(
-            db_mod.Environment.dev, json_output=False, strict=False
-        )
-    assert exc.value.exit_code == 2
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_schema_drift_check(
-            db_mod.Environment.dev, json_output=True, strict=False
-        )
-    assert exc.value.exit_code == 2
-
-    monkeypatch.setattr(
-        db_mod,
-        "_run_schema_drift_check",
-        lambda *_args, **_kwargs: (
-            {
-                "database": "tapdb_dev",
-                "schema_name": "public",
-                "strict": True,
-                "counts": {"expected": 1, "live": 0},
-                "missing": {"tables": ["generic_template"], "columns": []},
-                "unexpected": {"tables": [], "columns": []},
-            },
-            True,
-        ),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_schema_drift_check(
-            db_mod.Environment.dev, json_output=False, strict=True
-        )
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(
-        db_mod,
-        "_run_schema_drift_check",
-        lambda *_args, **_kwargs: (
-            {
-                "database": "tapdb_dev",
-                "schema_name": "public",
-                "strict": False,
-                "counts": {"expected": 1, "live": 1},
-                "missing": {"tables": [], "columns": []},
-                "unexpected": {"tables": [], "columns": []},
-            },
-            False,
-        ),
-    )
-    db_mod.db_schema_drift_check(
-        db_mod.Environment.dev, json_output=False, strict=False
+        db_mod, "_write_migration_baseline", lambda env: calls.append(("baseline", env))
     )
 
+    db_mod.db_schema_apply(reinitialize=False)
 
-def test_db_nuke_migrate_backup_restore_validate_admin_seed_and_setup(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(db_mod, "_get_db_config", lambda _env: _base_cfg())
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: False)
-    db_mod.db_nuke(db_mod.Environment.dev, force=False)
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(
-        db_mod,
-        "_get_table_counts",
-        lambda _env: {
-            "generic_template": 1,
-            "generic_instance": 2,
-            "generic_instance_lineage": 3,
-            "audit_log": 4,
-            "tapdb_identity_prefix_config": 5,
-        },
-    )
-    monkeypatch.setattr(db_mod.Confirm, "ask", lambda *args, **kwargs: False)
-    db_mod.db_nuke(db_mod.Environment.dev, force=False)
-
-    monkeypatch.setattr(db_mod.Confirm, "ask", lambda *args, **kwargs: True)
-    prompts = iter(["wrong-env"])
-    monkeypatch.setattr(db_mod.Prompt, "ask", lambda _msg: next(prompts))
-    db_mod.db_nuke(db_mod.Environment.dev, force=False)
-
-    prompts = iter(["dev", "DELETE EVERYTHING"])
-    monkeypatch.setattr(db_mod.Prompt, "ask", lambda _msg: next(prompts))
-    monkeypatch.setattr(
-        db_mod, "_run_psql", lambda *_args, **_kwargs: (False, "nuke failed")
-    )
-    log_calls: list[tuple[object, ...]] = []
-    monkeypatch.setattr(db_mod, "_log_operation", lambda *args: log_calls.append(args))
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_nuke(db_mod.Environment.dev, force=False)
-    assert exc.value.exit_code == 1
-    assert log_calls[-1][1] == "NUKE_FAILED"
-
-    monkeypatch.setattr(db_mod, "_run_psql", lambda *_args, **_kwargs: (True, ""))
-    db_mod.db_nuke(db_mod.Environment.dev, force=True)
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: False)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_migrate(db_mod.Environment.dev, dry_run=False)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(db_mod, "_schema_exists", lambda _env: False)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_migrate(db_mod.Environment.dev, dry_run=False)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_schema_exists", lambda _env: True)
-    monkeypatch.setattr(
-        db_mod,
-        "_find_schema_root",
-        lambda **_kwargs: (_ for _ in ()).throw(FileNotFoundError()),
-    )
-    db_mod.db_migrate(db_mod.Environment.dev, dry_run=False)
-
-    migrations_root = tmp_path / "schema"
-    (migrations_root / "migrations").mkdir(parents=True)
-    monkeypatch.setattr(db_mod, "_find_schema_root", lambda **_kwargs: migrations_root)
-    db_mod.db_migrate(db_mod.Environment.dev, dry_run=False)
-
-    migration_file = migrations_root / "migrations" / "20260407_init.sql"
-    migration_file.write_text("-- migration\n", encoding="utf-8")
-    monkeypatch.setattr(
-        db_mod, "_run_psql", lambda *_args, **_kwargs: (False, "ensure table failed")
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_migrate(db_mod.Environment.dev, dry_run=False)
-    assert exc.value.exit_code == 1
-
-    migration_state = {
-        "ensure": True,
-        "list": True,
-        "apply": True,
-    }
-
-    def _migrate_dry_run(_env, sql=None, file=None, database=None, user=None):
-        _ = (database, user)
-        if sql and "CREATE TABLE IF NOT EXISTS _tapdb_migrations" in sql:
-            return True, ""
-        if sql == "SELECT filename FROM _tapdb_migrations":
-            return True, ""
-        if file is not None:
-            return migration_state["apply"], "apply failed" if not migration_state[
-                "apply"
-            ] else ""
-        return True, ""
-
-    monkeypatch.setattr(db_mod, "_run_psql", _migrate_dry_run)
-    db_mod.db_migrate(db_mod.Environment.dev, dry_run=True)
-    migration_state["apply"] = False
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_migrate(db_mod.Environment.dev, dry_run=False)
-    assert exc.value.exit_code == 1
-    migration_state["apply"] = True
-    db_mod.db_migrate(db_mod.Environment.dev, dry_run=False)
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: False)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_backup(db_mod.Environment.dev, backup_path=None, data_only=False)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: True)
-    backup_path = tmp_path / "tapdb.sql"
-
-    def _backup_run(cmd, capture_output=True, text=True, env=None):
-        _ = (capture_output, text, env)
-        Path(cmd[cmd.index("-f") + 1]).write_text("-- backup\n", encoding="utf-8")
-        return SimpleNamespace(returncode=0, stderr="")
-
-    monkeypatch.setattr(db_mod.subprocess, "run", _backup_run)
-    db_mod.db_backup(db_mod.Environment.dev, backup_path=backup_path, data_only=True)
-
-    monkeypatch.setattr(
-        db_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=1, stderr="pg_dump failed"),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_backup(
-            db_mod.Environment.dev, backup_path=backup_path, data_only=False
-        )
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(
-        db_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError()),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_backup(
-            db_mod.Environment.dev, backup_path=backup_path, data_only=False
-        )
-    assert exc.value.exit_code == 1
-
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_restore(db_mod.Environment.dev, tmp_path / "missing.sql", force=False)
-    assert exc.value.exit_code == 1
-
-    restore_input = tmp_path / "restore.sql"
-    restore_input.write_text("-- restore\n", encoding="utf-8")
-    monkeypatch.setattr(db_mod.Confirm, "ask", lambda *args, **kwargs: False)
-    db_mod.db_restore(db_mod.Environment.dev, restore_input, force=False)
-
-    monkeypatch.setattr(db_mod.Confirm, "ask", lambda *args, **kwargs: True)
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: False)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_restore(db_mod.Environment.dev, restore_input, force=False)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(
-        db_mod, "_run_psql", lambda *_args, **_kwargs: (False, "restore failed")
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_restore(db_mod.Environment.dev, restore_input, force=True)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_run_psql", lambda *_args, **_kwargs: (True, ""))
-    monkeypatch.setattr(
-        db_mod,
-        "_get_table_counts",
-        lambda _env: {
-            "generic_template": 1,
-            "generic_instance": 2,
-            "generic_instance_lineage": 3,
-            "audit_log": 4,
-            "tapdb_identity_prefix_config": 5,
-        },
-    )
-    db_mod.db_restore(db_mod.Environment.dev, restore_input, force=True)
-
-    monkeypatch.setattr(
-        db_mod,
-        "_resolve_seed_config_dirs",
-        lambda _path: (_ for _ in ()).throw(FileNotFoundError("missing config")),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_validate_config(config_path=None, strict=True, json_output=False)
-    assert exc.value.exit_code == 1
-
-    issue_type = SimpleNamespace
-    monkeypatch.setattr(db_mod, "_resolve_seed_config_dirs", lambda _path: [tmp_path])
-    monkeypatch.setattr(
-        db_mod,
-        "_validate_template_configs",
-        lambda *_args, **_kwargs: (
-            [],
-            [
-                issue_type(
-                    level="error",
-                    message="bad template",
-                    source_file="a.json",
-                    template_code="generic/a",
-                ),
-                issue_type(
-                    level="warning",
-                    message="warn template",
-                    source_file="b.json",
-                    template_code="generic/b",
-                ),
-            ],
-        ),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_validate_config(config_path=None, strict=True, json_output=True)
-    assert exc.value.exit_code == 1
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_validate_config(config_path=None, strict=True, json_output=False)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(
-        db_mod, "_validate_template_configs", lambda *_args, **_kwargs: ([], [])
-    )
-    db_mod.db_validate_config(config_path=None, strict=False, json_output=False)
-
-    monkeypatch.setattr(db_mod, "_get_db_config", lambda _env: _base_cfg())
-    assert (
-        db_mod._create_default_admin(
-            db_mod.Environment.dev, insecure_dev_defaults=False
-        )
-        is False
-    )
-    assert (
-        db_mod._create_default_admin(
-            db_mod.Environment.prod, insecure_dev_defaults=True
-        )
-        is False
-    )
-
-    monkeypatch.setattr(
-        db_mod,
-        "TAPDBConnection",
-        lambda **kwargs: _FakeConn(session="session"),
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.user_store.create_or_get",
-        lambda *_args, **_kwargs: (SimpleNamespace(username="tapdb_admin"), False),
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.user._hash_password", lambda _value: "hashed"
-    )
-    assert (
-        db_mod._create_default_admin(db_mod.Environment.dev, insecure_dev_defaults=True)
-        is False
-    )
-
-    monkeypatch.setattr(
-        "daylily_tapdb.user_store.create_or_get",
-        lambda *_args, **_kwargs: (SimpleNamespace(username="tapdb_admin"), True),
-    )
-    assert (
-        db_mod._create_default_admin(db_mod.Environment.dev, insecure_dev_defaults=True)
-        is True
-    )
-
-    monkeypatch.setattr(
-        db_mod,
-        "TAPDBConnection",
-        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("connection failed")),
-    )
-    assert (
-        db_mod._create_default_admin(db_mod.Environment.dev, insecure_dev_defaults=True)
-        is False
-    )
-
-    monkeypatch.setattr(
-        db_mod,
-        "_resolve_seed_config_dirs",
-        lambda _path: (_ for _ in ()).throw(FileNotFoundError("missing config")),
-    )
-    monkeypatch.setattr(db_mod, "_get_db_config", lambda _env: _base_cfg())
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_seed(
-            db_mod.Environment.dev,
-            config_path=None,
-            include_workflow=False,
-            skip_existing=True,
-            dry_run=False,
-        )
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_resolve_seed_config_dirs", lambda _path: [tmp_path])
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: False)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_seed(
-            db_mod.Environment.dev,
-            config_path=None,
-            include_workflow=False,
-            skip_existing=True,
-            dry_run=False,
-        )
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(db_mod, "_schema_exists", lambda _env: False)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_seed(
-            db_mod.Environment.dev,
-            config_path=None,
-            include_workflow=False,
-            skip_existing=True,
-            dry_run=False,
-        )
-    assert exc.value.exit_code == 1
-
-    issue_type = SimpleNamespace
-    monkeypatch.setattr(
-        db_mod,
-        "_validate_template_configs",
-        lambda *_args, **_kwargs: (
-            [],
-            [
-                issue_type(
-                    level="error",
-                    message="bad template",
-                    source_file="a.json",
-                    template_code="generic/a",
-                )
-            ],
-        ),
-    )
-    monkeypatch.setattr(db_mod, "_schema_exists", lambda _env: True)
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_seed(
-            db_mod.Environment.dev,
-            config_path=None,
-            include_workflow=False,
-            skip_existing=True,
-            dry_run=False,
-        )
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(
-        db_mod, "_validate_template_configs", lambda *_args, **_kwargs: ([], [])
-    )
-    db_mod.db_seed(
-        db_mod.Environment.dev,
-        config_path=None,
-        include_workflow=False,
-        skip_existing=True,
-        dry_run=False,
-    )
-
-    templates = [
-        {
-            "category": "generic",
-            "type": "core",
-            "subtype": "foo",
-            "version": "1.0",
-            "name": "Foo",
-        }
+    assert calls == [
+        ("ensure", db_mod.Environment.target),
+        ("sync", db_mod.Environment.target),
+        ("baseline", db_mod.Environment.target),
     ]
+
+
+def test_db_status_uses_explicit_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(db_mod, "_check_db_exists", lambda env, db: True)
+    monkeypatch.setattr(db_mod, "_schema_exists", lambda env: True)
     monkeypatch.setattr(
-        db_mod, "_validate_template_configs", lambda *_args, **_kwargs: (templates, [])
+        db_mod, "_get_table_counts", lambda env: {"generic_template": 1}
     )
-    monkeypatch.setattr(
-        db_mod,
-        "_find_duplicate_template_keys",
-        lambda _templates: {("generic", "core", "foo", "1.0"): ["a.json", "b.json"]},
+
+    db_mod.db_status()
+
+
+def test_db_delete_old_env_argument_is_rejected() -> None:
+    result = runner.invoke(app, ["db", "delete", "prod", "--confirm-target", "x"])
+
+    assert result.exit_code == 2
+    assert "unexpected extra argument" in result.output.lower()
+
+
+def test_tapdb_connection_for_env_passes_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class FakeConnection:
+        def __init__(self, **kwargs):
+            seen.update(kwargs)
+
+    monkeypatch.setattr(db_mod, "TAPDBConnection", FakeConnection)
+
+    conn = db_mod._tapdb_connection_for_env(
+        db_mod.Environment.target,
+        app_username="tester",
     )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_seed(
-            db_mod.Environment.dev,
-            config_path=None,
-            include_workflow=False,
-            skip_existing=True,
-            dry_run=False,
+
+    assert isinstance(conn, FakeConnection)
+    assert seen["schema_name"] == "tapdb_testdb"
+    assert seen["db_name"] == "tapdb_shared"
+    assert seen["app_username"] == "tester"
+
+
+def test_create_default_admin_skips_without_insecure_flag() -> None:
+    assert (
+        db_mod._create_default_admin(
+            db_mod.Environment.target, insecure_dev_defaults=False
         )
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(db_mod, "_find_duplicate_template_keys", lambda _templates: {})
-    db_mod.db_seed(
-        db_mod.Environment.dev,
-        config_path=None,
-        include_workflow=False,
-        skip_existing=True,
-        dry_run=True,
+        is False
     )
-
-    monkeypatch.setattr(
-        db_mod,
-        "_tapdb_connection_for_env",
-        lambda _env, app_username: (_ for _ in ()).throw(RuntimeError("seed failed")),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        db_mod.db_seed(
-            db_mod.Environment.dev,
-            config_path=None,
-            include_workflow=False,
-            skip_existing=True,
-            dry_run=False,
-        )
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(
-        db_mod,
-        "_tapdb_connection_for_env",
-        lambda _env, app_username: _FakeConn(session="session"),
-    )
-    monkeypatch.setattr(
-        db_mod, "_loader_find_tapdb_core_config_dir", lambda: tmp_path / "core"
-    )
-    seed_call: dict[str, object] = {}
-
-    def _fake_loader_seed_templates(*_args, **kwargs):
-        seed_call.update(kwargs)
-        return SimpleNamespace(inserted=2, updated=1, skipped=3, prefixes_ensured=4)
-
-    monkeypatch.setattr(
-        db_mod,
-        "_loader_seed_templates",
-        _fake_loader_seed_templates,
-    )
-    db_mod.db_seed(
-        db_mod.Environment.dev,
-        config_path=None,
-        include_workflow=True,
-        skip_existing=False,
-        dry_run=False,
-    )
-    assert "prefix_registry_path" in seed_call
-
-    db_calls: list[str] = []
-    monkeypatch.setattr(
-        db_mod, "db_delete", lambda *_args, **_kwargs: db_calls.append("delete")
-    )
-    monkeypatch.setattr(
-        db_mod, "db_create", lambda *_args, **_kwargs: db_calls.append("create")
-    )
-    monkeypatch.setattr(
-        db_mod, "db_schema_apply", lambda *_args, **_kwargs: db_calls.append("apply")
-    )
-    monkeypatch.setattr(
-        db_mod, "db_migrate", lambda *_args, **_kwargs: db_calls.append("migrate")
-    )
-    monkeypatch.setattr(
-        db_mod, "db_seed", lambda *_args, **_kwargs: db_calls.append("seed")
-    )
-    monkeypatch.setattr(db_mod, "_create_default_admin", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(
-        db_mod,
-        "_get_connection_string",
-        lambda _env: "postgresql://tapdb@localhost:5533/tapdb_dev",
-    )
-
-    monkeypatch.setattr(
-        db_mod, "_get_db_config", lambda _env: _base_cfg(engine_type="local")
-    )
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda *_args, **_kwargs: True)
-    db_mod.db_setup(
-        db_mod.Environment.dev,
-        force=True,
-        include_workflow=False,
-        insecure_dev_defaults=True,
-    )
-    assert db_calls[:6] == ["delete", "create", "apply", "migrate", "seed"]
-
-    db_calls.clear()
-    monkeypatch.setattr(
-        db_mod, "_get_db_config", lambda _env: _base_cfg(engine_type="aurora")
-    )
-    db_mod.db_setup(
-        db_mod.Environment.dev,
-        force=True,
-        include_workflow=True,
-        insecure_dev_defaults=False,
-    )
-    assert "delete" not in db_calls

--- a/tests/test_cli_floor_lift_part1.py
+++ b/tests/test_cli_floor_lift_part1.py
@@ -1,734 +1,232 @@
+"""Additional explicit-target CLI/runtime coverage."""
+
 from __future__ import annotations
 
-import json
-import runpy
-from dataclasses import dataclass
-from datetime import datetime
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-import typer
+from typer.testing import CliRunner
 
-import daylily_tapdb.cli as cli_mod
 import daylily_tapdb.cli.pg as pg_mod
 import daylily_tapdb.cli.user as user_mod
 import daylily_tapdb.web.runtime as runtime_mod
+from daylily_tapdb.cli import app
+from daylily_tapdb.cli.context import clear_cli_context, set_cli_context
 from daylily_tapdb.cli.db import Environment
 
-
-class _FakeConn:
-    def __init__(self) -> None:
-        self.sessions: list[SimpleNamespace] = []
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        return False
-
-    def session_scope(self, commit: bool = False):
-        session = SimpleNamespace(commit=commit)
-        self.sessions.append(session)
-
-        class _Scope:
-            def __enter__(self):
-                return session
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-        return _Scope()
+runner = CliRunner()
 
 
-class _FakeTransaction:
-    def __init__(self) -> None:
-        self.commits = 0
-        self.rollbacks = 0
-
-    def commit(self) -> None:
-        self.commits += 1
-
-    def rollback(self) -> None:
-        self.rollbacks += 1
-
-
-class _FakeSession:
-    def __init__(self, *, fail_execute: Exception | None = None) -> None:
-        self.fail_execute = fail_execute
-        self.closed = 0
-        self.execute_calls: list[tuple[object, object]] = []
-        self.transactions: list[_FakeTransaction] = []
-
-    def begin(self) -> _FakeTransaction:
-        tx = _FakeTransaction()
-        self.transactions.append(tx)
-        return tx
-
-    def execute(self, stmt, params=None):
-        self.execute_calls.append((stmt, params))
-        if self.fail_execute is not None:
-            raise self.fail_execute
-        return None
-
-    def close(self) -> None:
-        self.closed += 1
-
-
-@dataclass
-class _FakeBundle:
-    config_path: str
-    env_name: str
-    engine: object
-    SessionFactory: object
-    cfg: dict[str, str]
-
-
-def test_cli_module_main_raises_system_exit(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(cli_mod, "main", lambda: 7)
-
-    with pytest.raises(SystemExit) as exc:
-        runpy.run_module("daylily_tapdb.cli.__main__", run_name="__main__")
-
-    assert exc.value.code == 7
+def _write_config(path: Path, *, socket_dir: str = "") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    domain_registry = path.parent / "domain_code_registry.json"
+    prefix_registry = path.parent / "prefix_ownership_registry.json"
+    domain_registry.write_text(
+        '{"version":"0.4.0","domains":{"Z":{"name":"test"}}}\n',
+        encoding="utf-8",
+    )
+    prefix_registry.write_text(
+        (
+            '{"version":"0.4.0","ownership":{"Z":{'
+            '"TPX":{"issuer_app_code":"daylily-tapdb"},'
+            '"EDG":{"issuer_app_code":"daylily-tapdb"},'
+            '"ADT":{"issuer_app_code":"daylily-tapdb"},'
+            '"SYS":{"issuer_app_code":"daylily-tapdb"},'
+            '"MSG":{"issuer_app_code":"daylily-tapdb"}}}}\n'
+        ),
+        encoding="utf-8",
+    )
+    unix_socket_line = f"  unix_socket_dir: {socket_dir}\n" if socket_dir else ""
+    path.write_text(
+        "meta:\n"
+        "  config_version: 4\n"
+        "  client_id: testclient\n"
+        "  database_name: testdb\n"
+        "  owner_repo_name: daylily-tapdb\n"
+        f"  domain_registry_path: {domain_registry}\n"
+        f"  prefix_ownership_registry_path: {prefix_registry}\n"
+        "target:\n"
+        "  engine_type: local\n"
+        "  host: localhost\n"
+        "  port: '5533'\n"
+        "  ui_port: '8911'\n"
+        "  domain_code: Z\n"
+        "  user: tapdb\n"
+        "  password: ''\n"
+        "  database: tapdb_shared\n"
+        "  schema_name: tapdb_testdb\n"
+        f"{unix_socket_line}"
+        "safety:\n"
+        "  safety_tier: shared\n"
+        "  destructive_operations: confirm_required\n",
+        encoding="utf-8",
+    )
+    os.chmod(path, 0o600)
+    return path
 
 
-def test_user_format_date_blank_and_raw_string() -> None:
-    assert user_mod._format_date("") == "-"
-    assert user_mod._format_date("not-a-date") == "not-a-date"
-    assert user_mod._format_date(datetime(2026, 4, 7, 9, 30), include_time=True) == (
-        "2026-04-07 09:30"
+@pytest.fixture(autouse=True)
+def _explicit_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+    clear_cli_context()
+    set_cli_context(config_path=cfg_path)
+    yield cfg_path
+    clear_cli_context()
+
+
+def test_user_cli_rejects_invalid_role_before_db_access() -> None:
+    result = runner.invoke(
+        app, ["users", "add", "--username", "alice", "--role", "owner"]
     )
 
-
-def test_user_list_error_branch(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        user_mod,
-        "_open_connection",
-        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("boom")),
-    )
-
-    with pytest.raises(typer.Exit) as exc:
-        user_mod.user_list(Environment.dev, False)
-
-    assert exc.value.exit_code == 1
+    assert result.exit_code == 1
+    assert "Invalid role" in result.output
 
 
-def test_user_add_invalid_role_and_hash_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    with pytest.raises(typer.Exit) as exc:
-        user_mod.user_add(
-            Environment.dev,
-            username="alice@example.com",
-            role="owner",
-            email=None,
-            display_name=None,
-            password=None,
-        )
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(
-        user_mod,
-        "_hash_password",
-        lambda _value: (_ for _ in ()).throw(RuntimeError("bcrypt missing")),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        user_mod.user_add(
-            Environment.dev,
-            username="alice@example.com",
-            role="admin",
-            email=None,
-            display_name=None,
-            password="secret",
-        )
-    assert exc.value.exit_code == 1
-
-
-def test_user_add_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        user_mod,
-        "_open_connection",
-        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("db down")),
-    )
-
-    with pytest.raises(typer.Exit) as exc:
-        user_mod.user_add(
-            Environment.dev,
-            username="alice@example.com",
-            role="admin",
-            email="alice@example.com",
-            display_name="Alice",
-            password=None,
-        )
-
-    assert exc.value.exit_code == 1
-
-
-def test_user_set_role_error_paths(monkeypatch: pytest.MonkeyPatch) -> None:
-    with pytest.raises(typer.Exit) as exc:
-        user_mod.user_set_role(Environment.dev, "alice", "owner")
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(user_mod, "_open_connection", lambda *_a, **_k: _FakeConn())
-    monkeypatch.setattr(user_mod, "set_role", lambda *_a, **_k: False)
-    with pytest.raises(typer.Exit) as exc:
-        user_mod.user_set_role(Environment.dev, "alice", "admin")
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(
-        user_mod,
-        "_open_connection",
-        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("db down")),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        user_mod.user_set_role(Environment.dev, "alice", "admin")
-    assert exc.value.exit_code == 1
-
-
-@pytest.mark.parametrize(
-    ("command", "is_active"),
-    [("user_deactivate", False), ("user_activate", True)],
-)
-def test_user_activate_deactivate_error_paths(
-    monkeypatch: pytest.MonkeyPatch, command: str, is_active: bool
-) -> None:
-    fn = getattr(user_mod, command)
-    monkeypatch.setattr(user_mod, "_open_connection", lambda *_a, **_k: _FakeConn())
-    monkeypatch.setattr(user_mod, "set_active", lambda *_a, **_k: False)
-    with pytest.raises(typer.Exit) as exc:
-        fn(Environment.dev, "alice")
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(
-        user_mod,
-        "_open_connection",
-        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("db down")),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        fn(Environment.dev, "alice")
-    assert exc.value.exit_code == 1
-
-
-def test_user_set_password_error_paths(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        user_mod,
-        "_hash_password",
-        lambda _value: (_ for _ in ()).throw(RuntimeError("bcrypt missing")),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        user_mod.user_set_password(Environment.dev, "alice", "secret")
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(user_mod, "_hash_password", lambda value: f"hashed:{value}")
-    monkeypatch.setattr(user_mod, "_open_connection", lambda *_a, **_k: _FakeConn())
-    monkeypatch.setattr(user_mod, "set_password_hash", lambda *_a, **_k: False)
-    with pytest.raises(typer.Exit) as exc:
-        user_mod.user_set_password(Environment.dev, "alice", "secret")
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(
-        user_mod,
-        "_open_connection",
-        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("db down")),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        user_mod.user_set_password(Environment.dev, "alice", "secret")
-    assert exc.value.exit_code == 1
-
-
-def test_user_delete_error_paths(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(user_mod.typer, "confirm", lambda _msg: True)
-    monkeypatch.setattr(user_mod, "_open_connection", lambda *_a, **_k: _FakeConn())
-    monkeypatch.setattr(user_mod, "soft_delete", lambda *_a, **_k: False)
-
-    with pytest.raises(typer.Exit) as exc:
-        user_mod.user_delete(Environment.dev, "alice", True)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(
-        user_mod,
-        "_open_connection",
-        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("db down")),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        user_mod.user_delete(Environment.dev, "alice", True)
-    assert exc.value.exit_code == 1
-
-
-def test_runtime_parse_bool_and_audit_username() -> None:
-    assert runtime_mod._parse_bool(None, default=True) is True
-    assert runtime_mod._parse_bool("true", default=False) is True
-    assert runtime_mod._parse_bool("off", default=True) is False
-    assert runtime_mod._parse_bool("maybe", default=False) is False
-    assert runtime_mod._audit_username_for_session(None) == "unknown"
-    assert runtime_mod._audit_username_for_session(" alice ") == "alice"
-
-
-def test_runtime_set_audit_username_logs_warning(caplog) -> None:
-    session = _FakeSession(fail_execute=RuntimeError("no tx"))
-
-    with caplog.at_level("WARNING"):
-        runtime_mod._set_audit_username(session, "alice")
-
-    assert "Could not set session audit username" in caplog.text
-
-
-def test_runtime_db_connection_context_manager_commit_and_rollback(
+def test_user_open_connection_uses_explicit_target_schema(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    sessions: list[_FakeSession] = []
+    seen: dict[str, object] = {}
 
-    def _factory() -> _FakeSession:
-        session = _FakeSession()
-        sessions.append(session)
-        return session
+    class FakeConnection:
+        def __init__(self, **kwargs):
+            seen.update(kwargs)
+
+    monkeypatch.setattr(user_mod, "TAPDBConnection", FakeConnection)
+
+    conn = user_mod._open_connection(Environment.target, app_username="tester")
+
+    assert isinstance(conn, FakeConnection)
+    assert seen["db_name"] == "tapdb_shared"
+    assert seen["schema_name"] == "tapdb_testdb"
+    assert seen["app_username"] == "tester"
+
+
+def test_runtime_requires_schema_name() -> None:
+    with pytest.raises(RuntimeError, match="schema_name"):
+        runtime_mod._require_schema_name({})
+
+    assert (
+        runtime_mod._require_schema_name({"schema_name": "tapdb_testdb"})
+        == "tapdb_testdb"
+    )
+
+
+def test_runtime_connection_sets_search_path_and_audit_username(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[str, object]] = []
+
+    class FakeTx:
+        def commit(self):
+            events.append(("commit", None))
+
+        def rollback(self):
+            events.append(("rollback", None))
+
+    class FakeSession:
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+
+        def begin(self):
+            return FakeTx()
+
+        def execute(self, stmt, params=None):
+            events.append(("execute", params))
+
+        def close(self):
+            events.append(("close", None))
 
     bundle = runtime_mod.RuntimeBundle(
         config_path="/tmp/tapdb-config.yaml",
-        env_name="dev",
-        engine=object(),
-        SessionFactory=_factory,
+        target_name="target",
+        engine=SimpleNamespace(),
+        SessionFactory=lambda: FakeSession(),
         cfg={},
-        schema_name="tapdb_dev",
+        schema_name="tapdb_testdb",
     )
     conn = runtime_mod.RuntimeDBConnection(bundle)
-    conn.app_username = "alice"
-
-    with conn as entered:
-        assert entered is conn
+    conn.app_username = "alice@example.com"
 
     with conn.session_scope(commit=True):
         pass
-    assert sessions[-1].transactions[0].commits == 1
-    assert sessions[-1].transactions[0].rollbacks == 0
-    assert sessions[-1].closed == 1
 
-    with conn.session_scope(commit=False):
-        pass
-    assert sessions[-1].transactions[0].commits == 0
-    assert sessions[-1].transactions[0].rollbacks == 1
-    assert sessions[-1].closed == 1
-
-    with pytest.raises(RuntimeError, match="boom"):
-        with conn.session_scope(commit=True):
-            raise RuntimeError("boom")
-    assert sessions[-1].transactions[0].rollbacks == 1
-    assert sessions[-1].closed == 1
-
-
-def test_runtime_build_engine_for_cfg_local_and_aurora(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    create_calls: list[dict[str, object]] = []
-    attach_calls: list[dict[str, object]] = []
-
-    def _fake_create_engine(url, *, config_path, env_name, echo_sql):
-        create_calls.append(
-            {
-                "drivername": url.drivername,
-                "username": url.username,
-                "password": url.password,
-                "host": url.host,
-                "port": url.port,
-                "database": url.database,
-                "query": dict(url.query),
-                "config_path": config_path,
-                "env_name": env_name,
-                "echo_sql": echo_sql,
-            }
-        )
-        return f"engine-{len(create_calls)}"
-
-    monkeypatch.setattr(runtime_mod, "_create_engine", _fake_create_engine)
-    monkeypatch.setattr(
-        runtime_mod.AuroraConnectionBuilder,
-        "ensure_ca_bundle",
-        staticmethod(lambda: Path("/tmp/aurora-ca.pem")),
+    assert ("commit", None) in events
+    assert any(item == ("execute", {"schema_name": "tapdb_testdb"}) for item in events)
+    assert any(
+        item == ("execute", {"username": "alice@example.com"}) for item in events
     )
+
+
+def test_runtime_get_db_caches_by_config_and_schema(monkeypatch: pytest.MonkeyPatch):
+    builds: list[dict[str, str]] = []
+
     monkeypatch.setattr(
         runtime_mod,
-        "_attach_aurora_password_provider",
-        lambda engine, **kwargs: attach_calls.append({"engine": engine, **kwargs}),
-    )
-    monkeypatch.setenv("ECHO_SQL", "true")
-    monkeypatch.setenv("AWS_PROFILE", "ambient")
-
-    local_engine = runtime_mod._build_engine_for_cfg(
-        {
+        "get_db_config",
+        lambda config_path: {
+            "config_path": config_path,
+            "schema_name": "tapdb_testdb",
             "engine_type": "local",
             "host": "localhost",
-            "port": "5432",
-            "database": "tapdb_dev",
-            "schema_name": "tapdb_dev",
+            "port": "5533",
+            "database": "tapdb_shared",
             "user": "tapdb",
             "password": "",
         },
-        config_path="/tmp/local.yaml",
-        env_name="dev",
-    )
-    aurora_engine = runtime_mod._build_engine_for_cfg(
-        {
-            "engine_type": "aurora",
-            "host": "aurora.local",
-            "port": "6432",
-            "database": "tapdb_prod",
-            "schema_name": "tapdb_prod",
-            "user": "tapdb",
-            "password": "",
-            "iam_auth": "yes",
-            "region": "us-west-2",
-        },
-        config_path="/tmp/aurora.yaml",
-        env_name="prod",
     )
 
-    assert local_engine == "engine-1"
-    assert aurora_engine == "engine-2"
-    assert create_calls[0]["password"] is None
-    assert create_calls[0]["query"] == {}
-    assert create_calls[1]["query"]["sslmode"] == "verify-full"
-    assert create_calls[1]["query"]["sslrootcert"] == "/tmp/aurora-ca.pem"
-    assert create_calls[1]["echo_sql"] is True
-    assert attach_calls == [
-        {
-            "engine": "engine-2",
-            "region": "us-west-2",
-            "host": "aurora.local",
-            "port": 6432,
-            "user": "tapdb",
-            "aws_profile": "ambient",
-            "iam_auth": True,
-            "secret_arn": None,
-            "password": "",
-        }
-    ]
+    def _fake_build(cfg, *, config_path):
+        builds.append(dict(cfg))
+        return SimpleNamespace()
+
+    monkeypatch.setattr(runtime_mod, "_build_engine_for_cfg", _fake_build)
+    monkeypatch.setattr(runtime_mod, "sessionmaker", lambda **kwargs: lambda: None)
+    runtime_mod._clear_runtime_cache_for_tests()
+
+    first = runtime_mod.get_db("/tmp/tapdb-config.yaml")
+    second = runtime_mod.get_db("/tmp/tapdb-config.yaml")
+
+    assert isinstance(first, runtime_mod.RuntimeDBConnection)
+    assert isinstance(second, runtime_mod.RuntimeDBConnection)
+    assert len(builds) == 1
 
 
-def test_runtime_get_db_requires_env_name() -> None:
-    with pytest.raises(RuntimeError, match="env name is required"):
-        runtime_mod.get_db("/tmp/tapdb-config.yaml", "")
-
-
-def test_runtime_clear_cache_logs_dispose_errors(
-    monkeypatch: pytest.MonkeyPatch, caplog
+def test_pg_socket_dir_prefers_explicit_target_field(
+    tmp_path: Path,
 ) -> None:
-    class _Engine:
-        def dispose(self) -> None:
-            raise RuntimeError("dispose boom")
+    socket_dir = tmp_path / "custom-socket"
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml", socket_dir=str(socket_dir))
+    set_cli_context(config_path=cfg_path)
 
-    bundle = runtime_mod.RuntimeBundle(
-        config_path="/tmp/tapdb-config.yaml",
-        env_name="dev",
-        engine=_Engine(),
-        SessionFactory=lambda: None,
-        cfg={},
-        schema_name="tapdb_dev",
-    )
-    runtime_mod._bundles[("/tmp/tapdb-config.yaml", "dev")] = bundle
-
-    with caplog.at_level("WARNING"):
-        runtime_mod._clear_runtime_cache_for_tests()
-
-    assert "Error disposing DAG runtime engine" in caplog.text
-    assert runtime_mod._bundles == {}
+    assert pg_mod._get_postgres_socket_dir(Environment.target) == socket_dir
 
 
-def test_pg_socket_dir_prefers_configured_value(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        pg_mod,
-        "get_db_config_for_env",
-        lambda _env: {"unix_socket_dir": "~/tapdb-pg-socket"},
-    )
-
-    resolved = pg_mod._get_postgres_socket_dir(Environment.dev)
-
-    assert resolved == Path("~/tapdb-pg-socket").expanduser()
+def test_pg_active_env_is_always_explicit_target() -> None:
+    assert pg_mod._active_env() is Environment.target
 
 
-def test_pg_active_env_invalid_defaults_to_dev(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(pg_mod, "active_env_name", lambda _default="dev": "invalid")
-    assert pg_mod._active_env() == Environment.dev
-
-
-def test_pg_get_pg_service_cmd_linux_and_unknown(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(pg_mod.platform, "system", lambda: "Linux")
-
-    def _linux_systemd(path_self) -> bool:
-        return str(path_self) in {"/bin/systemctl", "/usr/bin/systemctl"}
-
-    monkeypatch.setattr(pg_mod.Path, "exists", _linux_systemd, raising=False)
-    method, start_cmd, stop_cmd, _ = pg_mod._get_pg_service_cmd()
-    assert method == "systemd"
-    assert start_cmd[-1] == "postgresql"
-    assert stop_cmd[-1] == "postgresql"
-
-    monkeypatch.setattr(pg_mod.Path, "exists", lambda _self: False, raising=False)
-    method, start_cmd, stop_cmd, log_path = pg_mod._get_pg_service_cmd()
-    assert (method, start_cmd, stop_cmd, log_path) == ("unknown", [], [], Path())
-
-    monkeypatch.setattr(pg_mod.platform, "system", lambda: "Darwin")
-    method, start_cmd, stop_cmd, log_path = pg_mod._get_pg_service_cmd()
-    assert (method, start_cmd, stop_cmd, log_path) == ("unknown", [], [], Path())
-
-
-def test_pg_is_pg_running_exception_branch(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        pg_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
-    )
-    assert pg_mod._is_pg_running() == (False, "boom")
-
-
-def test_pg_start_unknown_service_and_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_pg_stop_status_logs_and_restart_paths(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pg_mod, "_is_pg_running", lambda: (False, ""))
     monkeypatch.setattr(
         pg_mod, "_get_pg_service_cmd", lambda: ("unknown", [], [], Path())
     )
 
-    with pytest.raises(typer.Exit) as exc:
-        pg_mod.pg_start()
-    assert exc.value.exit_code == 1
-
-    calls = {"polls": 0}
-
-    def _fake_is_running():
-        if calls["polls"] == 0:
-            calls["polls"] += 1
-            return False, ""
-        return True, "PostgreSQL 16"
-
-    monkeypatch.setattr(pg_mod, "_is_pg_running", _fake_is_running)
-    monkeypatch.setattr(
-        pg_mod,
-        "_get_pg_service_cmd",
-        lambda: ("systemd", ["sudo", "systemctl", "start", "postgresql"], [], Path()),
-    )
-    monkeypatch.setattr(
-        pg_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stderr="", stdout=""),
-    )
-    monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: None)
-    pg_mod.pg_start()
-
-    monkeypatch.setattr(pg_mod, "_is_pg_running", lambda: (False, ""))
-    monkeypatch.setattr(
-        pg_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(
-            returncode=1, stderr="cannot start", stdout=""
-        ),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        pg_mod.pg_start()
-    assert exc.value.exit_code == 1
+    assert runner.invoke(app, ["pg", "status"]).exit_code == 0
+    assert runner.invoke(app, ["pg", "stop"]).exit_code == 0
 
 
-def test_pg_stop_status_logs_and_restart(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+def test_pg_start_local_rejects_missing_postgres_tools(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(pg_mod, "_is_pg_running", lambda: (False, ""))
-    pg_mod.pg_stop()
+    monkeypatch.setattr(pg_mod.shutil, "which", lambda name: None)
 
-    monkeypatch.setattr(pg_mod, "_is_pg_running", lambda: (True, "16"))
-    monkeypatch.setattr(
-        pg_mod, "_get_pg_service_cmd", lambda: ("unknown", [], [], Path())
+    result = runner.invoke(app, ["pg", "start-local"])
+
+    assert result.exit_code == 1
+    assert (
+        "Data directory not initialized" in result.output
+        or "pg_ctl is required" in result.output
     )
-    with pytest.raises(typer.Exit) as exc:
-        pg_mod.pg_stop()
-    assert exc.value.exit_code == 1
-
-    state = {"checks": 0}
-
-    def _stop_running():
-        state["checks"] += 1
-        if state["checks"] < 3:
-            return True, "16"
-        return False, ""
-
-    monkeypatch.setattr(pg_mod, "_is_pg_running", _stop_running)
-    monkeypatch.setattr(
-        pg_mod,
-        "_get_pg_service_cmd",
-        lambda: ("systemd", [], ["sudo", "systemctl", "stop", "postgresql"], Path()),
-    )
-    monkeypatch.setattr(
-        pg_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stderr="", stdout=""),
-    )
-    monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: None)
-    pg_mod.pg_stop()
-
-    monkeypatch.setattr(pg_mod, "_active_env", lambda: Environment.prod)
-    monkeypatch.setattr(pg_mod, "_is_pg_running", lambda: (False, "boom"))
-    pg_mod.pg_status()
-
-    monkeypatch.setattr(pg_mod, "_active_env", lambda: Environment.dev)
-    monkeypatch.setattr(
-        pg_mod,
-        "get_db_config_for_env",
-        lambda _env: {"host": "localhost", "port": "5533", "user": "tapdb"},
-    )
-    monkeypatch.setattr(
-        pg_mod, "_get_postgres_data_dir", lambda _env: Path("/tmp/data")
-    )
-    monkeypatch.setattr(
-        pg_mod, "_get_postgres_log_file", lambda _env: Path("/tmp/postgresql.log")
-    )
-    monkeypatch.setattr(
-        pg_mod, "_get_postgres_socket_dir", lambda _env: Path("/tmp/socket")
-    )
-    monkeypatch.setattr(
-        pg_mod, "_get_instance_lock_file", lambda _env: Path("/tmp/instance.lock")
-    )
-    monkeypatch.setattr(
-        pg_mod,
-        "resolve_context",
-        lambda **_kwargs: SimpleNamespace(namespace_slug=lambda: "atlas/app"),
-    )
-    monkeypatch.setattr(
-        pg_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="", stderr=""),
-    )
-    pg_mod.pg_status()
-
-    log_file = tmp_path / "postgresql.log"
-    log_file.write_text("line-1\nline-2\nline-3\n", encoding="utf-8")
-    monkeypatch.setattr(
-        pg_mod, "_get_pg_service_cmd", lambda: ("unknown", [], [], Path("/missing.log"))
-    )
-    monkeypatch.setattr(pg_mod, "_active_env", lambda: Environment.dev)
-    monkeypatch.setattr(pg_mod, "_get_postgres_log_file", lambda _env: log_file)
-    pg_mod.pg_logs(False, 2)
-
-    monkeypatch.setattr(
-        pg_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(KeyboardInterrupt()),
-    )
-    pg_mod.pg_logs(True, 5)
-
-    events: list[str] = []
-    monkeypatch.setattr(pg_mod, "pg_stop", lambda: events.append("stop"))
-    monkeypatch.setattr(pg_mod, "pg_start", lambda: events.append("start"))
-    monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: None)
-    pg_mod.pg_restart()
-    assert events == ["stop", "start"]
-
-
-def test_pg_init_start_local_and_stop_local_branches(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    data_dir = tmp_path / "data"
-    lock_file = tmp_path / "instance.lock"
-    log_file = tmp_path / "postgresql.log"
-    socket_dir = tmp_path / "socket"
-
-    monkeypatch.setattr(pg_mod, "_get_postgres_data_dir", lambda _env: data_dir)
-    monkeypatch.setattr(pg_mod, "_get_instance_lock_file", lambda _env: lock_file)
-    monkeypatch.setattr(pg_mod, "_get_postgres_log_file", lambda _env: log_file)
-    monkeypatch.setattr(pg_mod, "_get_postgres_socket_dir", lambda _env: socket_dir)
-    monkeypatch.setattr(
-        pg_mod,
-        "get_db_config_for_env",
-        lambda _env: {"user": "postgres", "port": "5533"},
-    )
-
-    with pytest.raises(typer.Exit) as exc:
-        pg_mod.pg_init(Environment.prod, False)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(pg_mod.shutil, "which", lambda _name: None)
-    with pytest.raises(typer.Exit) as exc:
-        pg_mod.pg_init(Environment.dev, False)
-    assert exc.value.exit_code == 1
-
-    data_dir.mkdir(parents=True, exist_ok=True)
-    (data_dir / "PG_VERSION").write_text("16\n", encoding="utf-8")
-    monkeypatch.setattr(pg_mod.shutil, "which", lambda _name: "/usr/bin/initdb")
-    pg_mod.pg_init(Environment.dev, False)
-
-    monkeypatch.setattr(
-        pg_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stderr="", stdout=""),
-    )
-    monkeypatch.setattr(pg_mod.shutil, "rmtree", lambda path: None)
-    pg_mod.pg_init(Environment.dev, True)
-
-    monkeypatch.setattr(
-        pg_mod,
-        "get_db_config_for_env",
-        lambda _env: {"port": "0", "user": "postgres"},
-    )
-    with pytest.raises(typer.Exit) as exc:
-        pg_mod.pg_start_local(Environment.dev, None)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(
-        pg_mod,
-        "get_db_config_for_env",
-        lambda _env: {"port": "5533", "user": "postgres"},
-    )
-    with pytest.raises(typer.Exit) as exc:
-        pg_mod.pg_start_local(Environment.dev, 5534)
-    assert exc.value.exit_code == 1
-
-    data_dir.mkdir(parents=True, exist_ok=True)
-    if (data_dir / "PG_VERSION").exists():
-        (data_dir / "PG_VERSION").unlink()
-    with pytest.raises(typer.Exit) as exc:
-        pg_mod.pg_start_local(Environment.dev, None)
-    assert exc.value.exit_code == 1
-
-    (data_dir / "PG_VERSION").write_text("16\n", encoding="utf-8")
-    (data_dir / "postgresql.conf").write_text(
-        "#shared_memory_type = mmap\ndynamic_shared_memory_type = posix\n",
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(pg_mod.shutil, "which", lambda _name: None)
-    with pytest.raises(typer.Exit) as exc:
-        pg_mod.pg_start_local(Environment.dev, None)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(pg_mod.shutil, "which", lambda _name: "/usr/bin/pg_ctl")
-    monkeypatch.setattr(pg_mod, "_is_port_available", lambda _port: False)
-    monkeypatch.setattr(pg_mod, "_port_conflict_details", lambda _port: "conflict")
-    with pytest.raises(typer.Exit) as exc:
-        pg_mod.pg_start_local(Environment.dev, None)
-    assert exc.value.exit_code == 1
-
-    monkeypatch.setattr(pg_mod, "_is_port_available", lambda _port: True)
-    monkeypatch.setattr(
-        pg_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stderr="", stdout=""),
-    )
-    pg_mod.pg_start_local(Environment.dev, None)
-    payload = json.loads(lock_file.read_text(encoding="utf-8"))
-    assert payload["port"] == 5533
-    assert payload["socket_dir"] == str(socket_dir)
-
-    monkeypatch.setattr(
-        pg_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(
-            returncode=1, stderr="could not stop", stdout=""
-        ),
-    )
-    pg_mod.pg_stop_local(Environment.dev)
-
-    monkeypatch.setattr(
-        pg_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
-    )
-    with pytest.raises(typer.Exit) as exc:
-        pg_mod.pg_stop_local(Environment.dev)
-    assert exc.value.exit_code == 1

--- a/tests/test_cli_helper_units.py
+++ b/tests/test_cli_helper_units.py
@@ -1,8 +1,9 @@
+"""Helper-unit tests for explicit-target CLI internals."""
+
 from __future__ import annotations
 
-from datetime import datetime
+import os
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
@@ -10,432 +11,142 @@ import daylily_tapdb.cli.db as db_mod
 import daylily_tapdb.cli.pg as pg_mod
 import daylily_tapdb.cli.user as user_mod
 from daylily_tapdb.cli.context import clear_cli_context, set_cli_context
-from daylily_tapdb.euid import normalize_prefix
 
 
-def test_normalize_meridian_prefix_accepts_valid_uppercases():
-    assert db_mod._normalize_meridian_prefix("a1", "instance_prefix") == "A1"
-
-
-@pytest.mark.parametrize("value", ["", "   ", "GX", "TGX", "I0", "ABCDE"])
-def test_normalize_meridian_prefix_rejects_invalid_values(value: str):
-    with pytest.raises(ValueError):
-        db_mod._normalize_meridian_prefix(value, "instance_prefix")
-
-
-def test_required_identity_prefixes_returns_reserved_tapdb_prefixes():
-    assert db_mod._required_identity_prefixes(db_mod.Environment.dev) == {
-        "generic_template": "TPX",
-        "generic_instance_lineage": "EDG",
-        "audit_log": "ADT",
-    }
-
-
-def test_sync_identity_prefix_config_runs_expected_sql(monkeypatch):
-    captured: dict[str, str] = {}
-
-    monkeypatch.setattr(
-        db_mod,
-        "_required_identity_prefixes",
-        lambda _env: {
-            "generic_template": "TPX",
-            "generic_instance_lineage": "EDG",
-            "audit_log": "ADT",
-        },
+def _write_config(path: Path, *, engine_type: str = "local") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    domain_registry = path.parent / "domain_code_registry.json"
+    prefix_registry = path.parent / "prefix_ownership_registry.json"
+    domain_registry.write_text(
+        '{"version":"0.4.0","domains":{"Z":{"name":"test"}}}\n',
+        encoding="utf-8",
     )
-    monkeypatch.setattr(
-        db_mod,
-        "_get_db_config",
-        lambda _env: {
-            "domain_code": "Z",
-            "owner_repo_name": "daylily-tapdb",
-        },
+    prefix_registry.write_text(
+        (
+            '{"version":"0.4.0","ownership":{"Z":{'
+            '"TPX":{"issuer_app_code":"daylily-tapdb"},'
+            '"EDG":{"issuer_app_code":"daylily-tapdb"},'
+            '"ADT":{"issuer_app_code":"daylily-tapdb"},'
+            '"SYS":{"issuer_app_code":"daylily-tapdb"},'
+            '"MSG":{"issuer_app_code":"daylily-tapdb"}}}}\n'
+        ),
+        encoding="utf-8",
     )
-
-    def _fake_run_psql(_env, sql=None, file=None, database=None):
-        _ = (file, database)
-        captured["sql"] = sql or ""
-        return True, ""
-
-    monkeypatch.setattr(db_mod, "_run_psql", _fake_run_psql)
-
-    db_mod._sync_identity_prefix_config(db_mod.Environment.dev)
-
-    sql = captured["sql"]
-    assert "tapdb_identity_prefix_config" in sql
-    assert "('generic_template', 'Z', 'daylily-tapdb', 'TPX')" in sql
-    assert "('generic_instance_lineage', 'Z', 'daylily-tapdb', 'EDG')" in sql
-    assert "('audit_log', 'Z', 'daylily-tapdb', 'ADT')" in sql
-    assert "ON CONFLICT (entity, domain_code, issuer_app_code)" in sql
-    assert 'CREATE SEQUENCE IF NOT EXISTS "adt_instance_seq"' in sql
-    assert 'CREATE SEQUENCE IF NOT EXISTS "edg_instance_seq"' in sql
-    assert 'CREATE SEQUENCE IF NOT EXISTS "tpx_instance_seq"' in sql
-
-
-def test_sync_identity_prefix_config_raises_on_psql_failure(monkeypatch):
-    monkeypatch.setattr(
-        db_mod,
-        "_required_identity_prefixes",
-        lambda _env: {
-            "generic_template": "TPX",
-            "generic_instance_lineage": "EDG",
-            "audit_log": "ADT",
-        },
+    path.write_text(
+        "meta:\n"
+        "  config_version: 4\n"
+        "  client_id: testclient\n"
+        "  database_name: testdb\n"
+        "  owner_repo_name: daylily-tapdb\n"
+        f"  domain_registry_path: {domain_registry}\n"
+        f"  prefix_ownership_registry_path: {prefix_registry}\n"
+        "target:\n"
+        f"  engine_type: {engine_type}\n"
+        "  host: localhost\n"
+        "  port: '5533'\n"
+        "  ui_port: '8911'\n"
+        "  domain_code: Z\n"
+        "  user: tapdb\n"
+        "  password: ''\n"
+        "  database: tapdb_shared\n"
+        "  schema_name: tapdb_testdb\n"
+        "  region: us-west-2\n"
+        "  iam_auth: 'false'\n"
+        "safety:\n"
+        "  safety_tier: shared\n"
+        "  destructive_operations: confirm_required\n",
+        encoding="utf-8",
     )
-    monkeypatch.setattr(
-        db_mod,
-        "_get_db_config",
-        lambda _env: {
-            "domain_code": "Z",
-            "owner_repo_name": "daylily-tapdb",
-        },
-    )
+    os.chmod(path, 0o600)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _explicit_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+    clear_cli_context()
+    set_cli_context(config_path=cfg_path)
+    yield cfg_path
+    clear_cli_context()
+
+
+def test_identity_prefix_sync_writes_expected_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sql_calls: list[str] = []
     monkeypatch.setattr(
         db_mod,
         "_run_psql",
-        lambda _env, sql=None, file=None, database=None: (False, "boom"),
+        lambda env, sql, **kwargs: sql_calls.append(sql) or (True, ""),
     )
-    with pytest.raises(RuntimeError, match="Failed to sync identity prefix config"):
-        db_mod._sync_identity_prefix_config(db_mod.Environment.dev)
+
+    db_mod._sync_identity_prefix_config(db_mod.Environment.target)
+
+    joined = "\n".join(sql_calls)
+    assert "tapdb_identity_prefix_config" in joined
+    assert "TPX" in joined
+    assert "EDG" in joined
+    assert "ADT" in joined
 
 
-def test_db_schema_apply_reapplies_when_schema_table_already_exists(
-    monkeypatch, tmp_path
-):
-    schema_file = tmp_path / "tapdb_schema.sql"
-    schema_file.write_text("-- schema\n", encoding="utf-8")
+def test_identity_prefix_sync_raises_on_psql_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(db_mod, "_run_psql", lambda *args, **kwargs: (False, "boom"))
 
-    monkeypatch.setattr(db_mod, "_ensure_dirs", lambda: None)
-    monkeypatch.setattr(
-        db_mod,
-        "_get_db_config",
-        lambda _env: {
-            "host": "localhost",
-            "port": "5432",
-            "database": "tapdb_dev",
-            "schema_name": "tapdb_app",
-            "user": "tapdb",
-        },
-    )
-    monkeypatch.setattr(db_mod, "_check_db_exists", lambda _env, _db: True)
-    monkeypatch.setattr(db_mod, "_find_schema_file", lambda: schema_file)
-    monkeypatch.setattr(db_mod, "_schema_exists", lambda _env: True)
-
-    psql_calls: list[tuple[object | None, object | None, object | None]] = []
-    sync_calls: list[db_mod.Environment] = []
-    baseline_calls: list[db_mod.Environment] = []
-    log_calls: list[tuple[object, ...]] = []
-
-    def _fake_run_psql(_env, sql=None, file=None, database=None):
-        psql_calls.append((sql, file, database))
-        return True, ""
-
-    monkeypatch.setattr(db_mod, "_run_psql", _fake_run_psql)
-    monkeypatch.setattr(db_mod, "_sync_identity_prefix_config", sync_calls.append)
-    monkeypatch.setattr(db_mod, "_write_migration_baseline", baseline_calls.append)
-    monkeypatch.setattr(db_mod, "_log_operation", lambda *args: log_calls.append(args))
-
-    db_mod.db_schema_apply(db_mod.Environment.dev)
-
-    assert psql_calls == [
-        ('CREATE SCHEMA IF NOT EXISTS "tapdb_app"', None, None),
-        (None, schema_file, None),
-    ]
-    assert sync_calls == [db_mod.Environment.dev]
-    assert baseline_calls == [db_mod.Environment.dev]
-    assert log_calls == [("dev", "SCHEMA_APPLY", f"Schema applied from {schema_file}")]
+    with pytest.raises(RuntimeError, match="boom"):
+        db_mod._sync_identity_prefix_config(db_mod.Environment.target)
 
 
-def test_prefix_normalizer_accepts_crockford_prefixes():
-    assert normalize_prefix("a1") == "A1"
-    with pytest.raises(ValueError):
-        normalize_prefix("ABCDE")
+def test_connection_string_adds_ssl_for_aurora(tmp_path: Path) -> None:
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml", engine_type="aurora")
+    set_cli_context(config_path=cfg_path)
 
-
-def test_get_connection_string_aurora_and_local(monkeypatch):
-    monkeypatch.setattr(
-        db_mod,
-        "_get_db_config",
-        lambda _env: {
-            "user": "alice",
-            "host": "db.local",
-            "port": "5432",
-            "database": "tapdb_dev",
-            "engine_type": "aurora",
-            "password": "secret",
-        },
-    )
-    aurora = db_mod._get_connection_string(db_mod.Environment.dev)
-    assert aurora == "postgresql://alice@db.local:5432/tapdb_dev?sslmode=verify-full"
-    assert "secret" not in aurora
-
-    monkeypatch.setattr(
-        db_mod,
-        "_get_db_config",
-        lambda _env: {
-            "user": "alice",
-            "host": "db.local",
-            "port": "5432",
-            "database": "tapdb_dev",
-            "engine_type": "local",
-        },
-    )
-    local = db_mod._get_connection_string(db_mod.Environment.dev, database="override")
-    assert local == "postgresql://alice@db.local:5432/override"
-
-
-def test_parse_single_int_parses_first_numeric_line():
-    assert db_mod._parse_single_int("\nabc\n 42 \n77\n") == 42
-
-
-def test_parse_single_int_raises_when_missing():
-    with pytest.raises(ValueError, match="Could not parse int"):
-        db_mod._parse_single_int("\nabc\n")
-
-
-def test_template_code_and_template_key_helpers():
-    template = {
-        "category": "generic",
-        "type": "actor",
-        "subtype": "system_user",
-        "version": "1.0",
-    }
-    assert db_mod._template_code(template) == "generic/actor/system_user/1.0/"
-    assert db_mod._template_key(template) == (
-        "generic",
-        "actor",
-        "system_user",
-        "1.0",
+    assert db_mod._get_connection_string(db_mod.Environment.target).endswith(
+        "?sslmode=verify-full"
     )
 
 
-def test_tapdb_connection_for_env_uses_normalized_engine_flags(monkeypatch):
-    monkeypatch.setattr(
-        db_mod,
-        "_get_db_config",
-        lambda _env: {
-            "host": "localhost",
-            "port": "5432",
-            "user": "tapdb",
-            "password": "",
-            "database": "tapdb_dev",
-            "engine_type": "AURORA",
-            "iam_auth": "yes",
-            "region": "us-east-1",
-            "domain_code": "Z",
-            "owner_repo_name": "daylily-tapdb",
-            "schema_name": "tapdb_dev",
-        },
-    )
-    captured: dict[str, object] = {}
+def test_tapdb_connection_for_env_uses_normalized_engine_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
 
-    class _FakeConn:
+    class FakeConnection:
         def __init__(self, **kwargs):
-            captured.update(kwargs)
+            seen.update(kwargs)
 
-    monkeypatch.setattr(db_mod, "TAPDBConnection", _FakeConn)
+    monkeypatch.setattr(db_mod, "TAPDBConnection", FakeConnection)
 
-    conn = db_mod._tapdb_connection_for_env(
-        db_mod.Environment.dev, app_username="tester"
-    )
-    assert isinstance(conn, _FakeConn)
-    assert captured == {
-        "db_hostname": "localhost:5432",
-        "db_user": "tapdb",
-        "db_pass": None,
-        "secret_arn": None,
-        "db_name": "tapdb_dev",
-        "engine_type": "aurora",
-        "region": "us-east-1",
-        "iam_auth": True,
-        "app_username": "tester",
-        "domain_code": "Z",
-        "owner_repo_name": "daylily-tapdb",
-        "schema_name": "tapdb_dev",
-    }
+    db_mod._tapdb_connection_for_env(db_mod.Environment.target, app_username="tester")
+
+    assert seen["engine_type"] == "local"
+    assert seen["iam_auth"] is False
+    assert seen["schema_name"] == "tapdb_testdb"
 
 
-def test_create_default_admin_passes_configured_schema_name(monkeypatch):
-    monkeypatch.setattr(
-        db_mod,
-        "_get_db_config",
-        lambda _env: {
-            "host": "localhost",
-            "port": "5533",
-            "user": "tapdb",
-            "password": "",
-            "database": "tapdb_dev",
-            "engine_type": "local",
-            "iam_auth": "false",
-            "region": "us-west-2",
-            "domain_code": "Z",
-            "owner_repo_name": "daylily-tapdb",
-            "schema_name": "tapdb_dev",
-        },
-    )
-    captured: dict[str, object] = {}
+def test_user_open_connection_maps_explicit_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
 
-    class _FakeConn:
+    class FakeConnection:
         def __init__(self, **kwargs):
-            captured.update(kwargs)
+            seen.update(kwargs)
 
-        def __enter__(self):
-            return self
+    monkeypatch.setattr(user_mod, "TAPDBConnection", FakeConnection)
 
-        def __exit__(self, exc_type, exc, tb):
-            return False
+    user_mod._open_connection(db_mod.Environment.target, app_username="alice")
 
-        def session_scope(self, commit: bool = False):
-            class _Scope:
-                def __enter__(self):
-                    return object()
+    assert seen["db_name"] == "tapdb_shared"
+    assert seen["schema_name"] == "tapdb_testdb"
+    assert seen["app_username"] == "alice"
 
-                def __exit__(self, exc_type, exc, tb):
-                    return False
 
-            return _Scope()
-
-    monkeypatch.setattr(db_mod, "TAPDBConnection", _FakeConn)
-    monkeypatch.setattr(user_mod, "_hash_password", lambda _value: "hashed")
-    monkeypatch.setattr(
-        "daylily_tapdb.user_store.create_or_get",
-        lambda *_args, **_kwargs: (SimpleNamespace(username="tapdb_admin"), False),
-    )
-
+def test_pg_active_env_and_lock_paths_are_explicit_target() -> None:
+    assert pg_mod._active_env() is db_mod.Environment.target
     assert (
-        db_mod._create_default_admin(db_mod.Environment.dev, insecure_dev_defaults=True)
-        is False
+        pg_mod._get_instance_lock_file(db_mod.Environment.target).name
+        == "instance.lock"
     )
-    assert captured["schema_name"] == "tapdb_dev"
-
-
-def test_pg_build_pg_ctl_options_quotes_socket_path():
-    opts = pg_mod._build_pg_ctl_options(5544, Path("/tmp/socket dir"))
-    assert "-p 5544" in opts
-    assert "-h localhost" in opts
-    assert "-k '/tmp/socket dir'" in opts
-
-
-def test_pg_port_conflict_details_with_listener_line(monkeypatch):
-    proc = SimpleNamespace(returncode=0, stdout="COMMAND\npostgres 111  TCP *:5432")
-    monkeypatch.setattr(pg_mod.subprocess, "run", lambda *args, **kwargs: proc)
-    details = pg_mod._port_conflict_details(5432)
-    assert "port 5432 is in use" in details
-    assert "postgres 111" in details
-
-
-def test_pg_port_conflict_details_fallback_on_exception(monkeypatch):
-    def _raise(*args, **kwargs):
-        raise RuntimeError("no lsof")
-
-    monkeypatch.setattr(pg_mod.subprocess, "run", _raise)
-    assert pg_mod._port_conflict_details(5432) == "port 5432 is already in use"
-
-
-def test_pg_active_env_defaults_and_invalid(monkeypatch):
-    clear_cli_context()
-    assert pg_mod._active_env() == db_mod.Environment.dev
-
-    set_cli_context(env_name="TEST")
-    assert pg_mod._active_env() == db_mod.Environment.test
-    clear_cli_context()
-
-
-def test_ensure_local_role_repairs_missing_postgres_role(monkeypatch):
-    monkeypatch.setattr(
-        db_mod,
-        "_get_db_config",
-        lambda _env: {
-            "engine_type": "local",
-            "user": "postgres",
-            "host": "localhost",
-            "port": "5533",
-            "password": "",
-            "database": "tapdb_dev",
-        },
-    )
-    monkeypatch.setenv("USER", "jmajor")
-
-    calls: list[tuple[str, str | None, str | None]] = []
-
-    def _fake_run_psql(_env, sql=None, file=None, database=None, user=None):
-        _ = file
-        calls.append((user or "", database, sql))
-        if sql == "SELECT 1" and user == "postgres":
-            return False, 'psql: error: FATAL:  role "postgres" does not exist'
-        if sql == "SELECT 1" and user == "jmajor":
-            return True, "1"
-        if sql and "CREATE ROLE" in sql and user == "jmajor":
-            return True, ""
-        raise AssertionError((user, database, sql))
-
-    monkeypatch.setattr(db_mod, "_run_psql", _fake_run_psql)
-
-    db_mod._ensure_local_role(db_mod.Environment.dev, "postgres")
-
-    assert calls == [
-        ("postgres", "postgres", "SELECT 1"),
-        ("jmajor", "postgres", "SELECT 1"),
-        (
-            "jmajor",
-            "postgres",
-            "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'postgres') THEN CREATE ROLE \"postgres\" LOGIN SUPERUSER CREATEDB CREATEROLE; END IF; END $$;",
-        ),
-    ]
-
-
-def test_user_open_connection_maps_config(monkeypatch):
-    monkeypatch.setattr(
-        user_mod,
-        "get_db_config_for_env",
-        lambda _env: {
-            "host": "db.host",
-            "port": "6000",
-            "user": "usr",
-            "password": "",
-            "database": "tapdb_test",
-            "engine_type": "LOCAL",
-            "iam_auth": "on",
-            "region": "us-west-1",
-            "domain_code": "Z",
-            "owner_repo_name": "daylily-tapdb",
-        },
-    )
-    captured: dict[str, object] = {}
-
-    class _FakeConn:
-        def __init__(self, **kwargs):
-            captured.update(kwargs)
-
-    monkeypatch.setattr(user_mod, "TAPDBConnection", _FakeConn)
-
-    conn = user_mod._open_connection(db_mod.Environment.test, app_username="alice")
-    assert isinstance(conn, _FakeConn)
-    assert captured == {
-        "db_hostname": "db.host:6000",
-        "db_user": "usr",
-        "db_pass": None,
-        "secret_arn": None,
-        "db_name": "tapdb_test",
-        "engine_type": "local",
-        "region": "us-west-1",
-        "iam_auth": True,
-        "app_username": "alice",
-        "domain_code": "Z",
-        "owner_repo_name": "daylily-tapdb",
-    }
-
-
-def test_user_format_date_handles_none_datetime_and_iso():
-    assert user_mod._format_date(None) == "-"
-
-    dt = datetime(2026, 3, 29, 10, 45)
-    assert user_mod._format_date(dt) == "2026-03-29"
-    assert user_mod._format_date(dt, include_time=True) == "2026-03-29 10:45"
-
-    assert user_mod._format_date("2026-03-29T10:45:00Z") == "2026-03-29"
-    assert (
-        user_mod._format_date("2026-03-29T10:45:00Z", include_time=True)
-        == "2026-03-29 10:45"
-    )
-    assert user_mod._format_date("not-a-date") == "not-a-date"

--- a/tests/test_cli_registry_v2.py
+++ b/tests/test_cli_registry_v2.py
@@ -31,7 +31,7 @@ def _write_config(path: Path) -> Path:
     )
     path.write_text(
         "meta:\n"
-        "  config_version: 3\n"
+        "  config_version: 4\n"
         "  client_id: alpha\n"
         "  database_name: beta\n"
         "  owner_repo_name: daylily-tapdb\n"
@@ -65,16 +65,19 @@ def _write_config(path: Path) -> Path:
         "  db_max_overflow: 10\n"
         "  db_pool_timeout: 30\n"
         "  db_pool_recycle: 1800\n"
-        "environments:\n"
-        "  dev:\n"
-        "    engine_type: local\n"
-        "    host: localhost\n"
-        "    port: '5533'\n"
-        "    ui_port: '8911'\n"
-        "    domain_code: Z\n"
-        "    user: tapdb\n"
-        "    password: ''\n"
-        "    database: tapdb_dev\n",
+        "target:\n"
+        "  engine_type: local\n"
+        "  host: localhost\n"
+        "  port: '5533'\n"
+        "  ui_port: '8911'\n"
+        "  domain_code: Z\n"
+        "  user: tapdb\n"
+        "  password: ''\n"
+        "  database: tapdb_shared\n"
+        "  schema_name: tapdb_beta\n"
+        "safety:\n"
+        "  safety_tier: shared\n"
+        "  destructive_operations: confirm_required\n",
         encoding="utf-8",
     )
     path.chmod(stat.S_IRUSR | stat.S_IWUSR)
@@ -85,7 +88,6 @@ def test_cli_spec_uses_platform_v2_context_contract() -> None:
     assert spec.policy.profile == "platform-v2"
     assert spec.context is not None
     assert [option.name for option in spec.context.options] == [
-        "env_name",
         "client_id",
         "database_name",
     ]
@@ -160,14 +162,22 @@ def test_json_rejected_for_non_json_command(tmp_path: Path) -> None:
             "beta",
             "--owner-repo-name",
             "daylily-tapdb",
-            "--env",
-            "dev",
             "--domain-code",
-            "dev=Z",
-            "--db-port",
-            "dev=5533",
+            "Z",
+            "--engine-type",
+            "local",
+            "--host",
+            "localhost",
+            "--port",
+            "5533",
             "--ui-port",
-            "dev=8911",
+            "8911",
+            "--user",
+            "tapdb",
+            "--database",
+            "tapdb_shared",
+            "--schema-name",
+            "tapdb_beta",
         ],
     )
 
@@ -183,7 +193,7 @@ def test_framework_invocation_context_reaches_runtime_command(tmp_path: Path) ->
 
     result = runner.invoke(
         framework_app,
-        ["--config", str(cfg_path), "--env", "dev", "ui", "status"],
+        ["--config", str(cfg_path), "ui", "status"],
     )
 
     assert result.exit_code == 0

--- a/tests/test_cli_root_floor_lift.py
+++ b/tests/test_cli_root_floor_lift.py
@@ -1,930 +1,177 @@
+"""Root CLI branch coverage for explicit-target TapDB."""
+
 from __future__ import annotations
 
-import json
 import os
-import re
-import stat
+import subprocess
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 import yaml
 from typer.testing import CliRunner
 
 import daylily_tapdb.cli as cli_mod
-from daylily_tapdb.cli.context import (
-    clear_cli_context,
-    set_cli_context,
-)
+from daylily_tapdb.cli import app
+from daylily_tapdb.cli.context import clear_cli_context, set_cli_context
 
 runner = CliRunner()
-_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
-def _strip(text: str) -> str:
-    return _ANSI_RE.sub("", text)
-
-
-@pytest.fixture
-def cli_namespace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("HOME", str(tmp_path))
-    cfg_path = (
-        tmp_path / ".config" / "tapdb" / "testclient" / "testdb" / "tapdb-config.yaml"
-    )
-    cfg_path.parent.mkdir(parents=True, exist_ok=True)
-    domain_registry = tmp_path / "domain_code_registry.json"
-    prefix_registry = tmp_path / "prefix_ownership_registry.json"
+def _write_config(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    domain_registry = path.parent / "domain_code_registry.json"
+    prefix_registry = path.parent / "prefix_ownership_registry.json"
     domain_registry.write_text(
-        json.dumps({"version": "0.4.0", "domains": {"Z": {"name": "test-localhost"}}})
-        + "\n",
+        '{"version":"0.4.0","domains":{"Z":{"name":"test"}}}\n',
         encoding="utf-8",
     )
     prefix_registry.write_text(
-        json.dumps(
-            {
-                "version": "0.4.0",
-                "ownership": {
-                    "Z": {
-                        "TPX": {"issuer_app_code": "daylily-tapdb"},
-                        "EDG": {"issuer_app_code": "daylily-tapdb"},
-                        "ADT": {"issuer_app_code": "daylily-tapdb"},
-                        "SYS": {"issuer_app_code": "daylily-tapdb"},
-                        "MSG": {"issuer_app_code": "daylily-tapdb"},
-                    }
-                },
-            }
-        )
-        + "\n",
+        (
+            '{"version":"0.4.0","ownership":{"Z":{'
+            '"TPX":{"issuer_app_code":"daylily-tapdb"},'
+            '"EDG":{"issuer_app_code":"daylily-tapdb"},'
+            '"ADT":{"issuer_app_code":"daylily-tapdb"},'
+            '"SYS":{"issuer_app_code":"daylily-tapdb"},'
+            '"MSG":{"issuer_app_code":"daylily-tapdb"}}}}\n'
+        ),
         encoding="utf-8",
     )
-    cfg_path.write_text(
+    path.write_text(
         "meta:\n"
-        "  config_version: 3\n"
+        "  config_version: 4\n"
         "  client_id: testclient\n"
         "  database_name: testdb\n"
         "  owner_repo_name: daylily-tapdb\n"
         f"  domain_registry_path: {domain_registry}\n"
         f"  prefix_ownership_registry_path: {prefix_registry}\n"
         "admin:\n"
-        "  footer:\n"
-        "    repo_url: https://github.com/example/tapdb\n"
         "  session:\n"
-        "    secret: session-secret\n"
+        "    secret: secret123\n"
         "  auth:\n"
         "    mode: tapdb\n"
-        "    disabled_user:\n"
-        "      email: tapdb-admin@localhost\n"
-        "      role: admin\n"
-        "    shared_host:\n"
-        "      session_secret: shared-secret\n"
-        "      session_cookie: session\n"
-        "      session_max_age_seconds: 1209600\n"
-        "  cors:\n"
-        "    allowed_origins: []\n"
-        "  ui:\n"
-        "    tls:\n"
-        "      cert_path: ''\n"
-        "      key_path: ''\n"
-        "  metrics:\n"
-        "    enabled: true\n"
-        "    queue_max: 20000\n"
-        "    flush_seconds: 1.0\n"
-        "  db_pool_size: 5\n"
-        "  db_max_overflow: 10\n"
-        "  db_pool_timeout: 30\n"
-        "  db_pool_recycle: 1800\n"
-        "environments:\n"
-        "  dev:\n"
-        "    engine_type: local\n"
-        "    host: localhost\n"
-        "    port: 5533\n"
-        "    ui_port: 8911\n"
-        "    domain_code: Z\n"
-        "    user: tapdb\n"
-        "    password: ''\n"
-        "    database: tapdb_dev\n"
-        "    schema_name: tapdb_testdb_dev\n"
-        "  prod:\n"
-        "    engine_type: local\n"
-        "    host: localhost\n"
-        "    port: 5535\n"
-        "    ui_port: 9443\n"
-        "    domain_code: Z\n"
-        "    user: tapdb\n"
-        "    password: ''\n"
-        "    database: tapdb_prod\n"
-        "    schema_name: tapdb_testdb_prod\n",
+        "target:\n"
+        "  engine_type: local\n"
+        "  host: localhost\n"
+        "  port: '5533'\n"
+        "  ui_port: '8911'\n"
+        "  domain_code: Z\n"
+        "  user: tapdb\n"
+        "  password: ''\n"
+        "  database: tapdb_shared\n"
+        "  schema_name: tapdb_testdb\n"
+        "safety:\n"
+        "  safety_tier: shared\n"
+        "  destructive_operations: confirm_required\n",
         encoding="utf-8",
     )
-    os.chmod(cfg_path, stat.S_IRUSR | stat.S_IWUSR)
+    os.chmod(path, 0o600)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _explicit_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
     clear_cli_context()
-    set_cli_context(
-        client_id="testclient",
-        database_name="testdb",
-        env_name="dev",
-        config_path=cfg_path,
-    )
+    set_cli_context(config_path=cfg_path)
     yield cfg_path
     clear_cli_context()
 
 
-def test_root_tls_helpers_and_admin_module_lookup(
-    cli_namespace: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_admin_settings_for_env",
-        lambda _env, config_path=None: {
-            "tls_cert_path": "~/admin.crt",
-            "tls_key_path": "~/admin.key",
-        },
-    )
-    cert_path, key_path = cli_mod._resolve_tls_paths("dev")
-    assert cert_path == Path("~/admin.crt").expanduser()
-    assert key_path == Path("~/admin.key").expanduser()
+def test_tls_paths_resolve_from_config_runtime(tmp_path: Path):
+    cert, key = cli_mod._resolve_tls_paths()
 
-    cert_path, key_path = cli_mod._resolve_tls_paths(
-        "dev",
-        cert_file=Path("~/explicit.crt"),
-        key_file=Path("~/explicit.key"),
-    )
-    assert cert_path == Path("~/explicit.crt").expanduser()
-    assert key_path == Path("~/explicit.key").expanduser()
-
-    cert_file = tmp_path / "certs" / "localhost.crt"
-    key_file = tmp_path / "certs" / "localhost.key"
-    monkeypatch.setattr(
-        cli_mod, "_resolve_tls_paths", lambda *_args, **_kwargs: (cert_file, key_file)
-    )
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: None)
-    with pytest.raises(RuntimeError, match="openssl is required"):
-        cli_mod._ensure_tls_certificates("localhost", env_name="dev")
-
-    openssl_calls: list[list[str]] = []
-
-    def _openssl_success(cmd, capture_output=True, text=True):
-        openssl_calls.append(list(cmd))
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: "/usr/bin/openssl")
-    monkeypatch.setattr(cli_mod.subprocess, "run", _openssl_success)
-    cli_mod._ensure_tls_certificates("tapdb.local", env_name="dev")
-    assert "subjectAltName=DNS:localhost,DNS:tapdb.local" in " ".join(openssl_calls[0])
-
-    fallback_calls: list[list[str]] = []
-
-    def _openssl_fallback(cmd, capture_output=True, text=True):
-        fallback_calls.append(list(cmd))
-        return SimpleNamespace(
-            returncode=1 if len(fallback_calls) == 1 else 0,
-            stdout="",
-            stderr="bad addext",
-        )
-
-    monkeypatch.setattr(cli_mod.subprocess, "run", _openssl_fallback)
-    cli_mod._ensure_tls_certificates("localhost", env_name="dev")
-    assert len(fallback_calls) == 2
-
-    monkeypatch.setattr(
-        cli_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(
-            returncode=1, stdout="", stderr="still broken"
-        ),
-    )
-    with pytest.raises(RuntimeError, match="Failed to generate TLS certificate"):
-        cli_mod._ensure_tls_certificates("localhost", env_name="dev")
-
-    monkeypatch.setattr(cli_mod.subprocess, "run", _openssl_success)
-    monkeypatch.setattr(
-        cli_mod.os,
-        "chmod",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("chmod blocked")),
-    )
-    cli_mod._ensure_tls_certificates("localhost", env_name="dev")
-
-    monkeypatch.chdir(tmp_path)
-    fake_pkg_root = tmp_path / "pkgroot" / "daylily_tapdb" / "cli"
-    fake_pkg_root.mkdir(parents=True)
-    monkeypatch.setattr(cli_mod, "__file__", str(fake_pkg_root / "__init__.py"))
-    with pytest.raises(ValueError, match="Cannot find admin module"):
-        cli_mod._find_admin_module()
+    assert cert == tmp_path / "runtime" / "ui" / "certs" / "localhost.crt"
+    assert key == tmp_path / "runtime" / "ui" / "certs" / "localhost.key"
 
 
-def test_root_port_details_register_and_main(
-    cli_namespace: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(
-        cli_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(
-            returncode=0,
-            stdout="COMMAND\npython 12345 user  TCP *:8911",
-            stderr="",
-        ),
-    )
-    assert "python 12345" in cli_mod._port_conflict_details(8911)
+def test_tls_generation_uses_openssl(monkeypatch: pytest.MonkeyPatch):
+    calls: list[list[str]] = []
 
-    captured: dict[str, object] = {}
+    def _fake_run(cmd, capture_output=True, text=True):
+        calls.append(list(cmd))
+        cert = Path(cmd[cmd.index("-out") + 1])
+        key = Path(cmd[cmd.index("-keyout") + 1])
+        cert.parent.mkdir(parents=True, exist_ok=True)
+        key.parent.mkdir(parents=True, exist_ok=True)
+        cert.write_text("cert", encoding="utf-8")
+        key.write_text("key", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
 
-    def _fake_run(_spec, argv):
-        captured["argv"] = list(argv)
-        return 17
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda name: "/usr/bin/openssl")
+    monkeypatch.setattr(cli_mod.subprocess, "run", _fake_run)
 
-    monkeypatch.setattr("cli_core_yo.app.run", _fake_run)
-    monkeypatch.setattr(
-        "sys.argv",
+    cert, key = cli_mod._ensure_tls_certificates("localhost")
+
+    assert cert.exists()
+    assert key.exists()
+    assert calls
+
+
+def test_config_update_and_info_share_single_target(tmp_path: Path):
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+
+    update = runner.invoke(
+        app,
         [
-            "tapdb",
             "--config",
-            str(cli_namespace),
-            "--env",
-            "dev",
-            "ui",
-            "status",
-        ],
-    )
-    with pytest.raises(SystemExit) as exc:
-        cli_mod.main()
-    assert exc.value.code == 17
-    assert captured["argv"] == [
-        "--config",
-        str(cli_namespace),
-        "--env",
-        "dev",
-        "ui",
-        "status",
-    ]
-
-
-def test_register_supports_registry_without_add_typer_app(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    fresh_app = cli_mod.build_app()
-    sentinel_policy = object()
-    monkeypatch.setattr(cli_mod, "app", fresh_app)
-    monkeypatch.setattr(cli_mod, "policy_for_command", lambda *_args: sentinel_policy)
-
-    class _Registry:
-        def __init__(self) -> None:
-            self.groups: list[tuple[str, str]] = []
-            self.commands: list[tuple[str | None, str, str, object]] = []
-
-        def add_group(
-            self,
-            name,
-            *,
-            help_text="",
-            order=None,
-            metadata=None,
-        ):
-            _ = (order, metadata)
-            self.groups.append((name, help_text))
-
-        def add_command(
-            self,
-            group_path,
-            name,
-            callback,
-            *,
-            help_text="",
-            policy,
-            order=None,
-        ):
-            _ = (callback, order)
-            self.commands.append((group_path, name, help_text, policy))
-
-    registry = _Registry()
-    cli_mod.register(registry, object())
-
-    assert any(name == "db-config" for name, _help_text in registry.groups)
-    assert any(
-        group_path == "ui" and name == "start" and policy is sentinel_policy
-        for group_path, name, _help_text, policy in registry.commands
-    )
-
-
-def test_root_callback_and_ui_start_branches(
-    cli_namespace: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(
-        cli_mod,
-        "_require_context",
-        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("bad context")),
-    )
-    result = runner.invoke(
-        fresh_app,
-        ["--config", str(cli_namespace), "--env", "dev", "info"],
-    )
-    assert result.exit_code == 1
-    assert isinstance(result.exception, RuntimeError)
-    assert str(result.exception) == "bad context"
-
-    fake_context = SimpleNamespace(
-        ui_dir=lambda _env: cli_namespace.parent / ".tapdb-ui",
-        namespace_slug=lambda: "testclient/testdb",
-    )
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(
-        cli_mod,
-        "_require_context",
-        lambda **_kwargs: fake_context,
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_db_config_for_env",
-        lambda _env: {"ui_port": "8911"},
-    )
-    result = runner.invoke(
-        fresh_app,
-        ["ui", "start", "--port", "9000"],
-    )
-    assert result.exit_code == 1
-
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(
-        cli_mod, "_require_admin_extras", lambda: (_ for _ in ()).throw(SystemExit(1))
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_db_config_for_env",
-        lambda _env: {"ui_port": "8911"},
-    )
-    result = runner.invoke(fresh_app, ["ui", "start"])
-    assert result.exit_code == 1
-    assert "Admin UI dependencies are not installed" in _strip(result.output)
-
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(cli_mod, "_require_admin_extras", lambda: None)
-    monkeypatch.setattr(cli_mod, "_get_pid", lambda _pid_file: 123)
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_db_config_for_env",
-        lambda _env: {"ui_port": "8911"},
-    )
-    result = runner.invoke(fresh_app, ["ui", "start"])
-    assert result.exit_code == 0
-    assert "already running" in _strip(result.output)
-
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(cli_mod, "_require_admin_extras", lambda: None)
-    monkeypatch.setattr(cli_mod, "_get_pid", lambda _pid_file: None)
-    monkeypatch.setattr(cli_mod, "_port_is_available", lambda _host, _port: False)
-    monkeypatch.setattr(cli_mod, "_port_conflict_details", lambda _port: "busy")
-    monkeypatch.setattr(
-        cli_mod,
-        "_require_context",
-        lambda **_kwargs: fake_context,
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_db_config_for_env",
-        lambda _env: {"ui_port": "8911"},
-    )
-    result = runner.invoke(fresh_app, ["ui", "start"])
-    assert result.exit_code == 1
-    assert "busy" in _strip(result.output)
-
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(cli_mod, "_require_admin_extras", lambda: None)
-    monkeypatch.setattr(cli_mod, "_get_pid", lambda _pid_file: None)
-    monkeypatch.setattr(cli_mod, "_port_is_available", lambda _host, _port: True)
-    monkeypatch.setattr(
-        cli_mod,
-        "_ensure_tls_certificates",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("tls failed")),
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_db_config_for_env",
-        lambda _env: {"ui_port": "8911"},
-    )
-    result = runner.invoke(fresh_app, ["ui", "start"])
-    assert result.exit_code == 1
-    assert "tls failed" in _strip(result.output)
-
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(cli_mod, "_require_admin_extras", lambda: None)
-    monkeypatch.setattr(cli_mod, "_get_pid", lambda _pid_file: None)
-    monkeypatch.setattr(cli_mod, "_port_is_available", lambda _host, _port: True)
-    monkeypatch.setattr(
-        cli_mod,
-        "_ensure_tls_certificates",
-        lambda *_args, **_kwargs: (
-            Path("/tmp/localhost.crt"),
-            Path("/tmp/localhost.key"),
-        ),
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_db_config_for_env",
-        lambda _env: {"ui_port": "8911"},
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_config_path",
-        lambda: cli_namespace,
-    )
-
-    class _PopenFail:
-        pid = 222
-
-        def poll(self):
-            return 1
-
-    monkeypatch.setattr(
-        cli_mod.subprocess,
-        "Popen",
-        lambda *args, **kwargs: _PopenFail(),
-    )
-    monkeypatch.setattr(cli_mod.time, "sleep", lambda *_args, **_kwargs: None)
-    result = runner.invoke(fresh_app, ["ui", "start"])
-    assert result.exit_code == 1
-    assert "Server failed to start" in _strip(result.output)
-
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(cli_mod, "_require_admin_extras", lambda: None)
-    monkeypatch.setattr(cli_mod, "_get_pid", lambda _pid_file: None)
-    monkeypatch.setattr(cli_mod, "_port_is_available", lambda _host, _port: True)
-    monkeypatch.setattr(
-        cli_mod,
-        "_ensure_tls_certificates",
-        lambda *_args, **_kwargs: (
-            Path("/tmp/localhost.crt"),
-            Path("/tmp/localhost.key"),
-        ),
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_db_config_for_env",
-        lambda _env: {"ui_port": "8911"},
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_config_path",
-        lambda: cli_namespace,
-    )
-
-    class _PopenOk:
-        pid = 321
-
-        def poll(self):
-            return None
-
-    monkeypatch.setattr(
-        cli_mod.subprocess,
-        "Popen",
-        lambda *args, **kwargs: _PopenOk(),
-    )
-    monkeypatch.setattr(cli_mod.time, "sleep", lambda *_args, **_kwargs: None)
-    result = runner.invoke(fresh_app, ["ui", "start"])
-    assert result.exit_code == 0
-    assert "UI server started" in _strip(result.output)
-
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(cli_mod, "_require_admin_extras", lambda: None)
-    monkeypatch.setattr(cli_mod, "_get_pid", lambda _pid_file: None)
-    monkeypatch.setattr(cli_mod, "_port_is_available", lambda _host, _port: True)
-    monkeypatch.setattr(
-        cli_mod,
-        "_ensure_tls_certificates",
-        lambda *_args, **_kwargs: (
-            Path("/tmp/localhost.crt"),
-            Path("/tmp/localhost.key"),
-        ),
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_db_config_for_env",
-        lambda _env: {"ui_port": "8911"},
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_config_path",
-        lambda: cli_namespace,
-    )
-    monkeypatch.setattr(
-        cli_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(KeyboardInterrupt()),
-    )
-    result = runner.invoke(fresh_app, ["ui", "start", "--foreground"])
-    assert result.exit_code == 0
-
-
-def test_ui_mkcert_stop_logs_restart_and_bootstrap(
-    cli_namespace: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: None)
-    result = runner.invoke(fresh_app, ["ui", "mkcert"])
-    assert result.exit_code == 1
-
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: "/usr/bin/mkcert")
-    mkcert_calls = {"count": 0}
-
-    def _mkcert_install_fail(cmd, capture_output=True, text=True):
-        mkcert_calls["count"] += 1
-        return SimpleNamespace(returncode=1, stdout="", stderr="install failed")
-
-    monkeypatch.setattr(cli_mod.subprocess, "run", _mkcert_install_fail)
-    result = runner.invoke(fresh_app, ["ui", "mkcert"])
-    assert result.exit_code == 1
-
-    fresh_app = cli_mod.build_app()
-
-    def _mkcert_generate_fail(cmd, capture_output=True, text=True):
-        return SimpleNamespace(
-            returncode=0 if "-install" in cmd else 1,
-            stdout="",
-            stderr="generate failed",
-        )
-
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: "/usr/bin/mkcert")
-    monkeypatch.setattr(cli_mod.subprocess, "run", _mkcert_generate_fail)
-    result = runner.invoke(fresh_app, ["ui", "mkcert"])
-    assert result.exit_code == 1
-
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(cli_mod.shutil, "which", lambda _name: "/usr/bin/mkcert")
-    monkeypatch.setattr(
-        cli_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
-    )
-    monkeypatch.setattr(
-        cli_mod.os,
-        "chmod",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("chmod blocked")),
-    )
-    result = runner.invoke(fresh_app, ["ui", "mkcert"])
-    assert result.exit_code == 0
-
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(cli_mod, "_get_pid", lambda _pid_file: 123)
-    kill_state = {"phase": 0}
-
-    def _kill_success(pid, sig):
-        if sig == 0 and kill_state["phase"] == 0:
-            kill_state["phase"] += 1
-            return None
-        if sig == 0:
-            raise ProcessLookupError()
-        return None
-
-    monkeypatch.setattr(cli_mod.os, "kill", _kill_success)
-    monkeypatch.setattr(cli_mod.time, "sleep", lambda *_args, **_kwargs: None)
-    result = runner.invoke(fresh_app, ["ui", "stop"])
-    assert result.exit_code == 0
-
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(cli_mod, "_get_pid", lambda _pid_file: 123)
-    monkeypatch.setattr(
-        cli_mod.os,
-        "kill",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(ProcessLookupError()),
-    )
-    result = runner.invoke(fresh_app, ["ui", "stop"])
-    assert result.exit_code == 0
-    assert "Server was not running" in _strip(result.output)
-
-    fresh_app = cli_mod.build_app()
-    monkeypatch.setattr(cli_mod, "_get_pid", lambda _pid_file: 123)
-    monkeypatch.setattr(
-        cli_mod.os,
-        "kill",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(PermissionError()),
-    )
-    result = runner.invoke(fresh_app, ["ui", "stop"])
-    assert result.exit_code == 1
-
-    fresh_app = cli_mod.build_app()
-    result = runner.invoke(fresh_app, ["ui", "logs"])
-    assert result.exit_code == 0
-    assert "No log file found" in _strip(result.output)
-
-    fresh_app = cli_mod.build_app()
-    cli_mod._require_context(env_name="dev")
-    _, log_file, _ = cli_mod._ui_runtime_paths("dev")
-    log_file.parent.mkdir(parents=True, exist_ok=True)
-    log_file.write_text("line-1\nline-2\n", encoding="utf-8")
-    monkeypatch.setattr(
-        cli_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(KeyboardInterrupt()),
-    )
-    result = runner.invoke(fresh_app, ["ui", "logs"])
-    assert result.exit_code == 0
-
-    fresh_app = cli_mod.build_app()
-    log_file.write_text("line-1\nline-2\n", encoding="utf-8")
-    monkeypatch.setattr(
-        "builtins.open",
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("read failed")),
-    )
-    result = runner.invoke(fresh_app, ["ui", "logs", "--no-follow"])
-    assert result.exit_code == 0
-    assert "Error reading logs: read failed" in _strip(result.output)
-
-    monkeypatch.setattr(cli_mod.time, "sleep", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(cli_mod, "_require_admin_extras", lambda: None)
-    monkeypatch.setattr(cli_mod, "_get_pid", lambda _pid_file: None)
-    monkeypatch.setattr(cli_mod, "_port_is_available", lambda _host, _port: True)
-    monkeypatch.setattr(
-        cli_mod,
-        "_ensure_tls_certificates",
-        lambda *_args, **_kwargs: (
-            Path("/tmp/localhost.crt"),
-            Path("/tmp/localhost.key"),
-        ),
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_db_config_for_env",
-        lambda _env: {"ui_port": "8911", "engine_type": "aurora"},
-    )
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_config_path",
-        lambda: cli_namespace,
-    )
-
-    class _PopenOk:
-        pid = 444
-
-        def poll(self):
-            return None
-
-    monkeypatch.setattr(cli_mod.subprocess, "Popen", lambda *args, **kwargs: _PopenOk())
-    fresh_app = cli_mod.build_app()
-    result = runner.invoke(fresh_app, ["bootstrap", "local"])
-    assert result.exit_code == 1
-    assert "use bootstrap aurora" in _strip(result.output)
-
-    monkeypatch.setattr("daylily_tapdb.cli.db.create_database", lambda **_kwargs: None)
-    monkeypatch.setattr("daylily_tapdb.cli.db.apply_schema", lambda **_kwargs: None)
-    monkeypatch.setattr("daylily_tapdb.cli.db.run_migrations", lambda **_kwargs: None)
-    monkeypatch.setattr("daylily_tapdb.cli.db.seed_templates", lambda **_kwargs: None)
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db._create_default_admin", lambda **_kwargs: False
-    )
-    monkeypatch.setattr("daylily_tapdb.cli.pg.pg_init", lambda **_kwargs: None)
-    monkeypatch.setattr("daylily_tapdb.cli.pg.pg_start_local", lambda **_kwargs: None)
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_db_config_for_env",
-        lambda _env: {"engine_type": "local", "ui_port": "9443"},
-    )
-    monkeypatch.setattr(
-        cli_mod, "_require_admin_extras", lambda: (_ for _ in ()).throw(SystemExit(1))
-    )
-    clear_cli_context()
-    set_cli_context(
-        client_id="testclient",
-        database_name="testdb",
-        env_name="prod",
-        config_path=cli_namespace,
-    )
-    fresh_app = cli_mod.build_app()
-    result = runner.invoke(fresh_app, ["bootstrap", "local"])
-    assert result.exit_code == 0
-    assert "Local bootstrap complete" in _strip(result.output)
-
-
-def test_config_init_update_and_info_commands(
-    cli_namespace: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    fresh_app = cli_mod.build_app()
-    init_path = tmp_path / "new-config.yaml"
-    clear_cli_context()
-    set_cli_context(config_path=init_path)
-    result = runner.invoke(
-        fresh_app,
-        [
-            "config",
-            "init",
-            "--client-id",
-            "atlas",
-            "--database-name",
-            "app",
-            "--owner-repo-name",
-            "lsmc-atlas",
-            "--env",
-            "dev",
-            "--env",
-            "test",
-            "--domain-code",
-            "dev=Z",
-            "--domain-code",
-            "test=Z",
-            "--db-port",
-            "dev=5533",
-            "--db-port",
-            "test=5534",
-            "--ui-port",
-            "dev=8911",
-            "--ui-port",
-            "test=8912",
-            "--schema-name",
-            "dev=tapdb_atlas_unidbtst_dev",
-        ],
-    )
-    assert result.exit_code == 0
-    init_payload = yaml.safe_load(init_path.read_text(encoding="utf-8"))
-    assert init_payload["meta"]["client_id"] == "atlas"
-    assert init_payload["environments"]["dev"]["ui_port"] == "8911"
-    assert (
-        init_payload["environments"]["dev"]["schema_name"] == "tapdb_atlas_unidbtst_dev"
-    )
-    assert init_payload["environments"]["test"]["port"] == "5534"
-    assert init_payload["environments"]["test"]["schema_name"] == "tapdb_app_test"
-
-    clear_cli_context()
-    set_cli_context(config_path=init_path)
-    result = runner.invoke(
-        fresh_app,
-        [
-            "config",
-            "init",
-            "--client-id",
-            "other",
-            "--database-name",
-            "app",
-            "--owner-repo-name",
-            "other-repo",
-            "--domain-code",
-            "dev=Z",
-            "--db-port",
-            "dev=5533",
-            "--ui-port",
-            "dev=8911",
-        ],
-    )
-    assert result.exit_code != 0
-
-    clear_cli_context()
-    set_cli_context(
-        client_id="testclient",
-        database_name="testdb",
-        env_name="dev",
-        config_path=cli_namespace,
-    )
-    fresh_app = cli_mod.build_app()
-    result = runner.invoke(
-        fresh_app,
-        ["config", "update", "--env", "dev", "--clear", "invalid"],
-    )
-    assert result.exit_code != 0
-
-    empty_cfg = tmp_path / "empty.yaml"
-    clear_cli_context()
-    set_cli_context(
-        client_id="testclient",
-        database_name="testdb",
-        env_name="dev",
-        config_path=empty_cfg,
-    )
-    fresh_app = cli_mod.build_app()
-    result = runner.invoke(
-        fresh_app, ["config", "update", "--env", "dev", "--host", "db.local"]
-    )
-    assert result.exit_code != 0
-
-    bad_meta_cfg = tmp_path / "bad-meta.yaml"
-    bad_meta_cfg.write_text("environments: {}\n", encoding="utf-8")
-    clear_cli_context()
-    set_cli_context(
-        client_id="testclient",
-        database_name="testdb",
-        env_name="dev",
-        config_path=bad_meta_cfg,
-    )
-    fresh_app = cli_mod.build_app()
-    result = runner.invoke(
-        fresh_app, ["config", "update", "--env", "dev", "--host", "db.local"]
-    )
-    assert result.exit_code != 0
-
-    bad_admin_cfg = tmp_path / "bad-admin.yaml"
-    bad_admin_cfg.write_text(
-        "meta:\n"
-        "  client_id: testclient\n"
-        "  database_name: testdb\n"
-        "admin: not-a-map\n"
-        "environments:\n"
-        "  dev: {}\n",
-        encoding="utf-8",
-    )
-    clear_cli_context()
-    set_cli_context(
-        client_id="testclient",
-        database_name="testdb",
-        env_name="dev",
-        config_path=bad_admin_cfg,
-    )
-    fresh_app = cli_mod.build_app()
-    result = runner.invoke(
-        fresh_app, ["config", "update", "--env", "dev", "--host", "db.local"]
-    )
-    assert result.exit_code != 0
-
-    clear_cli_context()
-    set_cli_context(
-        client_id="testclient",
-        database_name="testdb",
-        env_name="dev",
-        config_path=cli_namespace,
-    )
-    fresh_app = cli_mod.build_app()
-    result = runner.invoke(fresh_app, ["config", "update", "--env", "dev"])
-    assert result.exit_code != 0
-
-    result = runner.invoke(
-        fresh_app,
-        [
+            str(cfg_path),
             "config",
             "update",
-            "--env",
-            "dev",
-            "--host",
-            "db.internal",
             "--schema-name",
-            "tapdb_testdb_dev_next",
-            "--port",
-            "6543",
-            "--ui-port",
-            "9443",
-            "--support-email",
-            "support@example.com",
-            "--admin-repo-url",
-            "https://github.com/example/tapdb-core",
-            "--admin-session-secret",
-            "new-secret",
-            "--admin-auth-mode",
-            "shared_host",
-            "--admin-disabled-user-email",
-            "admin@example.com",
-            "--admin-disabled-user-role",
-            "admin",
-            "--admin-shared-host-session-secret",
-            "shared-host-secret",
-            "--admin-shared-host-session-cookie",
-            "tapdb_session",
-            "--admin-shared-host-session-max-age-seconds",
-            "3600",
-            "--admin-allowed-origin",
-            "https://portal.example.com",
-            "--admin-tls-cert-path",
-            "/tmp/localhost.crt",
-            "--admin-tls-key-path",
-            "/tmp/localhost.key",
-            "--admin-metrics-enabled",
-            "--admin-metrics-queue-max",
-            "500",
-            "--admin-metrics-flush-seconds",
-            "2.5",
-            "--clear",
-            "support_email",
+            "tapdb_updated",
+            "--destructive-operations",
+            "blocked",
         ],
     )
+    assert update.exit_code == 0, update.output
+
+    root = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    assert root["target"]["schema_name"] == "tapdb_updated"
+    assert root["safety"]["destructive_operations"] == "blocked"
+    assert "environments" not in root
+
+    info = runner.invoke(app, ["--config", str(cfg_path), "info", "--json"])
+    assert info.exit_code == 0, info.output
+    assert '"target": "explicit"' in info.output
+    assert '"schema_name": "tapdb_updated"' in info.output
+
+
+def test_ui_mkcert_generates_under_explicit_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    commands: list[list[str]] = []
+
+    def _fake_run(cmd, capture_output=True, text=True):
+        commands.append(list(cmd))
+        if "-cert-file" in cmd:
+            cert = Path(cmd[cmd.index("-cert-file") + 1])
+            key = Path(cmd[cmd.index("-key-file") + 1])
+            cert.parent.mkdir(parents=True, exist_ok=True)
+            key.parent.mkdir(parents=True, exist_ok=True)
+            cert.write_text("cert", encoding="utf-8")
+            key.write_text("key", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda name: "/usr/local/bin/mkcert")
+    monkeypatch.setattr(cli_mod.subprocess, "run", _fake_run)
+
+    result = runner.invoke(app, ["ui", "mkcert"])
+
+    assert result.exit_code == 0, result.output
+    assert commands[0] == ["/usr/local/bin/mkcert", "-install"]
+    assert any("-cert-file" in cmd for cmd in commands)
+
+
+def test_ui_logs_without_log_file_is_clear() -> None:
+    result = runner.invoke(app, ["ui", "logs"])
+
     assert result.exit_code == 0
-    updated = yaml.safe_load(cli_namespace.read_text(encoding="utf-8"))
-    assert updated["environments"]["dev"]["host"] == "db.internal"
-    assert updated["environments"]["dev"]["schema_name"] == "tapdb_testdb_dev_next"
-    assert (
-        updated["admin"]["footer"]["repo_url"]
-        == "https://github.com/example/tapdb-core"
-    )
-    assert updated["admin"]["auth"]["mode"] == "shared_host"
-    assert updated["admin"]["metrics"]["queue_max"] == 500
+    assert "No log file found" in result.output
 
-    monkeypatch.setattr(cli_mod, "_get_pid", lambda _pid_file: 321)
 
-    def _info_run(cmd, capture_output=True, text=True, env=None, timeout=None):
-        if cmd[:2] == ["ps", "-p"]:
-            return SimpleNamespace(
-                returncode=0,
-                stdout="Mon Apr 07 12:34:56 2025\n",
-                stderr="",
-            )
-        if cmd[0] == "psql" and cmd[-1] == "select 1;":
-            return SimpleNamespace(returncode=0, stdout="1\n", stderr="")
-        if cmd[0] == "psql" and "pg_postmaster_start_time" in cmd[-1]:
-            return SimpleNamespace(returncode=0, stdout="00:10:00\n", stderr="")
-        raise AssertionError(cmd)
+def test_root_env_option_is_not_registered() -> None:
+    result = runner.invoke(app, ["--env", "dev", "version"])
 
-    monkeypatch.setattr("shutil.which", lambda name: name)
-    monkeypatch.setattr(cli_mod.subprocess, "run", _info_run)
-    monkeypatch.setattr(
-        "daylily_tapdb.cli.db_config.get_db_config_for_env",
-        lambda env_name: {
-            "host": "localhost",
-            "port": "5533" if env_name == "dev" else "5534",
-            "user": "tapdb",
-            "password": "secret",
-            "database": f"tapdb_{env_name}",
-            "schema_name": f"tapdb_testdb_{env_name}",
-        },
-    )
-    result = runner.invoke(fresh_app, ["info", "--check-all-envs", "--json"])
-    assert result.exit_code == 0
-    payload = json.loads(result.output)
-    assert payload["ui"]["running"] is True
-    assert payload["postgres"]["dev"]["status"] == "ok"
-
-    monkeypatch.setattr(
-        cli_mod.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(
-            returncode=1, stdout="", stderr="ps failed"
-        ),
-    )
-    result = runner.invoke(fresh_app, ["info"])
-    assert result.exit_code == 0
+    assert result.exit_code == 2
+    assert "No such option" in result.output

--- a/tests/test_coverage_boost.py
+++ b/tests/test_coverage_boost.py
@@ -389,6 +389,7 @@ class TestConnection:
 
 class TestPasswords:
     def test_hash_password(self):
+        pytest.importorskip("passlib.context")
         from daylily_tapdb.passwords import hash_password
 
         h = hash_password("mysecret")
@@ -407,12 +408,14 @@ class TestPasswords:
             hash_password(None)
 
     def test_verify_password_correct(self):
+        pytest.importorskip("passlib.context")
         from daylily_tapdb.passwords import hash_password, verify_password
 
         h = hash_password("test123")
         assert verify_password("test123", h) is True
 
     def test_verify_password_wrong(self):
+        pytest.importorskip("passlib.context")
         from daylily_tapdb.passwords import hash_password, verify_password
 
         h = hash_password("test123")

--- a/tests/test_db_safety.py
+++ b/tests/test_db_safety.py
@@ -189,7 +189,7 @@ def test_db_migrate_idempotent_when_all_migrations_already_applied(
 
     monkeypatch.setattr(m, "_run_psql", fake_run_psql)
 
-    m.db_migrate(m.Environment.dev, dry_run=False)
+    m.db_migrate(dry_run=False)
 
     # Ensure we never attempted to apply a migration file.
     assert not any(c["file"] is not None for c in calls)
@@ -231,7 +231,7 @@ def test_db_migrate_uses_installed_data_migrations(tmp_path, monkeypatch):
     monkeypatch.setattr(m, "_run_psql", fake_run_psql)
     monkeypatch.setattr(m, "_log_operation", lambda *_args, **_kwargs: None)
 
-    m.db_migrate(m.Environment.dev, dry_run=False)
+    m.db_migrate(dry_run=False)
 
     assert any(c["file"] == migration_file for c in calls)
 
@@ -267,14 +267,14 @@ def test_db_nuke_drops_outbox_and_inbox_tables_before_scope_functions(monkeypatc
     captured: dict[str, str] = {}
 
     def fake_run_psql(env, *, sql=None, file=None):
-        assert env == m.Environment.dev
+        assert env == m.Environment.target
         assert file is None
         captured["sql"] = sql or ""
         return True, ""
 
     monkeypatch.setattr(m, "_run_psql", fake_run_psql)
 
-    m.db_nuke(m.Environment.dev, force=True)
+    m.db_nuke(confirm_target="None/None/tapdb_dev@tapdb_dev")
 
     sql = captured["sql"]
     outbox_attempt_drop = "DROP TABLE IF EXISTS outbox_event_attempt CASCADE;"
@@ -307,13 +307,13 @@ def test_ensure_instance_prefix_sequence_rejects_invalid_prefix():
     import daylily_tapdb.cli.db as m
 
     with pytest.raises(ValueError, match="must match"):
-        m._ensure_instance_prefix_sequence(m.Environment.dev, "ABCDE")
+        m._ensure_instance_prefix_sequence(m.Environment.target, "ABCDE")
 
     with pytest.raises(ValueError, match="cannot be empty"):
-        m._ensure_instance_prefix_sequence(m.Environment.dev, "")
+        m._ensure_instance_prefix_sequence(m.Environment.target, "")
 
     with pytest.raises(ValueError, match="cannot be empty"):
-        m._ensure_instance_prefix_sequence(m.Environment.dev, "   ")
+        m._ensure_instance_prefix_sequence(m.Environment.target, "   ")
 
     m._normalize_instance_prefix("A1")
 
@@ -329,7 +329,7 @@ def test_ensure_instance_prefix_sequence_quotes_sql(monkeypatch):
         return True, ""
 
     monkeypatch.setattr(m, "_run_psql", fake_run_psql)
-    m._ensure_instance_prefix_sequence(m.Environment.dev, "AGX")
+    m._ensure_instance_prefix_sequence(m.Environment.target, "AGX")
 
     sql = captured["sql"]
     assert '"agx_instance_seq"' in sql

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -16,7 +16,7 @@ def test_readme_exists_and_points_to_examples() -> None:
     assert "examples/readme/10_bootstrap_local.sh" in text
     assert "examples/readme/20_python_api.py" in text
     assert "source ./activate" in text
-    assert "tapdb --config <path> --env <name>" in text
+    assert "tapdb --config <path> ..." in text
     assert "--json info" in text
 
 
@@ -32,7 +32,8 @@ def test_examples_contain_the_canonical_commands() -> None:
     )
 
     assert "tapdb --help" in smoke
-    assert "db-config init" in bootstrap
+    assert "config init" in bootstrap
+    assert "--env" not in bootstrap
     assert "bootstrap local --no-gui" in bootstrap
     assert "TAPDBConnection" in python_api
     assert "TemplateManager" in python_api

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -88,7 +88,7 @@ def docs_local_runtime(tmp_path_factory: pytest.TempPathFactory) -> dict[str, ob
 
     stop_cmd = (
         "source ./activate >/dev/null 2>&1 && "
-        f"tapdb --config '{config_path}' --env dev pg stop-local dev"
+        f"tapdb --config '{config_path}' pg stop-local"
     )
     subprocess.run(
         ["bash", "-lc", stop_cmd],

--- a/tests/test_explicit_context.py
+++ b/tests/test_explicit_context.py
@@ -2,12 +2,9 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from types import SimpleNamespace
 
-import pytest
 from typer.testing import CliRunner
 
-import daylily_tapdb.cli as cli_mod
 from admin.db_metrics import current_metrics_path
 from daylily_tapdb.cli import app
 from daylily_tapdb.cli.context import (
@@ -15,7 +12,7 @@ from daylily_tapdb.cli.context import (
     resolve_context,
     set_cli_context,
 )
-from daylily_tapdb.cli.db_config import get_db_config_for_env
+from daylily_tapdb.cli.db_config import get_db_config
 
 runner = CliRunner()
 
@@ -30,7 +27,8 @@ def _write_config(path: Path) -> Path:
     )
     prefix_registry.write_text(
         (
-            '{"version":"0.4.0","ownership":{"Z":{"TPX":{"issuer_app_code":"daylily-tapdb"},'
+            '{"version":"0.4.0","ownership":{"Z":{'
+            '"TPX":{"issuer_app_code":"daylily-tapdb"},'
             '"EDG":{"issuer_app_code":"daylily-tapdb"},'
             '"ADT":{"issuer_app_code":"daylily-tapdb"},'
             '"SYS":{"issuer_app_code":"daylily-tapdb"},'
@@ -40,7 +38,7 @@ def _write_config(path: Path) -> Path:
     )
     path.write_text(
         "meta:\n"
-        "  config_version: 3\n"
+        "  config_version: 4\n"
         "  client_id: alpha\n"
         "  database_name: beta\n"
         "  owner_repo_name: daylily-tapdb\n"
@@ -74,37 +72,30 @@ def _write_config(path: Path) -> Path:
         "  db_max_overflow: 10\n"
         "  db_pool_timeout: 30\n"
         "  db_pool_recycle: 1800\n"
-        "environments:\n"
-        "  dev:\n"
-        "    engine_type: local\n"
-        "    host: localhost\n"
-        "    port: '5533'\n"
-        "    ui_port: '8911'\n"
-        "    domain_code: Z\n"
-        "    user: tapdb\n"
-        "    password: filepw\n"
-        "    database: tapdb_dev\n"
-        "    schema_name: tapdb_beta_dev\n"
-        "  test:\n"
-        "    engine_type: local\n"
-        "    host: localhost\n"
-        "    port: '5534'\n"
-        "    ui_port: '8912'\n"
-        "    domain_code: Z\n"
-        "    user: tapdb\n"
-        "    password: ''\n"
-        "    database: tapdb_test\n"
-        "    schema_name: tapdb_beta_test\n",
+        "target:\n"
+        "  engine_type: local\n"
+        "  host: localhost\n"
+        "  port: '5533'\n"
+        "  ui_port: '8911'\n"
+        "  domain_code: Z\n"
+        "  user: tapdb\n"
+        "  password: filepw\n"
+        "  database: tapdb_shared\n"
+        "  schema_name: tapdb_beta\n"
+        "safety:\n"
+        "  safety_tier: shared\n"
+        "  destructive_operations: confirm_required\n",
         encoding="utf-8",
     )
     os.chmod(path, 0o600)
     return path
 
 
-@pytest.fixture(autouse=True)
-def _clear_cli_context_fixture() -> None:
+def setup_function() -> None:
     clear_cli_context()
-    yield
+
+
+def teardown_function() -> None:
     clear_cli_context()
 
 
@@ -113,18 +104,16 @@ def test_resolve_context_uses_explicit_config_metadata_and_runtime_dir(tmp_path:
         tmp_path / ".config" / "tapdb" / "alpha" / "beta" / "tapdb-config.yaml"
     )
 
-    set_cli_context(config_path=cfg_path, env_name="dev")
-    ctx = resolve_context(require_keys=True, env_name="dev")
+    set_cli_context(config_path=cfg_path)
+    ctx = resolve_context(require_keys=True)
 
     assert ctx.client_id == "alpha"
     assert ctx.database_name == "beta"
     assert ctx.config_path() == cfg_path
-    assert ctx.runtime_dir("dev") == cfg_path.parent / "dev"
+    assert ctx.runtime_dir() == cfg_path.parent / "runtime"
 
 
-def test_get_db_config_for_env_ignores_ambient_env_fallbacks(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
+def test_get_db_config_ignores_ambient_env_defaults(monkeypatch, tmp_path: Path):
     cfg_path = _write_config(
         tmp_path / ".config" / "tapdb" / "alpha" / "beta" / "tapdb-config.yaml"
     )
@@ -134,19 +123,19 @@ def test_get_db_config_for_env_ignores_ambient_env_fallbacks(
     monkeypatch.setenv("PGPORT", "9999")
     monkeypatch.setenv("PGPASSWORD", "envpw")
 
-    set_cli_context(config_path=cfg_path, env_name="dev")
-    cfg = get_db_config_for_env("dev")
+    set_cli_context(config_path=cfg_path)
+    cfg = get_db_config()
 
     assert cfg["client_id"] == "alpha"
     assert cfg["database_name"] == "beta"
     assert cfg["host"] == "localhost"
     assert cfg["port"] == "5533"
     assert cfg["password"] == "filepw"
-    assert cfg["schema_name"] == "tapdb_beta_dev"
+    assert cfg["schema_name"] == "tapdb_beta"
     assert cfg["config_path"] == str(cfg_path)
 
 
-def test_runtime_command_requires_explicit_config_and_env(tmp_path: Path):
+def test_runtime_command_requires_explicit_config_and_rejects_env(tmp_path: Path):
     cfg_path = _write_config(
         tmp_path / ".config" / "tapdb" / "alpha" / "beta" / "tapdb-config.yaml"
     )
@@ -158,68 +147,21 @@ def test_runtime_command_requires_explicit_config_and_env(tmp_path: Path):
     assert str(result.exception) == "TapDB config path is required. Set --config."
 
     result = runner.invoke(app, ["--config", str(cfg_path), "--env", "dev", "info"])
+    assert result.exit_code == 2
+    assert "No such option" in result.output
 
+    result = runner.invoke(app, ["--config", str(cfg_path), "info"])
     assert result.exit_code == 0
     assert "alpha" in result.output
     assert "beta" in result.output
 
 
-def test_metrics_runtime_dir_follows_config_parent(tmp_path: Path):
+def test_metrics_runtime_dir_follows_explicit_config_parent(tmp_path: Path):
     cfg_path = _write_config(
         tmp_path / ".config" / "tapdb" / "alpha" / "beta" / "tapdb-config.yaml"
     )
 
-    set_cli_context(config_path=cfg_path, env_name="test")
-    metrics_path = current_metrics_path("test")
+    set_cli_context(config_path=cfg_path)
+    metrics_path = current_metrics_path("ignored")
 
-    assert metrics_path.parent == cfg_path.parent / "test" / "metrics"
-
-
-def test_ui_start_launches_admin_server_with_explicit_context(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
-    cfg_path = _write_config(
-        tmp_path / ".config" / "tapdb" / "alpha" / "beta" / "tapdb-config.yaml"
-    )
-    cert_path = tmp_path / "certs" / "localhost.crt"
-    key_path = tmp_path / "certs" / "localhost.key"
-    cert_path.parent.mkdir(parents=True, exist_ok=True)
-    cert_path.write_text("cert", encoding="utf-8")
-    key_path.write_text("key", encoding="utf-8")
-
-    captured: dict[str, list[str]] = {}
-
-    def _fake_popen(cmd, **kwargs):
-        _ = kwargs
-        captured["cmd"] = list(cmd)
-        return SimpleNamespace(pid=12345, poll=lambda: None)
-
-    monkeypatch.setattr(cli_mod, "_require_admin_extras", lambda: None)
-    monkeypatch.setattr(cli_mod, "_get_pid", lambda _path: None)
-    monkeypatch.setattr(cli_mod, "_port_is_available", lambda _host, _port: True)
-    monkeypatch.setattr(
-        cli_mod,
-        "_ensure_tls_certificates",
-        lambda _host, env_name=None, cert_file=None, key_file=None: (
-            cert_path,
-            key_path,
-        ),
-    )
-    monkeypatch.setattr(cli_mod.subprocess, "Popen", _fake_popen)
-    monkeypatch.setattr(cli_mod.time, "sleep", lambda _secs: None)
-
-    result = runner.invoke(
-        app,
-        ["--config", str(cfg_path), "--env", "dev", "ui", "start", "--background"],
-    )
-
-    assert result.exit_code == 0
-    assert captured["cmd"][:3] == [
-        cli_mod.sys.executable,
-        "-m",
-        "daylily_tapdb.cli.admin_server",
-    ]
-    assert "--config" in captured["cmd"]
-    assert str(cfg_path) in captured["cmd"]
-    assert "--env" in captured["cmd"]
-    assert "dev" in captured["cmd"]
+    assert metrics_path.parent == cfg_path.parent / "runtime" / "metrics"

--- a/tests/test_explicit_target_cutover.py
+++ b/tests/test_explicit_target_cutover.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from click.exceptions import Exit
+from typer.testing import CliRunner
+
+import daylily_tapdb.cli as cli_mod
+from daylily_tapdb.cli import app
+from daylily_tapdb.cli.context import clear_cli_context, set_cli_context
+from daylily_tapdb.cli.db import _require_destructive_confirmation
+from daylily_tapdb.cli.db_config import get_db_config
+
+runner = CliRunner()
+
+
+def _write_registries(root: Path) -> tuple[Path, Path]:
+    domain_registry = root / "domain_code_registry.json"
+    prefix_registry = root / "prefix_ownership_registry.json"
+    domain_registry.write_text(
+        '{"version":"0.4.0","domains":{"Z":{"name":"test-localhost"}}}\n',
+        encoding="utf-8",
+    )
+    prefix_registry.write_text(
+        (
+            '{"version":"0.4.0","ownership":{"Z":{'
+            '"TPX":{"issuer_app_code":"daylily-tapdb"},'
+            '"EDG":{"issuer_app_code":"daylily-tapdb"},'
+            '"ADT":{"issuer_app_code":"daylily-tapdb"},'
+            '"SYS":{"issuer_app_code":"daylily-tapdb"},'
+            '"MSG":{"issuer_app_code":"daylily-tapdb"}}}}\n'
+        ),
+        encoding="utf-8",
+    )
+    return domain_registry, prefix_registry
+
+
+def _init_explicit_config(tmp_path: Path) -> Path:
+    cfg_path = tmp_path / "tapdb-config.yaml"
+    domain_registry, prefix_registry = _write_registries(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(cfg_path),
+            "config",
+            "init",
+            "--client-id",
+            "alpha",
+            "--database-name",
+            "beta",
+            "--owner-repo-name",
+            "daylily-tapdb",
+            "--domain-code",
+            "Z",
+            "--domain-registry-path",
+            str(domain_registry),
+            "--prefix-ownership-registry-path",
+            str(prefix_registry),
+            "--engine-type",
+            "local",
+            "--host",
+            "localhost",
+            "--port",
+            "5533",
+            "--ui-port",
+            "8911",
+            "--user",
+            "tapdb",
+            "--database",
+            "tapdb_shared",
+            "--schema-name",
+            "tapdb_alpha_beta",
+            "--safety-tier",
+            "shared",
+            "--destructive-operations",
+            "confirm_required",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    return cfg_path
+
+
+@pytest.fixture(autouse=True)
+def _clear_context() -> None:
+    clear_cli_context()
+    yield
+    clear_cli_context()
+
+
+def test_root_rejects_legacy_env_selector(tmp_path: Path) -> None:
+    cfg_path = _init_explicit_config(tmp_path)
+
+    result = runner.invoke(app, ["--config", str(cfg_path), "--env", "dev", "info"])
+
+    assert result.exit_code == 2
+    assert "No such option" in result.output
+
+
+def test_explicit_config_init_writes_single_resolved_target(tmp_path: Path) -> None:
+    cfg_path = _init_explicit_config(tmp_path)
+    raw = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+
+    assert raw["meta"]["config_version"] == 4
+    assert raw["meta"]["client_id"] == "alpha"
+    assert raw["meta"]["database_name"] == "beta"
+    assert "environments" not in raw
+    assert raw["target"]["database"] == "tapdb_shared"
+    assert raw["target"]["schema_name"] == "tapdb_alpha_beta"
+    assert raw["safety"] == {
+        "safety_tier": "shared",
+        "destructive_operations": "confirm_required",
+    }
+
+    set_cli_context(config_path=cfg_path)
+    cfg = get_db_config()
+    assert cfg["client_id"] == "alpha"
+    assert cfg["database_name"] == "beta"
+    assert cfg["database"] == "tapdb_shared"
+    assert cfg["schema_name"] == "tapdb_alpha_beta"
+
+
+def test_legacy_v3_environment_config_is_rejected(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "tapdb-config.yaml"
+    domain_registry, prefix_registry = _write_registries(tmp_path)
+    cfg_path.write_text(
+        "meta:\n"
+        "  config_version: 3\n"
+        "  client_id: alpha\n"
+        "  database_name: beta\n"
+        "  owner_repo_name: daylily-tapdb\n"
+        f"  domain_registry_path: {domain_registry}\n"
+        f"  prefix_ownership_registry_path: {prefix_registry}\n"
+        "environments:\n"
+        "  dev:\n"
+        "    engine_type: local\n"
+        "    host: localhost\n"
+        "    port: '5533'\n"
+        "    ui_port: '8911'\n"
+        "    domain_code: Z\n"
+        "    user: tapdb\n"
+        "    database: tapdb_dev\n"
+        "    schema_name: tapdb_beta_dev\n",
+        encoding="utf-8",
+    )
+    cfg_path.chmod(0o600)
+    set_cli_context(config_path=cfg_path)
+
+    with pytest.raises(RuntimeError, match="Unsupported config_version '3'"):
+        get_db_config()
+
+
+def test_ui_start_launches_admin_server_without_env_argument(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cfg_path = _init_explicit_config(tmp_path)
+    cert_path = tmp_path / "certs" / "localhost.crt"
+    key_path = tmp_path / "certs" / "localhost.key"
+    cert_path.parent.mkdir(parents=True, exist_ok=True)
+    cert_path.write_text("cert", encoding="utf-8")
+    key_path.write_text("key", encoding="utf-8")
+    captured: dict[str, list[str]] = {}
+
+    def _fake_popen(cmd, **kwargs):
+        _ = kwargs
+        captured["cmd"] = list(cmd)
+        return SimpleNamespace(pid=12345, poll=lambda: None)
+
+    monkeypatch.setattr(cli_mod, "_require_admin_extras", lambda: None)
+    monkeypatch.setattr(cli_mod, "_get_pid", lambda _path: None)
+    monkeypatch.setattr(cli_mod, "_port_is_available", lambda _host, _port: True)
+    monkeypatch.setattr(
+        cli_mod,
+        "_ensure_tls_certificates",
+        lambda _host, cert_file=None, key_file=None: (cert_path, key_path),
+    )
+    monkeypatch.setattr(cli_mod.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(cli_mod.time, "sleep", lambda _secs: None)
+
+    result = runner.invoke(
+        app,
+        ["--config", str(cfg_path), "ui", "start", "--background"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["cmd"][:3] == [
+        cli_mod.sys.executable,
+        "-m",
+        "daylily_tapdb.cli.admin_server",
+    ]
+    assert "--config" in captured["cmd"]
+    assert str(cfg_path) in captured["cmd"]
+    assert "--env" not in captured["cmd"]
+
+
+def test_destructive_confirmation_uses_resolved_target_label() -> None:
+    cfg = {
+        "client_id": "atlas",
+        "database_name": "orders",
+        "schema_name": "tapdb_atlas_dayfly5_dev",
+        "database": "tapdb_dayfly5_dev",
+        "destructive_operations": "confirm_required",
+    }
+
+    with pytest.raises(Exit):
+        _require_destructive_confirmation(
+            cfg,
+            operation="reset schema",
+            confirm_target=None,
+        )
+
+    _require_destructive_confirmation(
+        cfg,
+        operation="reset schema",
+        confirm_target="atlas/orders/tapdb_atlas_dayfly5_dev@tapdb_dayfly5_dev",
+    )

--- a/tests/test_pg_integration.py
+++ b/tests/test_pg_integration.py
@@ -28,7 +28,6 @@ def _set_context(pg_instance, monkeypatch):
     set_cli_context(
         client_id="testclient",
         database_name="testdb",
-        env_name="dev",
         config_path=info["config_path"],
     )
     monkeypatch.setattr(cli_mod, "PID_FILE", info["base"] / "ui.pid")
@@ -62,7 +61,7 @@ class TestPgConnectivity:
 class TestSchemaApply:
     def test_db_schema_apply(self, pg_instance):
         """Apply the full tapdb schema to the ephemeral database."""
-        result = runner.invoke(app, ["db", "schema", "apply", "dev"])
+        result = runner.invoke(app, ["db", "schema", "apply"])
         output = result.output
         # Should succeed or at least exercise the code path
         assert result.exit_code in (0, 1), f"exit={result.exit_code}\n{output}"
@@ -96,7 +95,7 @@ class TestSchemaApply:
 
 class TestSchemaStatus:
     def test_db_schema_status(self, pg_instance):
-        result = runner.invoke(app, ["db", "schema", "status", "dev"])
+        result = runner.invoke(app, ["db", "schema", "status"])
         assert result.exit_code in (0, 1)
 
 
@@ -108,7 +107,7 @@ class TestSchemaStatus:
 class TestDbLifecycle:
     def test_db_create_already_exists(self, pg_instance):
         """db create should handle 'already exists' gracefully."""
-        result = runner.invoke(app, ["db", "create", "dev"])
+        result = runner.invoke(app, ["db", "create"])
         assert result.exit_code in (0, 1)
 
     def test_db_config_validate(self, pg_instance):
@@ -124,7 +123,7 @@ class TestDbLifecycle:
 class TestDataSeed:
     def test_db_data_seed(self, pg_instance):
         """Attempt to seed template data. May fail if schema not applied."""
-        result = runner.invoke(app, ["db", "data", "seed", "dev"])
+        result = runner.invoke(app, ["db", "data", "seed"])
         assert result.exit_code in (0, 1)
 
 
@@ -164,7 +163,7 @@ class TestConnectionModule:
 
 class TestSchemaMigrate:
     def test_db_schema_migrate(self, pg_instance):
-        result = runner.invoke(app, ["db", "schema", "migrate", "dev"])
+        result = runner.invoke(app, ["db", "schema", "migrate"])
         assert result.exit_code in (0, 1)
 
 

--- a/tests/test_runtime_utils_coverage.py
+++ b/tests/test_runtime_utils_coverage.py
@@ -1,814 +1,270 @@
+"""Runtime/admin utility coverage for explicit TapDB targets."""
+
 from __future__ import annotations
 
 import json
-import sys
-import uuid
-from datetime import datetime, timedelta, timezone
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from fastapi import HTTPException
-from sqlalchemy import create_engine
+from fastapi import FastAPI, HTTPException
+from starlette.requests import Request
 
-import daylily_tapdb.audit as audit_mod
 import daylily_tapdb.cli.admin_server as admin_server_mod
-import daylily_tapdb.outbox.inbox as inbox_mod
-import daylily_tapdb.outbox.queries as outbox_queries_mod
-import daylily_tapdb.stats as stats_mod
-import daylily_tapdb.web as web_mod
 import daylily_tapdb.web.factory as web_factory_mod
 import daylily_tapdb.web.runtime as runtime_mod
+from daylily_tapdb.cli.context import clear_cli_context, set_cli_context
 from daylily_tapdb.web.bridge import TapdbHostBridge
 
 
-class _MappingResult:
-    def __init__(self, rows):
-        self._rows = list(rows)
-
-    def mappings(self):
-        return self
-
-    def all(self):
-        return list(self._rows)
-
-    def one(self):
-        return self._rows[0]
-
-    def __iter__(self):
-        return iter(self._rows)
-
-
-class _ScalarResult:
-    def __init__(self, rows=None, scalar=None):
-        self._rows = list(rows or [])
-        self._scalar = scalar
-
-    def all(self):
-        return list(self._rows)
-
-    def scalars(self):
-        return self
-
-    def scalar_one_or_none(self):
-        return self._scalar
-
-
-class _QueryStub:
-    def __init__(self, first_value=None, one_value=None):
-        self._first_value = first_value
-        self._one_value = one_value
-
-    def filter(self, *_args, **_kwargs):
-        return self
-
-    def first(self):
-        return self._first_value
-
-    def one(self):
-        return self._one_value
-
-
-def test_query_audit_trail_builds_filtered_sql_and_dataclasses():
-    changed_at = datetime(2026, 4, 7, 10, 0, tzinfo=timezone.utc)
-    captured = {}
-
-    class _Session:
-        def execute(self, statement, params):
-            captured["sql"] = str(statement)
-            captured["params"] = dict(params)
-            return _MappingResult(
-                [
-                    {
-                        "euid": "GX1",
-                        "changed_by": "admin",
-                        "operation_type": "UPDATE",
-                        "changed_at": changed_at,
-                        "name": "Root Tube",
-                        "polymorphic_discriminator": "generic_instance",
-                        "category": "container",
-                        "type": "tube",
-                        "subtype": "sample",
-                        "bstatus": "active",
-                        "old_value": "old",
-                        "new_value": "new",
-                    }
-                ]
-            )
-
-    rows = audit_mod.query_audit_trail(
-        _Session(),
-        changed_by="admin",
-        euid="GX1",
-        since=changed_at,
-        domain_code="DAY",
-        issuer_app_code="CORE",
-        limit=25,
-        order="asc",
+def _write_config(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    domain_registry = path.parent / "domain_code_registry.json"
+    prefix_registry = path.parent / "prefix_ownership_registry.json"
+    domain_registry.write_text(
+        '{"version":"0.4.0","domains":{"Z":{"name":"test"}}}\n',
+        encoding="utf-8",
     )
-
-    assert rows == [
-        audit_mod.AuditEntry(
-            euid="GX1",
-            changed_by="admin",
-            operation_type="UPDATE",
-            changed_at=changed_at,
-            name="Root Tube",
-            polymorphic_discriminator="generic_instance",
-            category="container",
-            type="tube",
-            subtype="sample",
-            bstatus="active",
-            old_value="old",
-            new_value="new",
-        )
-    ]
-    assert "al.changed_by = :changed_by" in captured["sql"]
-    assert "al.rel_table_euid_fk = :euid" in captured["sql"]
-    assert "al.changed_at >= :since" in captured["sql"]
-    assert "al.domain_code = :domain_code" in captured["sql"]
-    assert "al.issuer_app_code = :issuer_app_code" in captured["sql"]
-    assert "ORDER BY al.changed_at ASC" in captured["sql"]
-    assert captured["params"]["limit"] == 25
-
-
-@pytest.mark.parametrize(
-    ("fn", "expected_type", "expected_key"),
-    [
-        (stats_mod.get_template_stats, stats_mod.TemplateStats, "singleton_count"),
+    prefix_registry.write_text(
         (
-            stats_mod.get_instance_stats,
-            stats_mod.InstanceStats,
-            "distinct_polymorphic_discriminators",
+            '{"version":"0.4.0","ownership":{"Z":{'
+            '"TPX":{"issuer_app_code":"daylily-tapdb"},'
+            '"EDG":{"issuer_app_code":"daylily-tapdb"},'
+            '"ADT":{"issuer_app_code":"daylily-tapdb"},'
+            '"SYS":{"issuer_app_code":"daylily-tapdb"},'
+            '"MSG":{"issuer_app_code":"daylily-tapdb"}}}}\n'
         ),
-        (
-            stats_mod.get_lineage_stats,
-            stats_mod.LineageStats,
-            "distinct_parent_types",
-        ),
-    ],
-)
-def test_stats_queries_include_optional_filters(fn, expected_type, expected_key):
-    now = datetime(2026, 4, 7, 10, 30, tzinfo=timezone.utc)
-    captured = {}
-
-    class _Session:
-        def execute(self, statement, params):
-            captured["sql"] = str(statement)
-            captured["params"] = dict(params)
-            return _MappingResult(
-                [
-                    {
-                        "total": 4,
-                        "distinct_types": 2,
-                        "distinct_subtypes": 3,
-                        "distinct_categories": 1,
-                        "latest_created": now,
-                        "earliest_created": now - timedelta(days=7),
-                        "average_age": timedelta(days=2),
-                        "singleton_count": 1,
-                        "distinct_poly": 2,
-                        "distinct_parent_types": 2,
-                        "distinct_child_types": 3,
-                    }
-                ]
-            )
-
-    result = fn(
-        _Session(),
-        include_deleted=True,
-        domain_code="DAY",
-        issuer_app_code="CORE",
+        encoding="utf-8",
     )
-
-    assert isinstance(result, expected_type)
-    assert getattr(result, expected_key) >= 1
-    assert captured["params"]["is_deleted"] is True
-    assert captured["params"]["domain_code"] == "DAY"
-    assert captured["params"]["issuer_app_code"] == "CORE"
-    assert "domain_code = :domain_code" in captured["sql"]
-    assert "issuer_app_code = :issuer_app_code" in captured["sql"]
-
-
-def test_receive_message_handles_insert_and_existing_paths():
-    message_uuid = uuid.uuid4()
-    receipt_uuid = uuid.uuid4()
-    received_dt = datetime(2026, 4, 7, 11, 0, tzinfo=timezone.utc)
-
-    class _InsertSession:
-        def __init__(self) -> None:
-            self.flushed = False
-
-        def execute(self, _stmt):
-            return SimpleNamespace(
-                first=lambda: SimpleNamespace(
-                    receipt_machine_uuid=receipt_uuid,
-                    status="received",
-                    received_dt=received_dt,
-                )
-            )
-
-        def flush(self):
-            self.flushed = True
-
-    inserted = inbox_mod.receive_message(
-        _InsertSession(),
-        message_machine_uuid=message_uuid,
-        payload={"ok": True},
-        domain_code="DAY",
-        issuer_app_code="CORE",
-        source_destination="atlas",
+    path.write_text(
+        "meta:\n"
+        "  config_version: 4\n"
+        "  client_id: testclient\n"
+        "  database_name: testdb\n"
+        "  owner_repo_name: daylily-tapdb\n"
+        f"  domain_registry_path: {domain_registry}\n"
+        f"  prefix_ownership_registry_path: {prefix_registry}\n"
+        "admin:\n"
+        "  session:\n"
+        "    secret: secret123\n"
+        "target:\n"
+        "  engine_type: local\n"
+        "  host: localhost\n"
+        "  port: '5533'\n"
+        "  ui_port: '8911'\n"
+        "  domain_code: Z\n"
+        "  user: tapdb\n"
+        "  password: ''\n"
+        "  database: tapdb_shared\n"
+        "  schema_name: tapdb_testdb\n"
+        "safety:\n"
+        "  safety_tier: shared\n"
+        "  destructive_operations: confirm_required\n",
+        encoding="utf-8",
     )
-    assert inserted.message_machine_uuid == message_uuid
-    assert inserted.receipt_machine_uuid == receipt_uuid
-    assert inserted.status == "received"
-
-    existing_row = SimpleNamespace(
-        receipt_machine_uuid=uuid.uuid4(),
-        status="processed",
-        received_dt=received_dt,
-        processed_dt=received_dt + timedelta(minutes=5),
-    )
-
-    class _ExistingSession:
-        def execute(self, _stmt):
-            return SimpleNamespace(first=lambda: None)
-
-        def query(self, _model):
-            return _QueryStub(one_value=existing_row)
-
-    existing = inbox_mod.receive_message(
-        _ExistingSession(),
-        message_machine_uuid=message_uuid,
-        payload={"ok": True},
-    )
-    assert existing.status == "processed"
-    assert existing.processed_dt == existing_row.processed_dt
+    os.chmod(path, 0o600)
+    return path
 
 
-def test_inbox_status_helpers_execute_and_flush():
-    captured = {"count": 0}
-    expected = SimpleNamespace(message_machine_uuid=uuid.uuid4())
-
-    class _Session:
-        def execute(self, _stmt):
-            captured["count"] += 1
-
-        def flush(self):
-            captured["flushed"] = captured.get("flushed", 0) + 1
-
-        def query(self, _model):
-            return _QueryStub(first_value=expected)
-
-    session = _Session()
-    inbox_mod.mark_inbox_processing(session, expected.message_machine_uuid)
-    inbox_mod.mark_inbox_processed(session, expected.message_machine_uuid)
-    inbox_mod.mark_inbox_failed(
-        session,
-        expected.message_machine_uuid,
-        error_code="E1",
-        error_message="x" * 20_000,
-    )
-    inbox_mod.mark_inbox_rejected(
-        session,
-        expected.message_machine_uuid,
-        error_code="E2",
-        error_message="bad",
-    )
-
-    assert captured["count"] == 4
-    assert captured["flushed"] == 4
-    assert (
-        inbox_mod.get_inbox_message_by_machine_uuid(
-            session, expected.message_machine_uuid
-        )
-        is expected
-    )
+@pytest.fixture(autouse=True)
+def _explicit_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+    clear_cli_context()
+    set_cli_context(config_path=cfg_path)
+    yield cfg_path
+    clear_cli_context()
+    runtime_mod._clear_runtime_cache_for_tests()
 
 
-def test_outbox_query_helpers_return_structured_results():
-    event = SimpleNamespace(id=1, status="failed")
-    attempt = SimpleNamespace(attempt_no=1)
-    rows = iter(
-        [
-            _ScalarResult(
-                rows=[
-                    SimpleNamespace(status="pending", cnt=3),
-                    SimpleNamespace(status="failed", cnt=1),
-                ]
-            ),
-            _ScalarResult(rows=[event]),
-            _ScalarResult(rows=[event]),
-            _ScalarResult(rows=[attempt]),
-            _ScalarResult(
-                rows=[
-                    SimpleNamespace(status="received", cnt=2),
-                    SimpleNamespace(status="processed", cnt=4),
-                ]
-            ),
-            _ScalarResult(rows=[event]),
-            _ScalarResult(rows=[event]),
-            _ScalarResult(scalar=event),
-            _ScalarResult(scalar=event),
-        ]
-    )
-
-    class _Session:
-        def execute(self, _query):
-            return next(rows)
-
-    session = _Session()
-    summary = outbox_queries_mod.outbox_status_summary(
-        session, domain_code="DAY", issuer_app_code="CORE"
-    )
-    assert summary.pending == 3
-    assert summary.failed == 1
-    assert outbox_queries_mod.list_failed_events(
-        session, domain_code="DAY", issuer_app_code="CORE", limit=5
-    ) == [event]
-    assert outbox_queries_mod.list_stale_delivering(
-        session, domain_code="DAY", limit=5
-    ) == [event]
-    assert outbox_queries_mod.get_event_attempts(session, 1) == [attempt]
-    inbox_summary = outbox_queries_mod.inbox_status_summary(
-        session, domain_code="DAY", issuer_app_code="CORE"
-    )
-    assert inbox_summary.received == 2
-    assert inbox_summary.processed == 4
-    assert outbox_queries_mod.list_events_by_destination(
-        session,
-        "atlas",
-        domain_code="DAY",
-        issuer_app_code="CORE",
-        status="failed",
-        limit=3,
-    ) == [event]
-    assert outbox_queries_mod.list_by_destination(session, "atlas") == [event]
-    assert (
-        outbox_queries_mod.get_outbox_event_by_receipt_uuid(session, uuid.uuid4())
-        is event
-    )
-    assert (
-        outbox_queries_mod.lookup_by_machine_uuid(
-            session,
-            uuid.uuid4(),
-            domain_code="DAY",
-            issuer_app_code="CORE",
-        )
-        is event
-    )
-
-
-def test_admin_server_context_file_helpers_round_trip(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(
-        admin_server_mod,
-        "resolve_context",
-        lambda **_kwargs: SimpleNamespace(ui_dir=lambda env: tmp_path / "ui" / env),
-    )
-
+def test_admin_server_parser_has_no_env_argument(tmp_path: Path):
     parser = admin_server_mod._build_parser()
+
     args = parser.parse_args(
         [
             "--config",
-            "/tmp/tapdb.yaml",
-            "--env",
-            "dev",
+            str(tmp_path / "tapdb-config.yaml"),
             "--host",
-            "127.0.0.1",
+            "localhost",
             "--port",
             "8911",
             "--ssl-keyfile",
-            "/tmp/key.pem",
+            "key.pem",
             "--ssl-certfile",
-            "/tmp/cert.pem",
+            "cert.pem",
         ]
     )
-    assert args.reload is False
 
-    path = admin_server_mod._write_context_file(
-        config_path="/tmp/tapdb.yaml",
-        env_name="dev",
-        host="127.0.0.1",
+    assert args.config.endswith("tapdb-config.yaml")
+    assert not hasattr(args, "env")
+
+
+def test_admin_server_context_file_helpers_round_trip(tmp_path: Path) -> None:
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+    set_cli_context(config_path=cfg_path)
+
+    written = admin_server_mod._write_context_file(
+        config_path=str(cfg_path),
+        host="localhost",
         port=8911,
     )
-    monkeypatch.chdir(path.parent)
-    assert admin_server_mod._context_file_path() == path.parent / "context.json"
-    assert admin_server_mod._read_context_file() == {
-        "config_path": str(Path("/tmp/tapdb.yaml").expanduser().resolve()),
-        "env_name": "dev",
-        "host": "127.0.0.1",
-        "port": 8911,
-    }
 
-    (path.parent / "context.json").write_text(json.dumps(["bad"]), encoding="utf-8")
-    with pytest.raises(RuntimeError, match="Invalid TAPDB admin context file"):
-        admin_server_mod._read_context_file()
+    assert written.parent == cfg_path.parent / "runtime" / "ui"
+    payload = json.loads(written.read_text(encoding="utf-8"))
+    assert payload["target"] == "explicit"
+    assert payload["config_path"] == str(cfg_path.resolve())
 
 
-def test_admin_server_load_build_and_main_paths(tmp_path, monkeypatch):
-    fake_app = SimpleNamespace(state=SimpleNamespace())
-    fake_admin_main = SimpleNamespace(app=fake_app)
-    set_calls = []
+def test_admin_server_load_admin_app_sets_explicit_context(monkeypatch, tmp_path: Path):
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+    fake_app = FastAPI()
+    fake_admin = SimpleNamespace(app=fake_app)
+
     monkeypatch.setattr(
-        admin_server_mod, "set_cli_context", lambda **kwargs: set_calls.append(kwargs)
-    )
-    monkeypatch.setattr(
-        admin_server_mod.importlib,
-        "import_module",
-        lambda name: fake_admin_main if name == "admin.main" else None,
+        admin_server_mod.importlib, "import_module", lambda name: fake_admin
     )
     monkeypatch.setattr(admin_server_mod.importlib, "reload", lambda module: module)
 
-    app = admin_server_mod.load_admin_app(config_path="/tmp/tapdb.yaml", env_name="dev")
+    app = admin_server_mod.load_admin_app(config_path=str(cfg_path))
+
     assert app is fake_app
-    assert app.state.tapdb_admin_module is fake_admin_main
-    assert set_calls == [{"config_path": "/tmp/tapdb.yaml", "env_name": "dev"}]
-
-    monkeypatch.setattr(
-        admin_server_mod,
-        "_read_context_file",
-        lambda: {"config_path": "/tmp/tapdb.yaml", "env_name": "dev"},
-    )
-    monkeypatch.setattr(web_mod, "create_tapdb_web_app", lambda **kwargs: kwargs)
-    assert admin_server_mod.build_app() == {
-        "config_path": "/tmp/tapdb.yaml",
-        "env_name": "dev",
-    }
-
-    monkeypatch.setattr(
-        admin_server_mod,
-        "_read_context_file",
-        lambda: {"config_path": "", "env_name": "dev"},
-    )
-    with pytest.raises(RuntimeError, match="context file is incomplete"):
-        admin_server_mod.build_app()
-
-    parser = SimpleNamespace(
-        parse_args=lambda: SimpleNamespace(
-            config="/tmp/tapdb.yaml",
-            env="dev",
-            host="127.0.0.1",
-            port=8911,
-            ssl_keyfile="/tmp/key.pem",
-            ssl_certfile="/tmp/cert.pem",
-            reload=True,
-        )
-    )
-    monkeypatch.setattr(admin_server_mod, "_build_parser", lambda: parser)
-    context_file = tmp_path / "ui" / "context.json"
-    context_file.parent.mkdir(parents=True, exist_ok=True)
-    context_file.write_text("{}", encoding="utf-8")
-    monkeypatch.setattr(
-        admin_server_mod, "_write_context_file", lambda **_kwargs: context_file
-    )
-
-    run_calls = []
-    monkeypatch.setitem(
-        sys.modules,
-        "uvicorn",
-        SimpleNamespace(run=lambda *args, **kwargs: run_calls.append((args, kwargs))),
-    )
-
-    admin_server_mod.main()
-    assert run_calls[0][0] == ("daylily_tapdb.cli.admin_server:build_app",)
-    assert run_calls[0][1]["factory"] is True
-    assert run_calls[0][1]["reload"] is True
+    assert app.state.tapdb_admin_module is fake_admin
 
 
-def test_runtime_db_connection_session_scope_commit_and_rollback():
-    class _Trans:
-        def __init__(self):
-            self.commits = 0
-            self.rollbacks = 0
+def test_runtime_db_connection_session_scope_sets_search_path_and_audit_username():
+    events: list[tuple[str, object]] = []
 
+    class FakeTx:
         def commit(self):
-            self.commits += 1
+            events.append(("commit", None))
 
         def rollback(self):
-            self.rollbacks += 1
+            events.append(("rollback", None))
 
-    class _Session:
-        def __init__(self):
-            self.trans = _Trans()
-            self.closed = 0
-            self.executed = []
+    class FakeSession:
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
 
         def begin(self):
-            return self.trans
-
-        def execute(self, *args):
-            self.executed.append(args)
-
-        def close(self):
-            self.closed += 1
-
-    session = _Session()
-    bundle = runtime_mod.RuntimeBundle(
-        config_path="/tmp/tapdb.yaml",
-        env_name="dev",
-        engine=create_engine("sqlite://"),
-        SessionFactory=lambda: session,
-        cfg={},
-        schema_name="tapdb_unit",
-    )
-    conn = runtime_mod.RuntimeDBConnection(bundle)
-    conn.app_username = "tester"
-
-    with conn.session_scope(commit=False) as active:
-        assert active is session
-    assert session.trans.commits == 0
-    assert session.trans.rollbacks == 1
-    assert session.closed == 1
-    assert session.executed
-
-    session = _Session()
-    conn = runtime_mod.RuntimeDBConnection(
-        runtime_mod.RuntimeBundle(
-            config_path="/tmp/tapdb.yaml",
-            env_name="dev",
-            engine=create_engine("sqlite://"),
-            SessionFactory=lambda: session,
-            cfg={},
-            schema_name="tapdb_unit",
-        )
-    )
-    with conn.session_scope(commit=True):
-        pass
-    assert session.trans.commits == 1
-    assert session.trans.rollbacks == 0
-
-    session = _Session()
-    conn = runtime_mod.RuntimeDBConnection(
-        runtime_mod.RuntimeBundle(
-            config_path="/tmp/tapdb.yaml",
-            env_name="dev",
-            engine=create_engine("sqlite://"),
-            SessionFactory=lambda: session,
-            cfg={},
-            schema_name="tapdb_unit",
-        )
-    )
-    with pytest.raises(RuntimeError, match="boom"):
-        with conn.session_scope(commit=True):
-            raise RuntimeError("boom")
-    assert session.trans.rollbacks == 1
-
-
-def test_runtime_db_connection_session_scope_sets_search_path():
-    class _Trans:
-        def commit(self):
-            return None
-
-        def rollback(self):
-            return None
-
-    class _Session:
-        def __init__(self):
-            self.bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
-            self.statements = []
-
-        def begin(self):
-            return _Trans()
+            return FakeTx()
 
         def execute(self, stmt, params=None):
-            self.statements.append((str(stmt), params or {}))
+            events.append(("execute", params))
 
         def close(self):
-            return None
+            events.append(("close", None))
 
-    session = _Session()
-    conn = runtime_mod.RuntimeDBConnection(
-        runtime_mod.RuntimeBundle(
-            config_path="/tmp/tapdb.yaml",
-            env_name="dev",
-            engine=create_engine("sqlite://"),
-            SessionFactory=lambda: session,
-            cfg={"schema_name": "tapdb_dev"},
-            schema_name="tapdb_dev",
-        )
+    bundle = runtime_mod.RuntimeBundle(
+        config_path="/tmp/tapdb-config.yaml",
+        target_name="target",
+        engine=SimpleNamespace(),
+        SessionFactory=lambda: FakeSession(),
+        cfg={},
+        schema_name="tapdb_testdb",
     )
+    conn = runtime_mod.RuntimeDBConnection(bundle)
+    conn.app_username = "alice@example.com"
 
-    with conn.session_scope(commit=False):
+    with conn.session_scope(commit=True):
         pass
 
-    assert "set_config('search_path'" in session.statements[0][0]
-    assert session.statements[0][1]["schema_name"] == "tapdb_dev"
+    assert ("commit", None) in events
+    assert ("execute", {"schema_name": "tapdb_testdb"}) in events
+    assert ("execute", {"username": "alice@example.com"}) in events
 
 
-def test_runtime_engine_helpers_cover_auth_modes_and_cache(monkeypatch):
-    captured = {}
-    monkeypatch.setattr(
-        runtime_mod,
-        "get_admin_settings_for_env",
-        lambda env_name, config_path: {
-            "db_pool_size": 3,
-            "db_max_overflow": 4,
-            "db_pool_timeout": 5,
-            "db_pool_recycle": 6,
-        },
-    )
-    monkeypatch.setattr(
-        runtime_mod,
-        "create_engine",
-        lambda url, **kwargs: (
-            captured.setdefault("engines", []).append((url, kwargs))
-            or SimpleNamespace(dispose=lambda: None)
-        ),
-    )
-    runtime_mod._create_engine(
-        runtime_mod.URL.create("postgresql+psycopg2", username="tapdb", host="db"),
-        config_path="/tmp/tapdb.yaml",
-        env_name="dev",
-        echo_sql=True,
-    )
-    assert captured["engines"][0][1]["pool_size"] == 3
-    assert captured["engines"][0][1]["echo"] is True
+def test_runtime_engine_cache_key_includes_schema(monkeypatch):
+    builds: list[str] = []
 
-    listeners = {}
-    monkeypatch.setattr(
-        runtime_mod.event,
-        "listen",
-        lambda _engine, name, fn, **_kwargs: listeners.setdefault(name, fn),
-    )
-    monkeypatch.setattr(
-        runtime_mod.AuroraConnectionBuilder,
-        "get_iam_auth_token",
-        lambda **_kwargs: "iam-token",
-    )
-    runtime_mod._attach_aurora_password_provider(
-        SimpleNamespace(),
-        region="us-west-2",
-        host="db.local",
-        port=5432,
-        user="tapdb",
-        aws_profile="default",
-        iam_auth=True,
-        secret_arn=None,
-        password="",
-    )
-    cparams = {}
-    listeners["do_connect"](None, None, None, cparams)
-    assert cparams["password"] == "iam-token"
-
-    listeners = {}
-    monkeypatch.setattr(
-        runtime_mod.event,
-        "listen",
-        lambda _engine, name, fn, **_kwargs: listeners.setdefault(name, fn),
-    )
-    runtime_mod._attach_aurora_password_provider(
-        SimpleNamespace(),
-        region="us-west-2",
-        host="db.local",
-        port=5432,
-        user="tapdb",
-        aws_profile=None,
-        iam_auth=False,
-        secret_arn=None,
-        password="secret",
-    )
-    cparams = {}
-    listeners["do_connect"](None, None, None, cparams)
-    assert cparams["password"] == "secret"
-
-    listeners = {}
-    monkeypatch.setattr(
-        runtime_mod.event,
-        "listen",
-        lambda _engine, name, fn, **_kwargs: listeners.setdefault(name, fn),
-    )
-    runtime_mod._attach_aurora_password_provider(
-        SimpleNamespace(),
-        region="us-west-2",
-        host="db.local",
-        port=5432,
-        user="tapdb",
-        aws_profile=None,
-        iam_auth=False,
-        secret_arn=None,
-        password="",
-    )
-    with pytest.raises(ValueError, match="requires a password or secret_arn"):
-        listeners["do_connect"](None, None, None, {})
-
-    created = []
-    monkeypatch.setattr(
-        runtime_mod,
-        "get_db_config_for_env",
-        lambda env, config_path: {
-            "config_path": "/resolved/tapdb.yaml",
+    def fake_get_db_config(config_path):
+        schema = "schema_a" if config_path.endswith("a.yaml") else "schema_b"
+        return {
+            "config_path": config_path,
+            "schema_name": schema,
             "engine_type": "local",
             "host": "localhost",
-            "port": "5432",
-            "database": "tapdb_dev",
-            "schema_name": "tapdb_dev",
+            "port": "5533",
+            "database": "tapdb_shared",
             "user": "tapdb",
             "password": "",
-        },
-    )
+        }
+
+    monkeypatch.setattr(runtime_mod, "get_db_config", fake_get_db_config)
     monkeypatch.setattr(
         runtime_mod,
         "_build_engine_for_cfg",
-        lambda cfg, *, config_path, env_name: (
-            created.append((cfg, config_path, env_name))
-            or SimpleNamespace(dispose=lambda: None)
+        lambda cfg, *, config_path: (
+            builds.append(cfg["schema_name"]) or SimpleNamespace()
         ),
     )
-    runtime_mod._clear_runtime_cache_for_tests()
-    conn1 = runtime_mod.get_db("/tmp/tapdb.yaml", "DEV")
-    conn2 = runtime_mod.get_db("/tmp/tapdb.yaml", "dev")
-    assert len(created) == 1
-    assert conn1._bundle is conn2._bundle
-    runtime_mod._clear_runtime_cache_for_tests()
+    monkeypatch.setattr(runtime_mod, "sessionmaker", lambda **kwargs: lambda: None)
 
-    with pytest.raises(RuntimeError, match="env name is required"):
-        runtime_mod.get_db("/tmp/tapdb.yaml", "")
+    runtime_mod.get_db("/tmp/a.yaml")
+    runtime_mod.get_db("/tmp/b.yaml")
+    runtime_mod.get_db("/tmp/a.yaml")
 
-    monkeypatch.setattr(
-        runtime_mod,
-        "get_db_config_for_env",
-        lambda env, config_path: {
-            "config_path": "/resolved/tapdb.yaml",
-            "engine_type": "local",
-            "host": "localhost",
-            "port": "5432",
-            "database": "tapdb_dev",
-            "user": "tapdb",
-            "password": "",
-        },
-    )
-    runtime_mod._clear_runtime_cache_for_tests()
-    with pytest.raises(RuntimeError, match="schema_name"):
-        runtime_mod.get_db("/tmp/tapdb.yaml", "dev")
+    assert builds == ["schema_a", "schema_b"]
 
 
 @pytest.mark.anyio
-async def test_web_factory_helpers_require_user_and_build_apps(monkeypatch):
-    request = SimpleNamespace(state=SimpleNamespace())
-
-    async def _user(_request):
-        return {"uid": 1, "username": "admin"}
-
-    monkeypatch.setattr("admin.auth.get_current_user", _user)
-    user = await web_factory_mod.require_tapdb_api_user(request)
-    assert user["uid"] == 1
-    assert request.state.user == user
-
-    async def _anon(_request):
+async def test_require_tapdb_api_user_rejects_anonymous(monkeypatch):
+    async def _no_user(request):
         return None
 
-    monkeypatch.setattr("admin.auth.get_current_user", _anon)
-    with pytest.raises(HTTPException, match="tapdb_auth_required"):
-        await web_factory_mod.require_tapdb_api_user(
-            SimpleNamespace(state=SimpleNamespace())
-        )
+    monkeypatch.setattr("admin.auth.get_current_user", _no_user)
+    request = Request({"type": "http", "method": "GET", "path": "/", "headers": []})
 
-    assert (
-        web_factory_mod._requested_path(
-            SimpleNamespace(
-                scope={
-                    "root_path": "/tapdb",
-                    "path": "/graph",
-                    "query_string": b"depth=2",
-                }
-            )
-        )
-        == "/tapdb/graph?depth=2"
-    )
+    with pytest.raises(HTTPException) as exc_info:
+        await web_factory_mod.require_tapdb_api_user(request)
 
-    configured = []
-    attached = []
-    fake_app = SimpleNamespace(state=SimpleNamespace(tapdb_admin_module="admin-main"))
+    assert exc_info.value.status_code == 401
+
+
+def test_web_factory_builds_app_from_explicit_config(monkeypatch, tmp_path: Path):
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+    fake_app = FastAPI()
+    fake_admin = SimpleNamespace(TEMPLATES_DIR=tmp_path)
+    fake_app.state.tapdb_admin_module = fake_admin
+    fake_admin.templates = SimpleNamespace(loader=None, globals={})
+
     monkeypatch.setattr(
-        admin_server_mod,
-        "load_admin_app",
-        lambda **kwargs: fake_app,
+        "daylily_tapdb.cli.admin_server.load_admin_app",
+        lambda config_path: fake_app,
     )
     monkeypatch.setattr(
         web_factory_mod,
-        "_configure_template_environment",
-        lambda admin_main, bridge: configured.append((admin_main, bridge)),
+        "create_tapdb_dag_router",
+        lambda **kwargs: FastAPI().router,
+    )
+
+    app = web_factory_mod.create_tapdb_web_app(config_path=str(cfg_path))
+
+    assert app is fake_app
+    assert app.state.tapdb_host_bridge is None
+    assert app.state.tapdb_dag_router_attached is True
+
+
+def test_web_factory_wraps_host_bridge(monkeypatch, tmp_path: Path):
+    cfg_path = _write_config(tmp_path / "tapdb-config.yaml")
+    fake_app = FastAPI()
+    fake_admin = SimpleNamespace(TEMPLATES_DIR=tmp_path)
+    fake_app.state.tapdb_admin_module = fake_admin
+    fake_admin.templates = SimpleNamespace(loader=None, globals={})
+    bridge = TapdbHostBridge(service_name="atlas", auth_mode="host_session")
+
+    monkeypatch.setattr(
+        "daylily_tapdb.cli.admin_server.load_admin_app",
+        lambda config_path: fake_app,
     )
     monkeypatch.setattr(
         web_factory_mod,
-        "_attach_canonical_dag_router",
-        lambda app, **kwargs: attached.append((app, kwargs)),
+        "create_tapdb_dag_router",
+        lambda **kwargs: FastAPI().router,
     )
 
-    host_bridge = TapdbHostBridge(auth_mode="host_session", service_name="dewey")
     wrapped = web_factory_mod.create_tapdb_web_app(
-        config_path="/tmp/tapdb.yaml",
-        env_name="dev",
-        host_bridge=host_bridge,
+        config_path=str(cfg_path),
+        host_bridge=bridge,
     )
-    assert isinstance(wrapped, web_factory_mod.TapdbHostBridgeMount)
-    assert configured[0] == ("admin-main", host_bridge)
-    assert attached[0][1]["service_name"] == "dewey"
 
-    plain = web_factory_mod.create_tapdb_web_app(
-        config_path="/tmp/tapdb.yaml",
-        env_name="dev",
-        host_bridge=None,
-    )
-    assert plain is fake_app
+    assert isinstance(wrapped, web_factory_mod.TapdbHostBridgeMount)

--- a/tests/test_schema_name_isolation.py
+++ b/tests/test_schema_name_isolation.py
@@ -5,7 +5,8 @@ from pathlib import Path
 import yaml
 from sqlalchemy import func, select
 
-from daylily_tapdb.cli.db_config import get_db_config_for_env
+from daylily_tapdb.cli.context import clear_cli_context, set_cli_context
+from daylily_tapdb.cli.db_config import get_db_config
 from daylily_tapdb.connection import TAPDBConnection
 from daylily_tapdb.models.template import generic_template
 from tests.test_integration import (
@@ -28,20 +29,23 @@ def _write_tapdb_config(
     )
     meta = dict(source_config["meta"])
     meta["database_name"] = database_name
+    meta["config_version"] = 4
     payload = {
         "meta": meta,
-        "environments": {
-            "dev": {
-                "engine_type": "local",
-                "host": "localhost",
-                "port": pg_instance["port"],
-                "ui_port": 18911,
-                "domain_code": "Z",
-                "user": pg_instance["user"],
-                "password": "",
-                "database": pg_instance["database"],
-                "schema_name": schema_name,
-            },
+        "target": {
+            "engine_type": "local",
+            "host": "localhost",
+            "port": pg_instance["port"],
+            "ui_port": 18911,
+            "domain_code": "Z",
+            "user": pg_instance["user"],
+            "password": "",
+            "database": pg_instance["database"],
+            "schema_name": schema_name,
+        },
+        "safety": {
+            "safety_tier": "local",
+            "destructive_operations": "confirm_required",
         },
     }
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -114,8 +118,13 @@ def test_two_configured_schemas_share_one_physical_database_without_cross_reads(
         schema_name=schema_b,
     )
 
-    cfg_a = get_db_config_for_env("dev", config_path=config_a)
-    cfg_b = get_db_config_for_env("dev", config_path=config_b)
+    try:
+        set_cli_context(config_path=config_a)
+        cfg_a = get_db_config()
+        set_cli_context(config_path=config_b)
+        cfg_b = get_db_config()
+    finally:
+        clear_cli_context()
     assert cfg_a["database"] == cfg_b["database"] == pg_instance["database"]
     assert cfg_a["schema_name"] == schema_a
     assert cfg_b["schema_name"] == schema_b

--- a/tests/test_security_posture.py
+++ b/tests/test_security_posture.py
@@ -1,14 +1,11 @@
 """Focused tests for security-sensitive configuration paths."""
 
-import tempfile
 from pathlib import Path
 
 import pytest
 
 from admin import main as admin_main
 from daylily_tapdb.aurora import connection as aurora_connection
-from daylily_tapdb.cli.db import Environment
-from daylily_tapdb.cli.pg import _get_instance_lock_file
 
 
 def test_admin_templates_enable_html_autoescape():
@@ -59,7 +56,7 @@ def test_aurora_ca_bundle_rejects_non_https_download_url(monkeypatch, tmp_path: 
         aurora_connection.AuroraConnectionBuilder.ensure_ca_bundle()
 
 
-def test_prod_instance_lock_uses_system_temp_dir():
-    assert _get_instance_lock_file(Environment.prod) == (
-        Path(tempfile.gettempdir()) / "tapdb-prod-instance.lock"
-    )
+def test_env_selector_names_are_absent_from_security_surface():
+    from daylily_tapdb.cli.db import Environment
+
+    assert [item.value for item in Environment] == ["target"]

--- a/tests/test_user_cli_commands.py
+++ b/tests/test_user_cli_commands.py
@@ -34,7 +34,7 @@ def test_user_list_shows_no_users(monkeypatch: pytest.MonkeyPatch):
         user_mod, "list_users", lambda _session, include_inactive=False: []
     )
 
-    result = runner.invoke(user_mod.user_app, ["list", "dev"])
+    result = runner.invoke(user_mod.user_app, ["list"])
 
     assert result.exit_code == 0
     assert "No users found" in result.output
@@ -58,10 +58,10 @@ def test_user_list_renders_table(monkeypatch: pytest.MonkeyPatch):
         ],
     )
 
-    result = runner.invoke(user_mod.user_app, ["list", "dev"])
+    result = runner.invoke(user_mod.user_app, ["list"])
 
     assert result.exit_code == 0
-    assert "TAPDB Users (dev)" in result.output
+    assert "TAPDB Users (explicit target)" in result.output
     assert "Admin" in result.output
     assert "14:00" in result.output
 
@@ -81,7 +81,6 @@ def test_user_add_success(monkeypatch: pytest.MonkeyPatch):
         user_mod.user_app,
         [
             "add",
-            "dev",
             "--username",
             "alice@example.com",
             "--role",
@@ -115,7 +114,7 @@ def test_user_add_duplicate_exits_nonzero(monkeypatch: pytest.MonkeyPatch):
 
     result = runner.invoke(
         user_mod.user_app,
-        ["add", "dev", "--username", "alice@example.com"],
+        ["add", "--username", "alice@example.com"],
     )
 
     assert result.exit_code == 1
@@ -128,7 +127,7 @@ def test_user_set_role_success(monkeypatch: pytest.MonkeyPatch):
 
     result = runner.invoke(
         user_mod.user_app,
-        ["set-role", "dev", "alice@example.com", "admin"],
+        ["set-role", "alice@example.com", "admin"],
     )
 
     assert result.exit_code == 0
@@ -145,8 +144,8 @@ def test_user_activate_and_deactivate_success(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr(user_mod, "set_active", _fake_set_active)
 
-    deactivate = runner.invoke(user_mod.user_app, ["deactivate", "dev", "alice"])
-    activate = runner.invoke(user_mod.user_app, ["activate", "dev", "alice"])
+    deactivate = runner.invoke(user_mod.user_app, ["deactivate", "alice"])
+    activate = runner.invoke(user_mod.user_app, ["activate", "alice"])
 
     assert deactivate.exit_code == 0
     assert activate.exit_code == 0
@@ -170,7 +169,7 @@ def test_user_set_password_success(monkeypatch: pytest.MonkeyPatch):
 
     result = runner.invoke(
         user_mod.user_app,
-        ["set-password", "dev", "alice", "--password", "secret"],
+        ["set-password", "alice", "--password", "secret"],
     )
 
     assert result.exit_code == 0
@@ -185,7 +184,7 @@ def test_user_set_password_success(monkeypatch: pytest.MonkeyPatch):
 def test_user_delete_cancelled_without_force(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(user_mod.typer, "confirm", lambda _msg: False)
 
-    result = runner.invoke(user_mod.user_app, ["delete", "dev", "alice"])
+    result = runner.invoke(user_mod.user_app, ["delete", "alice"])
 
     assert result.exit_code == 0
     assert "Cancelled" in result.output
@@ -196,7 +195,7 @@ def test_user_delete_success(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(user_mod, "_open_connection", lambda *_a, **_k: _FakeConn())
     monkeypatch.setattr(user_mod, "soft_delete", lambda _session, _username: True)
 
-    result = runner.invoke(user_mod.user_app, ["delete", "dev", "alice"])
+    result = runner.invoke(user_mod.user_app, ["delete", "alice"])
 
     assert result.exit_code == 0
     assert "Deleted user" in result.output

--- a/tests/test_web_dag.py
+++ b/tests/test_web_dag.py
@@ -202,7 +202,7 @@ def test_create_tapdb_dag_router_serves_exact_lookup_graph_and_external(
 ) -> None:
     monkeypatch.setattr(
         "daylily_tapdb.web.runtime.get_db",
-        lambda _config_path, _env_name: _build_fake_runtime_connection().conn,
+        lambda _config_path: _build_fake_runtime_connection().conn,
     )
     monkeypatch.setattr(
         "daylily_tapdb.web.dag.fetch_remote_graph",
@@ -234,7 +234,6 @@ def test_create_tapdb_dag_router_serves_exact_lookup_graph_and_external(
     app.include_router(
         create_tapdb_dag_router(
             config_path="/tmp/tapdb-config.yaml",
-            env_name="dev",
             service_name="dewey",
         )
     )
@@ -315,13 +314,12 @@ def test_create_tapdb_dag_router_serves_exact_lookup_graph_and_external(
 def test_create_tapdb_dag_router_returns_404_for_non_owned_euid(monkeypatch) -> None:
     monkeypatch.setattr(
         "daylily_tapdb.web.runtime.get_db",
-        lambda _config_path, _env_name: _build_fake_runtime_connection().conn,
+        lambda _config_path: _build_fake_runtime_connection().conn,
     )
     app = FastAPI()
     app.include_router(
         create_tapdb_dag_router(
             config_path="/tmp/tapdb-config.yaml",
-            env_name="dev",
             service_name="dewey",
         )
     )


### PR DESCRIPTION
## Summary
- remove operator-facing TapDB env selection and require explicit config targets
- convert config/runtime helpers to root target plus safety settings
- update docs, examples, and tests for explicit-target CLI usage

## Tests
- pytest -q

## Release
- intended release tag after merge: 7.0.0