### PR TITLE
Require explicit echo_sql in TapDB CLI connections

### DIFF
--- a/daylily_tapdb/cli/db.py
+++ b/daylily_tapdb/cli/db.py
@@ -1638,6 +1638,7 @@ def _tapdb_connection_for_env(
         domain_code=str(cfg["domain_code"]),
         owner_repo_name=str(cfg["owner_repo_name"]),
         schema_name=str(cfg["schema_name"]),
+        echo_sql=False,
     )
 
 
@@ -1682,6 +1683,7 @@ def _create_default_admin(env: Environment, insecure_dev_defaults: bool) -> bool
             domain_code=str(cfg["domain_code"]),
             owner_repo_name=str(cfg["owner_repo_name"]),
             schema_name=str(cfg["schema_name"]),
+            echo_sql=False,
         ) as conn:
             with conn.session_scope(commit=True) as session:
                 user, created = create_or_get(

--- a/tests/test_cli_db_floor_lift.py
+++ b/tests/test_cli_db_floor_lift.py
@@ -192,6 +192,7 @@ def test_tapdb_connection_for_env_passes_schema(
     assert seen["schema_name"] == "tapdb_testdb"
     assert seen["db_name"] == "tapdb_shared"
     assert seen["app_username"] == "tester"
+    assert seen["echo_sql"] is False
 
 
 def test_create_default_admin_skips_without_insecure_flag() -> None:

--- a/tests/test_cli_helper_units.py
+++ b/tests/test_cli_helper_units.py
@@ -126,6 +126,7 @@ def test_tapdb_connection_for_env_uses_normalized_engine_flags(
     assert seen["engine_type"] == "local"
     assert seen["iam_auth"] is False
     assert seen["schema_name"] == "tapdb_testdb"
+    assert seen["echo_sql"] is False
 
 
 def test_user_open_connection_maps_explicit_target(


### PR DESCRIPTION
## Summary\n- Pass explicit echo_sql=False when CLI helper code constructs TAPDBConnection\n- Add focused assertions for CLI helper and schema floor-lift paths\n\n## Tests\n- source ./activate >/tmp/tapdb_activate.log && python -m py_compile daylily_tapdb/cli/db.py tests/test_cli_helper_units.py tests/test_cli_db_floor_lift.py && pytest tests/test_cli_helper_units.py::test_tapdb_connection_for_env_uses_normalized_engine_flags tests/test_cli_db_floor_lift.py::test_tapdb_connection_for_env_passes_schema -q && ruff check daylily_tapdb/cli/db.py tests/test_cli_helper_units.py tests/test_cli_db_floor_lift.py