### PR TITLE
Include PyYAML in TapDB core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "jsonschema>=4.0",
     "typer",
     "rich",
+    "pyyaml",
     "uuid6>=2024.1.12",
     "cli-core-yo==2.1.1",
     "meridian-euid==0.4.5",
@@ -53,10 +54,9 @@ dev = [
 
 # Optional CLI add-ons.
 #
-# Note: The CLI itself (Typer + Rich) is intentionally part of core deps so
+# Note: The CLI itself (Typer + Rich + PyYAML) is intentionally part of core deps so
 # `tapdb --help` works after `pip install -e .` per REFACTOR_TAPDB.md Phase 0.
 cli = [
-    "pyyaml",
 ]
 
 # Optional Aurora (AWS RDS Aurora) support.

--- a/tests/test_activation_metadata.py
+++ b/tests/test_activation_metadata.py
@@ -16,6 +16,7 @@ def test_pyproject_pins_published_cli_core_yo() -> None:
     admin_dependencies = data["project"]["optional-dependencies"]["admin"]
 
     assert "cli-core-yo==2.1.1" in dependencies
+    assert "pyyaml" in dependencies
     assert "cli-core-yo==2.1.1" in dev_dependencies
     assert "daylily-auth-cognito==2.1.5" in admin_dependencies
     assert all("daylily-cognito" not in dependency for dependency in admin_dependencies)


### PR DESCRIPTION
## Summary
- move PyYAML into TapDB core dependencies so the tapdb console script works after a normal pip install
- keep the CLI extra available while making the console-script dependency explicit
- add a metadata guard for PyYAML in core dependencies

## Tests
- ruff check daylily_tapdb/ admin/ tests/
- ruff format --check daylily_tapdb/ admin/ tests/
- pytest -q tests/test_activation_metadata.py
- pytest -q