### PR TITLE
[codex] Integrate Meridian registry release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,10 @@
+# Shell Session Defaults
+
+- Default to an interactive shell for shell work. On this Mac, use the user's default shell unless the user explicitly asks for another shell.
+- For AWS EC2, ParallelCluster, and other remote Linux hosts, default to an interactive `bash` login shell as `ubuntu`. Do not use `root` unless the user explicitly grants permission for that specific work; use targeted `sudo` from `ubuntu` when escalation is required.
+- For Daylily/DayOA/DAY-EC headnode workflow work, use an interactive `ubuntu` tmux/login-shell pane for controllers and workflow commands. Run setup as separate commands in that pane (`source dyoainit`, then `dy-a ...`, then `dy-r ...`) so aliases/functions are defined before use.
+- SSM Run Command is for simple inspection or for writing helper scripts through the supported helpers. Do not launch workflow controllers or rely on `dy-*` aliases from non-interactive SSM scripts.
+
 # AGENTS.md — daylily-tapdb
 
 Canonical usage contract for AI agents (Augment, Claude, Copilot, etc.).

--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ For a repo-local smoke path, this repo ships example registry fixtures under
 `daylily_tapdb/etc/`. Those files are suitable for single-repo local runs and
 for the README example scripts.
 
+Meridian domain-code allocation is governed by the public
+[`lsmc-bio/meridian-registry`](https://github.com/lsmc-bio/meridian-registry)
+repository. TAPDB consumes `meridian-euid==0.4.7`, which pins that public
+domain registry at `0.1.1` and exposes explicit domain-availability checks:
+
+```bash
+meridian-euid domain-check Q \
+  --registry-index /abs/path/to/meridian-registry/registry/generated/domains.json
+```
+
+The TapDB `domain_registry_path` and `prefix_ownership_registry_path` values
+remain explicit local runtime inputs. They validate the domain and prefix claims
+used by a concrete TapDB deployment; they do not replace the public domain
+registry, and prefix assignment remains owned by domain holders rather than
+centralized in `meridian-registry`.
+
 If optional workflow packs are present in the config, add `--include-workflow` to the bootstrap command. If you want the generated scripts rather than inline commands, use the companion examples under `examples/readme/`:
 
 - `examples/readme/00_smoke.sh`

--- a/admin/main.py
+++ b/admin/main.py
@@ -157,16 +157,21 @@ def _is_production_like(env_name: str, settings: dict[str, Any]) -> bool:
 def _validate_production_admin_settings(settings: dict[str, Any]) -> None:
     auth_mode = str(settings.get("auth_mode") or "").strip().lower()
     if auth_mode == "disabled":
-        raise RuntimeError("Refusing to start production-like TapDB admin with disabled auth")
-    if auth_mode == "shared_host" and not str(
-        settings.get("shared_host_session_secret") or ""
-    ).strip():
+        raise RuntimeError(
+            "Refusing to start production-like TapDB admin with disabled auth"
+        )
+    if (
+        auth_mode == "shared_host"
+        and not str(settings.get("shared_host_session_secret") or "").strip()
+    ):
         raise RuntimeError(
             "Refusing to start production-like TapDB admin shared_host auth without "
             "admin.auth.shared_host.session_secret"
         )
     if not str(settings.get("session_secret") or "").strip():
-        raise RuntimeError("Refusing to start production-like TapDB admin without admin.session.secret")
+        raise RuntimeError(
+            "Refusing to start production-like TapDB admin without admin.session.secret"
+        )
 
 
 IS_PROD = _is_production_like(APP_ENV, ADMIN_SETTINGS)

--- a/config/tapdb-config-example.yaml
+++ b/config/tapdb-config-example.yaml
@@ -11,7 +11,11 @@ meta:
   client_id: local
   database_name: tapdb
   owner_repo_name: daylily-tapdb
+  # Local runtime registry fixture. Public domain-code allocation is governed by
+  # meridian-registry 0.1.1 through meridian-euid 0.4.7.
   domain_registry_path: ~/.config/tapdb/domain_code_registry.json
+  # Prefix claims remain domain-holder governed and are not centralized in
+  # meridian-registry.
   prefix_ownership_registry_path: ~/.config/tapdb/prefix_ownership_registry.json
 
 admin:

--- a/daylily_tapdb/cli/admin_server.py
+++ b/daylily_tapdb/cli/admin_server.py
@@ -135,7 +135,9 @@ def _uvicorn_tls_kwargs(
     raw_keyfile = str(ssl_keyfile or "").strip()
     raw_certfile = str(ssl_certfile or "").strip()
     if not raw_keyfile or not raw_certfile:
-        raise RuntimeError("HTTPS admin mode requires --ssl-keyfile and --ssl-certfile.")
+        raise RuntimeError(
+            "HTTPS admin mode requires --ssl-keyfile and --ssl-certfile."
+        )
     key_path = Path(raw_keyfile).expanduser()
     cert_path = Path(raw_certfile).expanduser()
     missing = [str(path) for path in (key_path, cert_path) if not path.exists()]

--- a/daylily_tapdb/cli/pg.py
+++ b/daylily_tapdb/cli/pg.py
@@ -311,12 +311,15 @@ def pg_status():
     socket_dir = _get_postgres_socket_dir(env)
     lock_file = _get_instance_lock_file(env)
 
-    ready = subprocess.run(
-        ["pg_isready", "-h", host, "-p", str(port), "-q"],
-        capture_output=True,
-        timeout=5,
-    )
-    if ready.returncode == 0:
+    try:
+        ready_code = subprocess.run(
+            ["pg_isready", "-h", host, "-p", str(port), "-q"],
+            capture_output=True,
+            timeout=5,
+        ).returncode
+    except FileNotFoundError:
+        ready_code = 1
+    if ready_code == 0:
         ccyo_out.success("Local PostgreSQL is running")
     else:
         ccyo_out.error("○ Local PostgreSQL is not running")

--- a/daylily_tapdb/connection.py
+++ b/daylily_tapdb/connection.py
@@ -153,11 +153,17 @@ class TAPDBConnection:
                     f"db_hostname is required when engine_type={engine_type!r}"
                 )
             if db_pass is None:
-                raise ValueError(f"db_pass is required when engine_type={engine_type!r}")
+                raise ValueError(
+                    f"db_pass is required when engine_type={engine_type!r}"
+                )
             if not db_user:
-                raise ValueError(f"db_user is required when engine_type={engine_type!r}")
+                raise ValueError(
+                    f"db_user is required when engine_type={engine_type!r}"
+                )
             if not db_name:
-                raise ValueError(f"db_name is required when engine_type={engine_type!r}")
+                raise ValueError(
+                    f"db_name is required when engine_type={engine_type!r}"
+                )
             self._db_url = f"{db_url_prefix}{db_user}:{db_pass}@{db_hostname}/{db_name}"
 
         # Create engine with connection pooling
@@ -196,7 +202,9 @@ class TAPDBConnection:
         def _on_checkout(dbapi_connection, _connection_record, _connection_proxy):
             cursor = dbapi_connection.cursor()
             try:
-                cursor.execute("SELECT set_config('search_path', %s, false)", (schema_name,))
+                cursor.execute(
+                    "SELECT set_config('search_path', %s, false)", (schema_name,)
+                )
                 cursor.execute(
                     "SET session.current_domain_code = %s",
                     (domain_code,),

--- a/daylily_tapdb/container_entry.py
+++ b/daylily_tapdb/container_entry.py
@@ -18,7 +18,9 @@ def _required_port(value: str) -> int:
     try:
         port = int(value)
     except ValueError as exc:
-        raise RuntimeError(f"TAPDB_ADMIN_PORT must be an integer, got {value!r}.") from exc
+        raise RuntimeError(
+            f"TAPDB_ADMIN_PORT must be an integer, got {value!r}."
+        ) from exc
     if port <= 0 or port > 65535:
         raise RuntimeError(f"TAPDB_ADMIN_PORT must be between 1 and 65535, got {port}.")
     return port
@@ -74,7 +76,8 @@ def build_admin_server_argv(env: Mapping[str, str] | None = None) -> list[str]:
 
 def main() -> None:
     argv = build_admin_server_argv()
-    os.execv(sys.executable, argv)
+    # Re-exec uses the current Python executable with fixed admin-server argv.
+    os.execv(sys.executable, argv)  # nosec B606
 
 
 if __name__ == "__main__":

--- a/daylily_tapdb/core_config/_metadata.json
+++ b/daylily_tapdb/core_config/_metadata.json
@@ -13,6 +13,7 @@
   },
   "euid_prefixes": {
     "system_user": "SYS",
-    "system_message": "MSG"
+    "system_message": "MSG",
+    "external_reference": "XRF"
   }
 }

--- a/daylily_tapdb/core_config/system/external_reference.json
+++ b/daylily_tapdb/core_config/system/external_reference.json
@@ -1,0 +1,35 @@
+{
+  "$comment": "TapDB reserved operational template for typed external object links",
+  "templates": [
+    {
+      "name": "External Object Reference",
+      "polymorphic_discriminator": "generic_template",
+      "category": "XRF",
+      "type": "external_identifier",
+      "subtype": "tapdb_object",
+      "version": "1.0",
+      "instance_prefix": "XRF",
+      "is_singleton": false,
+      "bstatus": "active",
+      "json_addl": {
+        "description": "Reserved TapDB operational object for linking local instances to non-local object identifiers through lineage.",
+        "properties": {
+          "system": "",
+          "foreign_uid": "",
+          "root_euid": "",
+          "href": "",
+          "external_identifier": {
+            "system": "",
+            "target_euid": "",
+            "href": "",
+            "base_url": "",
+            "graph_data_path": "",
+            "object_detail_path_template": "",
+            "auth_mode": "none"
+          }
+        },
+        "instantiation_layouts": []
+      }
+    }
+  ]
+}

--- a/daylily_tapdb/etc/prefix_ownership_registry.json
+++ b/daylily_tapdb/etc/prefix_ownership_registry.json
@@ -16,6 +16,9 @@
       },
       "MSG": {
         "issuer_app_code": "daylily-tapdb"
+      },
+      "XRF": {
+        "issuer_app_code": "daylily-tapdb"
       }
     }
   }

--- a/daylily_tapdb/euid.py
+++ b/daylily_tapdb/euid.py
@@ -20,6 +20,7 @@ GENERIC_INSTANCE_LINEAGE_PREFIX = "EDG"
 AUDIT_LOG_PREFIX = "ADT"
 SYSTEM_USER_PREFIX = "SYS"
 SYSTEM_MESSAGE_PREFIX = "MSG"
+EXTERNAL_REFERENCE_PREFIX = "XRF"
 
 _ALPHABET_32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 _VALUE_32 = {char: index for index, char in enumerate(_ALPHABET_32)}
@@ -179,6 +180,7 @@ _CANONICAL_CORE_PREFIXES = MappingProxyType(
         "audit_log": AUDIT_LOG_PREFIX,
         "system_user_instance": SYSTEM_USER_PREFIX,
         "system_message_instance": SYSTEM_MESSAGE_PREFIX,
+        "external_reference_instance": EXTERNAL_REFERENCE_PREFIX,
     }
 )
 

--- a/daylily_tapdb/governance.py
+++ b/daylily_tapdb/governance.py
@@ -6,8 +6,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
 
+from meridian_euid import (
+    MERIDIAN_REGISTRY_INDEX_URL,
+    MERIDIAN_REGISTRY_REPOSITORY,
+    MERIDIAN_REGISTRY_VERSION,
+)
 from meridian_euid import assert_registered_domain as meridian_assert_registered_domain
 from meridian_euid import load_domain_registry as meridian_load_domain_registry
+from meridian_euid import (
+    load_domain_registry_metadata as meridian_load_domain_registry_metadata,
+)
 from meridian_euid import (
     load_prefix_ownership_registry as meridian_load_prefix_ownership_registry,
 )
@@ -40,6 +48,11 @@ def load_domain_registry(path: str | Path) -> frozenset[str]:
     return meridian_load_domain_registry(resolved)
 
 
+def load_domain_registry_metadata(path: str | Path) -> dict[str, dict[str, object]]:
+    resolved = _resolved_path(path)
+    return meridian_load_domain_registry_metadata(resolved)
+
+
 def load_prefix_ownership_registry(
     path: str | Path,
 ) -> dict[tuple[str, str], str]:
@@ -66,15 +79,26 @@ def assert_registered_domain(
     domain_code: str,
     *,
     registry: frozenset[str] | None = None,
+    registry_metadata: Mapping[str, Mapping[str, object]] | None = None,
     path: str | Path | None = None,
 ) -> str:
     normalized_domain_code = _validate_domain_code(domain_code)
+    if registry is None and registry_metadata is None:
+        resolved_path = _resolved_path(path)
+    else:
+        resolved_path = _resolved_path(path) if path is not None else None
     if registry is None:
         return meridian_assert_registered_domain(
             normalized_domain_code,
-            path=_resolved_path(path),
+            registry_metadata=registry_metadata,
+            path=resolved_path,
         )
-    return meridian_assert_registered_domain(normalized_domain_code, registry=registry)
+    return meridian_assert_registered_domain(
+        normalized_domain_code,
+        registry=registry,
+        registry_metadata=registry_metadata,
+        path=resolved_path,
+    )
 
 
 def resolve_prefix_owner_repo_name(
@@ -129,7 +153,11 @@ class GovernanceContext:
     domain_registry_path: Path
     prefix_ownership_registry_path: Path
     registered_domains: frozenset[str]
+    domain_registry_metadata: Mapping[str, Mapping[str, object]]
     prefix_ownership: Mapping[tuple[str, str], str]
+    public_domain_registry_repository: str = MERIDIAN_REGISTRY_REPOSITORY
+    public_domain_registry_version: str = MERIDIAN_REGISTRY_VERSION
+    public_domain_registry_index_url: str = MERIDIAN_REGISTRY_INDEX_URL
 
     @classmethod
     def load(
@@ -148,13 +176,17 @@ class GovernanceContext:
             domain_registry_path=resolved_domain_registry_path,
             prefix_ownership_registry_path=resolved_prefix_ownership_registry_path,
         )
-        registered_domains = load_domain_registry(resolved_domain_registry_path)
+        domain_registry_metadata = load_domain_registry_metadata(
+            resolved_domain_registry_path
+        )
+        registered_domains = frozenset(domain_registry_metadata)
         prefix_ownership = load_prefix_ownership_registry(
             resolved_prefix_ownership_registry_path
         )
         normalized_domain_code = assert_registered_domain(
             domain_code,
             registry=registered_domains,
+            registry_metadata=domain_registry_metadata,
             path=resolved_domain_registry_path,
         )
         normalized_owner_repo_name = normalize_owner_repo_name(owner_repo_name)
@@ -164,6 +196,7 @@ class GovernanceContext:
             domain_registry_path=resolved_domain_registry_path,
             prefix_ownership_registry_path=resolved_prefix_ownership_registry_path,
             registered_domains=registered_domains,
+            domain_registry_metadata=domain_registry_metadata,
             prefix_ownership=prefix_ownership,
         )
 

--- a/daylily_tapdb/gui/__init__.py
+++ b/daylily_tapdb/gui/__init__.py
@@ -1,0 +1,15 @@
+"""Embeddable TapDB GUI surfaces."""
+
+from daylily_tapdb.gui.router import (
+    create_tapdb_gui_app,
+    create_tapdb_gui_router,
+    require_tapdb_gui_admin,
+    require_tapdb_gui_user,
+)
+
+__all__ = [
+    "create_tapdb_gui_app",
+    "create_tapdb_gui_router",
+    "require_tapdb_gui_admin",
+    "require_tapdb_gui_user",
+]

--- a/daylily_tapdb/gui/router.py
+++ b/daylily_tapdb/gui/router.py
@@ -626,6 +626,11 @@ def _meridian_validation_payload(
         "prefix": prefix,
         "prefix_owner": prefix_owner,
         "prefix_error": prefix_error,
+        "public_domain_registry": {
+            "repository": governance.public_domain_registry_repository,
+            "version": governance.public_domain_registry_version,
+            "index_url": governance.public_domain_registry_index_url,
+        },
     }
 
 
@@ -650,7 +655,8 @@ def _readiness_payload(*, config_path: str) -> dict[str, Any]:
             "ok": True,
             "detail": (
                 f"Domain {governance.domain_code}; owner "
-                f"{governance.owner_repo_name}"
+                f"{governance.owner_repo_name}; public registry "
+                f"{governance.public_domain_registry_version}"
             ),
         }
     )
@@ -684,6 +690,11 @@ def _readiness_payload(*, config_path: str) -> dict[str, Any]:
         "client_id": cfg.get("client_id"),
         "domain_code": cfg.get("domain_code"),
         "owner_repo_name": cfg.get("owner_repo_name"),
+        "public_domain_registry": {
+            "repository": governance.public_domain_registry_repository,
+            "version": governance.public_domain_registry_version,
+            "index_url": governance.public_domain_registry_index_url,
+        },
         "checks": checks,
     }
 

--- a/daylily_tapdb/gui/router.py
+++ b/daylily_tapdb/gui/router.py
@@ -396,27 +396,17 @@ def _validate_template_payload(payload: dict[str, Any]) -> list[ConfigIssue]:
 
 
 def _external_link_template(session: Any) -> generic_template | None:
-    candidates = [
-        ("XRF", "external_identifier", "tapdb_object"),
-        ("external_identifier", "tapdb", "object"),
-        ("tapdb_external_identifier", "tapdb", "object"),
-        ("external_reference", "tapdb", "object"),
-    ]
-    for category, type_name, subtype in candidates:
-        template = (
-            session.query(generic_template)
-            .filter_by(
-                category=category,
-                type=type_name,
-                subtype=subtype,
-                is_deleted=False,
-            )
-            .order_by(generic_template.version.desc())
-            .first()
+    return (
+        session.query(generic_template)
+        .filter_by(
+            category="XRF",
+            type="external_identifier",
+            subtype="tapdb_object",
+            is_deleted=False,
         )
-        if template is not None:
-            return template
-    return None
+        .order_by(generic_template.version.desc())
+        .first()
+    )
 
 
 def _external_link_properties(
@@ -480,8 +470,8 @@ def _create_external_link(
         raise HTTPException(
             status_code=422,
             detail=(
-                "No external link template is seeded. Seed a template "
-                "with category external_identifier, type tapdb, subtype object."
+                "No XRF/external_identifier/tapdb_object external link "
+                "template is seeded."
             ),
         )
     factory = InstanceFactory(TemplateManager(), domain_code=str(cfg["domain_code"]))
@@ -715,6 +705,13 @@ def create_tapdb_gui_router(
     async def gui_css():
         css_path = BASE_DIR / "static" / "css" / "tapdb-gui.css"
         return HTMLResponse(css_path.read_text(encoding="utf-8"), media_type="text/css")
+
+    @router.get("/static/lsmc-ui.js")
+    async def gui_lsmc_ui_js():
+        js_path = BASE_DIR / "static" / "js" / "lsmc-ui.js"
+        return HTMLResponse(
+            js_path.read_text(encoding="utf-8"), media_type="application/javascript"
+        )
 
     @router.get("/", response_class=HTMLResponse)
     async def home(
@@ -953,7 +950,7 @@ def create_tapdb_gui_router(
     async def create_page(
         request: Request,
         template_euid: str,
-        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
     ):
         with get_db(resolved_config_path) as conn:
             conn.app_username = user.get("username")
@@ -986,7 +983,7 @@ def create_tapdb_gui_router(
     async def create_submit(
         request: Request,
         template_euid: str,
-        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
     ):
         form = await _read_urlencoded_form(request)
         name = str(form.get("name") or "")
@@ -1015,7 +1012,7 @@ def create_tapdb_gui_router(
     async def create_api(
         request: Request,
         template_euid: str,
-        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
     ):
         payload = await request.json()
         if not isinstance(payload, dict):

--- a/daylily_tapdb/gui/router.py
+++ b/daylily_tapdb/gui/router.py
@@ -190,7 +190,9 @@ def _resolve_instance(session: Any, euid: str, *, label: str) -> generic_instanc
     return obj
 
 
-def _object_relationships(obj: Any, record_type: str) -> dict[str, list[dict[str, Any]]]:
+def _object_relationships(
+    obj: Any, record_type: str
+) -> dict[str, list[dict[str, Any]]]:
     parent_of: list[dict[str, Any]] = []
     child_of: list[dict[str, Any]] = []
     if record_type != "instance":
@@ -297,7 +299,9 @@ def _parse_json_object(raw: str, *, label: str) -> dict[str, Any]:
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError as exc:
-        raise HTTPException(status_code=400, detail=f"{label} invalid JSON: {exc}") from exc
+        raise HTTPException(
+            status_code=400, detail=f"{label} invalid JSON: {exc}"
+        ) from exc
     if not isinstance(payload, dict):
         raise HTTPException(status_code=400, detail=f"{label} must be a JSON object")
     return payload
@@ -316,16 +320,16 @@ async def _read_urlencoded_form(request: Request) -> dict[str, str]:
 
 
 def _template_code(template: Any) -> str:
-    return (
-        f"{template.category}/{template.type}/{template.subtype}/{template.version}/"
-    )
+    return f"{template.category}/{template.type}/{template.subtype}/{template.version}/"
 
 
 def _validate_template_payload(payload: dict[str, Any]) -> list[ConfigIssue]:
     issues: list[ConfigIssue] = []
     templates = payload.get("templates")
     if not isinstance(templates, list) or not templates:
-        return [ConfigIssue(level="error", message="templates must be a non-empty array")]
+        return [
+            ConfigIssue(level="error", message="templates must be a non-empty array")
+        ]
 
     required = (
         "name",
@@ -519,7 +523,9 @@ def _create_instance_from_template(
         .first()
     )
     if template is None:
-        raise HTTPException(status_code=404, detail=f"Template not found: {template_euid}")
+        raise HTTPException(
+            status_code=404, detail=f"Template not found: {template_euid}"
+        )
     factory = InstanceFactory(TemplateManager(), domain_code=str(cfg["domain_code"]))
     instance = factory.create_instance(
         session,
@@ -536,7 +542,9 @@ def _create_instance_from_template(
     }
 
 
-def _update_object_json(session: Any, *, euid: str, json_addl: dict[str, Any]) -> dict[str, Any]:
+def _update_object_json(
+    session: Any, *, euid: str, json_addl: dict[str, Any]
+) -> dict[str, Any]:
     obj, record_type = find_object_by_euid(session, euid)
     if obj is None or record_type is None:
         raise HTTPException(status_code=404, detail=f"Object not found: {euid}")
@@ -664,7 +672,10 @@ def _readiness_payload(*, config_path: str) -> dict[str, Any]:
         with conn.session_scope() as session:
             external_template = _external_link_template(session)
             template_count = (
-                session.query(generic_template).filter_by(is_deleted=False).limit(500).all()
+                session.query(generic_template)
+                .filter_by(is_deleted=False)
+                .limit(500)
+                .all()
             )
     checks.append(
         {
@@ -744,7 +755,9 @@ def create_tapdb_gui_router(
         user: dict[str, Any] = Depends(require_tapdb_gui_user),
     ):
         if record_type not in SEARCH_RECORD_TYPES:
-            raise HTTPException(status_code=400, detail=f"Invalid record_type: {record_type}")
+            raise HTTPException(
+                status_code=400, detail=f"Invalid record_type: {record_type}"
+            )
         cfg = get_db_config(config_path=resolved_config_path)
         with get_db(resolved_config_path) as conn:
             conn.app_username = user.get("username")
@@ -786,7 +799,9 @@ def create_tapdb_gui_router(
         user: dict[str, Any] = Depends(require_tapdb_gui_user),
     ):
         if record_type not in SEARCH_RECORD_TYPES:
-            raise HTTPException(status_code=400, detail=f"Invalid record_type: {record_type}")
+            raise HTTPException(
+                status_code=400, detail=f"Invalid record_type: {record_type}"
+            )
         cfg = get_db_config(config_path=resolved_config_path)
         with get_db(resolved_config_path) as conn:
             conn.app_username = user.get("username")
@@ -1000,7 +1015,9 @@ def create_tapdb_gui_router(
         name = str(form.get("name") or "")
         properties_json = str(form.get("properties_json") or "{}")
         create_children = str(form.get("create_children") or "")
-        properties = _parse_json_object(properties_json or "{}", label="properties_json")
+        properties = _parse_json_object(
+            properties_json or "{}", label="properties_json"
+        )
         cfg = get_db_config(config_path=resolved_config_path)
         with get_db(resolved_config_path) as conn:
             conn.app_username = user.get("username")
@@ -1015,7 +1032,9 @@ def create_tapdb_gui_router(
                 )
                 instance_euid = created["instance_euid"]
         return RedirectResponse(
-            gui_url_with_query(request, f"/object/{instance_euid}", notice="instance_created"),
+            gui_url_with_query(
+                request, f"/object/{instance_euid}", notice="instance_created"
+            ),
             status_code=303,
         )
 
@@ -1033,7 +1052,9 @@ def create_tapdb_gui_router(
             )
         properties = payload.get("properties") or {}
         if not isinstance(properties, dict):
-            raise HTTPException(status_code=400, detail="properties must be a JSON object")
+            raise HTTPException(
+                status_code=400, detail="properties must be a JSON object"
+            )
         cfg = get_db_config(config_path=resolved_config_path)
         with get_db(resolved_config_path) as conn:
             conn.app_username = user.get("username")
@@ -1062,7 +1083,9 @@ def create_tapdb_gui_router(
             with conn.session_scope() as session:
                 obj, record_type = find_object_by_euid(session, euid)
                 if obj is None or record_type is None:
-                    raise HTTPException(status_code=404, detail=f"Object not found: {euid}")
+                    raise HTTPException(
+                        status_code=404, detail=f"Object not found: {euid}"
+                    )
                 graph = build_graph_payload(
                     obj,
                     record_type=record_type,
@@ -1091,7 +1114,9 @@ def create_tapdb_gui_router(
             with conn.session_scope() as session:
                 obj, record_type = find_object_by_euid(session, euid)
                 if obj is None or record_type is None:
-                    raise HTTPException(status_code=404, detail=f"Object not found: {euid}")
+                    raise HTTPException(
+                        status_code=404, detail=f"Object not found: {euid}"
+                    )
                 return build_graph_payload(
                     obj,
                     record_type=record_type,
@@ -1161,7 +1186,9 @@ def create_tapdb_gui_router(
     ):
         payload = await request.json()
         if not isinstance(payload, dict):
-            raise HTTPException(status_code=400, detail="json_addl must be a JSON object")
+            raise HTTPException(
+                status_code=400, detail="json_addl must be a JSON object"
+            )
         with get_db(resolved_config_path) as conn:
             conn.app_username = user.get("username")
             with conn.session_scope(commit=True) as session:
@@ -1194,7 +1221,9 @@ def create_tapdb_gui_router(
     ):
         payload = await request.json()
         if not isinstance(payload, dict):
-            raise HTTPException(status_code=400, detail="status payload must be a JSON object")
+            raise HTTPException(
+                status_code=400, detail="status payload must be a JSON object"
+            )
         with get_db(resolved_config_path) as conn:
             conn.app_username = user.get("username")
             with conn.session_scope(commit=True) as session:
@@ -1239,7 +1268,9 @@ def create_tapdb_gui_router(
     ):
         payload = await request.json()
         if not isinstance(payload, dict):
-            raise HTTPException(status_code=400, detail="lineage payload must be a JSON object")
+            raise HTTPException(
+                status_code=400, detail="lineage payload must be a JSON object"
+            )
         with get_db(resolved_config_path) as conn:
             conn.app_username = user.get("username")
             with conn.session_scope(commit=True) as session:
@@ -1249,7 +1280,9 @@ def create_tapdb_gui_router(
                         euid=euid,
                         related_euid=str(payload.get("related_euid") or ""),
                         direction=str(payload.get("direction") or "parent"),
-                        relationship_type=str(payload.get("relationship_type") or "generic"),
+                        relationship_type=str(
+                            payload.get("relationship_type") or "generic"
+                        ),
                     )
                 )
 
@@ -1282,9 +1315,7 @@ def create_tapdb_gui_router(
         display_url = str(form.get("display_url") or "")
         graph_base_url = str(form.get("graph_base_url") or "")
         graph_data_path = str(form.get("graph_data_path") or "")
-        object_detail_path_template = str(
-            form.get("object_detail_path_template") or ""
-        )
+        object_detail_path_template = str(form.get("object_detail_path_template") or "")
         auth_mode = str(form.get("auth_mode") or "none")
         missing = [
             label
@@ -1319,7 +1350,9 @@ def create_tapdb_gui_router(
                 )
                 link_euid = created["link_euid"]
         return RedirectResponse(
-            gui_url_with_query(request, f"/object/{link_euid}", notice="external_link_created"),
+            gui_url_with_query(
+                request, f"/object/{link_euid}", notice="external_link_created"
+            ),
             status_code=303,
         )
 

--- a/daylily_tapdb/gui/router.py
+++ b/daylily_tapdb/gui/router.py
@@ -1,0 +1,1511 @@
+"""Embeddable TapDB GUI router.
+
+This module is intentionally separate from ``admin.main``. The legacy admin app
+keeps its current routes, while this package exposes mount-friendly pages that
+client FastAPI apps can adopt without rewriting their existing TapDB usage.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlencode
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import HTMLResponse, RedirectResponse
+from jinja2 import ChoiceLoader, Environment, FileSystemLoader, select_autoescape
+from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
+
+from admin.db_metrics import build_metrics_page_context
+from daylily_tapdb import InstanceFactory, TemplateManager, __version__
+from daylily_tapdb.cli.db_config import get_db_config
+from daylily_tapdb.euid import validate_euid
+from daylily_tapdb.governance import GovernanceContext
+from daylily_tapdb.models.audit import audit_log
+from daylily_tapdb.models.instance import generic_instance
+from daylily_tapdb.models.lineage import generic_instance_lineage
+from daylily_tapdb.models.template import generic_template
+from daylily_tapdb.services.external_refs import external_ref_payloads
+from daylily_tapdb.services.graph_payloads import build_graph_payload
+from daylily_tapdb.services.object_lookup import find_object_by_euid
+from daylily_tapdb.services.object_search import search_objects
+from daylily_tapdb.templates.loader import (
+    ConfigIssue,
+    find_tapdb_core_config_dir,
+    seed_templates,
+)
+from daylily_tapdb.validation.instantiation_layouts import (
+    format_validation_error,
+    validate_instantiation_layouts,
+)
+from daylily_tapdb.web.bridge import (
+    TapdbHostBridge,
+    resolve_host_context,
+    resolve_host_shell,
+)
+from daylily_tapdb.web.factory import TapdbHostBridgeMount
+from daylily_tapdb.web.runtime import get_db
+
+BASE_DIR = Path(__file__).resolve().parent
+TEMPLATES_DIR = BASE_DIR / "templates"
+SEARCH_RECORD_TYPES = {"all", "template", "instance", "lineage"}
+
+
+def _build_templates(bridge: TapdbHostBridge | None) -> Environment:
+    override_dirs: list[str] = []
+    if bridge is not None:
+        override_dirs = [
+            str(Path(item).expanduser().resolve())
+            for item in bridge.template_override_dirs
+            if str(item).strip() and Path(item).expanduser().exists()
+        ]
+    loaders = [FileSystemLoader(path) for path in override_dirs]
+    loaders.append(FileSystemLoader(str(TEMPLATES_DIR)))
+    env = Environment(
+        loader=ChoiceLoader(loaders),
+        autoescape=select_autoescape(["html", "htm", "xml"]),
+    )
+    env.globals["tapdb_gui_url"] = gui_url
+    env.globals["tapdb_gui_host_shell"] = lambda request: resolve_host_shell(
+        bridge, request
+    )
+    env.globals["tapdb_gui_host_context"] = lambda request: resolve_host_context(
+        bridge, request
+    )
+    env.globals["tapdb_version"] = __version__
+    return env
+
+
+def gui_base_path(request: Request) -> str:
+    return str(request.scope.get("root_path") or "").rstrip("/")
+
+
+def gui_url(request: Request, path: str) -> str:
+    suffix = "/" + str(path or "/").lstrip("/")
+    return f"{gui_base_path(request)}{suffix}"
+
+
+def gui_url_with_query(request: Request, path: str, **query: str) -> str:
+    base = gui_url(request, path)
+    clean = {key: value for key, value in query.items() if str(value or "").strip()}
+    if not clean:
+        return base
+    return f"{base}?{urlencode(clean)}"
+
+
+async def require_tapdb_gui_user(request: Request) -> dict[str, Any]:
+    """Require a host-injected or TapDB-authenticated GUI user."""
+
+    host_user = request.scope.get("tapdb_host_user")
+    if isinstance(host_user, dict) and host_user.get("username"):
+        request.state.user = host_user
+        return host_user
+
+    from admin.auth import get_current_user
+
+    user = await get_current_user(request)
+    if not user:
+        raise HTTPException(status_code=401, detail="tapdb_gui_auth_required")
+    request.state.user = user
+    return user
+
+
+async def require_tapdb_gui_admin(
+    user: dict[str, Any] = Depends(require_tapdb_gui_user),
+) -> dict[str, Any]:
+    role = str(user.get("role") or "").strip().lower()
+    if role != "admin":
+        raise HTTPException(status_code=403, detail="tapdb_gui_admin_required")
+    return user
+
+
+def _render(
+    templates: Environment,
+    request: Request,
+    template_name: str,
+    *,
+    user: dict[str, Any],
+    **context: Any,
+) -> HTMLResponse:
+    html = templates.get_template(template_name).render(
+        request=request,
+        user=user,
+        **context,
+    )
+    return HTMLResponse(html)
+
+
+def _record_to_dict(obj: Any, record_type: str) -> dict[str, Any]:
+    return {
+        "uid": getattr(obj, "uid", None),
+        "euid": getattr(obj, "euid", None),
+        "record_type": record_type,
+        "name": getattr(obj, "name", None),
+        "category": getattr(obj, "category", None),
+        "type": getattr(obj, "type", None),
+        "subtype": getattr(obj, "subtype", None),
+        "version": getattr(obj, "version", None),
+        "bstatus": getattr(obj, "bstatus", None),
+        "json_addl": getattr(obj, "json_addl", None),
+        "created_dt": getattr(obj, "created_dt", None),
+        "modified_dt": getattr(obj, "modified_dt", None),
+    }
+
+
+def _new_lineage(
+    *,
+    parent: generic_instance,
+    child: generic_instance,
+    relationship_type: str,
+) -> generic_instance_lineage:
+    rel = (relationship_type or "").strip() or "generic"
+    return generic_instance_lineage(
+        name=f"{parent.euid}->{child.euid}:{rel}",
+        polymorphic_discriminator="generic_instance_lineage",
+        category="lineage",
+        type="lineage",
+        subtype="generic",
+        version="1.0",
+        bstatus="active",
+        parent_instance_uid=parent.uid,
+        child_instance_uid=child.uid,
+        relationship_type=rel,
+        parent_type=parent.polymorphic_discriminator,
+        child_type=child.polymorphic_discriminator,
+        json_addl={},
+    )
+
+
+def _resolve_instance(session: Any, euid: str, *, label: str) -> generic_instance:
+    obj = (
+        session.query(generic_instance)
+        .filter_by(euid=str(euid or "").strip(), is_deleted=False)
+        .first()
+    )
+    if obj is None:
+        raise HTTPException(status_code=404, detail=f"{label} not found: {euid}")
+    return obj
+
+
+def _object_relationships(obj: Any, record_type: str) -> dict[str, list[dict[str, Any]]]:
+    parent_of: list[dict[str, Any]] = []
+    child_of: list[dict[str, Any]] = []
+    if record_type != "instance":
+        return {"parent_of": parent_of, "child_of": child_of}
+    for lineage in obj.parent_of_lineages.filter_by(is_deleted=False).all():
+        child = getattr(lineage, "child_instance", None)
+        parent_of.append(
+            {
+                "lineage_euid": lineage.euid,
+                "related_euid": getattr(child, "euid", None),
+                "related_name": getattr(child, "name", None),
+                "relationship_type": lineage.relationship_type,
+            }
+        )
+    for lineage in obj.child_of_lineages.filter_by(is_deleted=False).all():
+        parent = getattr(lineage, "parent_instance", None)
+        child_of.append(
+            {
+                "lineage_euid": lineage.euid,
+                "related_euid": getattr(parent, "euid", None),
+                "related_name": getattr(parent, "name", None),
+                "relationship_type": lineage.relationship_type,
+            }
+        )
+    return {"parent_of": parent_of, "child_of": child_of}
+
+
+def _lineage_external_refs(obj: Any, record_type: str) -> list[dict[str, Any]]:
+    if record_type != "instance":
+        return []
+    refs: list[dict[str, Any]] = []
+    for lineage in obj.parent_of_lineages.filter_by(is_deleted=False).all():
+        child = getattr(lineage, "child_instance", None)
+        if child is None:
+            continue
+        markers = {
+            str(getattr(child, "category", "") or "").strip().lower(),
+            str(getattr(child, "type", "") or "").strip().lower(),
+            str(getattr(child, "subtype", "") or "").strip().lower(),
+        }
+        if not (
+            markers
+            & {
+                "external_identifier",
+                "external_id",
+                "external_reference",
+                "tapdb_external_identifier",
+            }
+        ):
+            continue
+        for ref in external_ref_payloads(child):
+            item = dict(ref)
+            item["link_euid"] = getattr(child, "euid", None)
+            item["lineage_euid"] = getattr(lineage, "euid", None)
+            item["relationship_type"] = getattr(lineage, "relationship_type", None)
+            refs.append(item)
+    return refs
+
+
+def _audit_rows(session: Any, euid: str, limit: int = 100) -> list[dict[str, Any]]:
+    rows = (
+        session.query(audit_log)
+        .filter_by(rel_table_euid_fk=euid, is_deleted=False)
+        .order_by(audit_log.changed_at.desc())
+        .limit(limit)
+        .all()
+    )
+    return [
+        {
+            "euid": row.euid,
+            "table": row.rel_table_name,
+            "column": row.column_name,
+            "operation": row.operation_type,
+            "old_value": row.old_value,
+            "new_value": row.new_value,
+            "changed_by": row.changed_by,
+            "changed_at": row.changed_at,
+        }
+        for row in rows
+    ]
+
+
+def _object_detail_context(
+    session: Any,
+    euid: str,
+) -> dict[str, Any]:
+    obj, record_type = find_object_by_euid(session, euid)
+    if obj is None or record_type is None:
+        raise HTTPException(status_code=404, detail=f"Object not found: {euid}")
+    payload = _record_to_dict(obj, record_type)
+    relationships = _object_relationships(obj, record_type)
+    refs = external_ref_payloads(obj)
+    refs.extend(_lineage_external_refs(obj, record_type))
+    return {
+        "obj": payload,
+        "record_type": record_type,
+        "relationships": relationships,
+        "audit_rows": _audit_rows(session, euid),
+        "external_refs": refs,
+    }
+
+
+def _parse_json_object(raw: str, *, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail=f"{label} invalid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail=f"{label} must be a JSON object")
+    return payload
+
+
+async def _read_urlencoded_form(request: Request) -> dict[str, str]:
+    content_type = str(request.headers.get("content-type") or "").split(";", 1)[0]
+    if content_type and content_type != "application/x-www-form-urlencoded":
+        raise HTTPException(
+            status_code=415,
+            detail="TapDB GUI form posts require application/x-www-form-urlencoded",
+        )
+    body = (await request.body()).decode("utf-8")
+    parsed = parse_qs(body, keep_blank_values=True)
+    return {key: values[-1] if values else "" for key, values in parsed.items()}
+
+
+def _template_code(template: Any) -> str:
+    return (
+        f"{template.category}/{template.type}/{template.subtype}/{template.version}/"
+    )
+
+
+def _validate_template_payload(payload: dict[str, Any]) -> list[ConfigIssue]:
+    issues: list[ConfigIssue] = []
+    templates = payload.get("templates")
+    if not isinstance(templates, list) or not templates:
+        return [ConfigIssue(level="error", message="templates must be a non-empty array")]
+
+    required = (
+        "name",
+        "polymorphic_discriminator",
+        "category",
+        "type",
+        "subtype",
+        "version",
+        "instance_prefix",
+    )
+    seen: set[tuple[str, str, str, str]] = set()
+    for index, template in enumerate(templates):
+        if not isinstance(template, dict):
+            issues.append(
+                ConfigIssue(
+                    level="error",
+                    message=f"templates[{index}] must be a JSON object",
+                )
+            )
+            continue
+        for key in required:
+            if not str(template.get(key) or "").strip():
+                issues.append(
+                    ConfigIssue(
+                        level="error",
+                        message=f"templates[{index}] missing required field {key!r}",
+                    )
+                )
+        key = (
+            str(template.get("category") or ""),
+            str(template.get("type") or ""),
+            str(template.get("subtype") or ""),
+            str(template.get("version") or ""),
+        )
+        if key in seen:
+            issues.append(
+                ConfigIssue(
+                    level="error",
+                    template_code="/".join(key),
+                    message=f"duplicate template key: {key!r}",
+                )
+            )
+        seen.add(key)
+        json_addl = template.get("json_addl")
+        if json_addl is not None and not isinstance(json_addl, dict):
+            issues.append(
+                ConfigIssue(
+                    level="error",
+                    template_code="/".join(key),
+                    message="json_addl must be a JSON object",
+                )
+            )
+        if isinstance(json_addl, dict) and json_addl.get("instantiation_layouts"):
+            try:
+                validate_instantiation_layouts(json_addl.get("instantiation_layouts"))
+            except ValidationError as exc:
+                issues.append(
+                    ConfigIssue(
+                        level="error",
+                        template_code="/".join(key),
+                        message=(
+                            "Invalid instantiation_layouts: "
+                            f"{format_validation_error(exc)}"
+                        ),
+                    )
+                )
+    return issues
+
+
+def _external_link_template(session: Any) -> generic_template | None:
+    candidates = [
+        ("XRF", "external_identifier", "tapdb_object"),
+        ("external_identifier", "tapdb", "object"),
+        ("tapdb_external_identifier", "tapdb", "object"),
+        ("external_reference", "tapdb", "object"),
+    ]
+    for category, type_name, subtype in candidates:
+        template = (
+            session.query(generic_template)
+            .filter_by(
+                category=category,
+                type=type_name,
+                subtype=subtype,
+                is_deleted=False,
+            )
+            .order_by(generic_template.version.desc())
+            .first()
+        )
+        if template is not None:
+            return template
+    return None
+
+
+def _external_link_properties(
+    *,
+    system: str,
+    foreign_uid: str,
+    display_url: str = "",
+    graph_base_url: str = "",
+    graph_data_path: str = "",
+    object_detail_path_template: str = "",
+    auth_mode: str = "none",
+) -> dict[str, Any]:
+    return {
+        "system": system.strip(),
+        "foreign_uid": foreign_uid.strip(),
+        "root_euid": foreign_uid.strip(),
+        "href": display_url.strip(),
+        "external_identifier": {
+            "system": system.strip(),
+            "target_euid": foreign_uid.strip(),
+            "href": display_url.strip() or None,
+            "base_url": graph_base_url.strip() or None,
+            "graph_data_path": graph_data_path.strip() or None,
+            "object_detail_path_template": object_detail_path_template.strip() or None,
+            "auth_mode": auth_mode.strip() or "none",
+        },
+    }
+
+
+def _create_external_link(
+    session: Any,
+    *,
+    cfg: dict[str, Any],
+    source_euid: str,
+    system: str,
+    foreign_uid: str,
+    relationship_type: str,
+    display_url: str = "",
+    graph_base_url: str = "",
+    graph_data_path: str = "",
+    object_detail_path_template: str = "",
+    auth_mode: str = "none",
+) -> dict[str, Any]:
+    missing = [
+        label
+        for label, value in (
+            ("system", system),
+            ("foreign_uid", foreign_uid),
+            ("relationship_type", relationship_type),
+        )
+        if not str(value or "").strip()
+    ]
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail="Missing required external link field(s): " + ", ".join(missing),
+        )
+    source = _resolve_instance(session, source_euid, label="Source object")
+    template = _external_link_template(session)
+    if template is None:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "No external link template is seeded. Seed a template "
+                "with category external_identifier, type tapdb, subtype object."
+            ),
+        )
+    factory = InstanceFactory(TemplateManager(), domain_code=str(cfg["domain_code"]))
+    link = factory.create_instance(
+        session,
+        _template_code(template),
+        name=f"{system.strip()}:{foreign_uid.strip()}",
+        properties=_external_link_properties(
+            system=system,
+            foreign_uid=foreign_uid,
+            display_url=display_url,
+            graph_base_url=graph_base_url,
+            graph_data_path=graph_data_path,
+            object_detail_path_template=object_detail_path_template,
+            auth_mode=auth_mode,
+        ),
+        create_children=False,
+    )
+    lineage = _new_lineage(
+        parent=source,
+        child=link,
+        relationship_type=relationship_type,
+    )
+    session.add(lineage)
+    return {
+        "source_euid": source.euid,
+        "link_euid": link.euid,
+        "lineage_euid": getattr(lineage, "euid", None),
+        "relationship_type": relationship_type.strip(),
+    }
+
+
+def _create_instance_from_template(
+    session: Any,
+    *,
+    cfg: dict[str, Any],
+    template_euid: str,
+    name: str,
+    properties: dict[str, Any],
+    create_children: bool,
+) -> dict[str, Any]:
+    template = (
+        session.query(generic_template)
+        .filter_by(euid=template_euid, is_deleted=False)
+        .first()
+    )
+    if template is None:
+        raise HTTPException(status_code=404, detail=f"Template not found: {template_euid}")
+    factory = InstanceFactory(TemplateManager(), domain_code=str(cfg["domain_code"]))
+    instance = factory.create_instance(
+        session,
+        _template_code(template),
+        name=name.strip(),
+        properties=properties,
+        create_children=create_children,
+    )
+    return {
+        "template_euid": template.euid,
+        "template_code": _template_code(template),
+        "instance_euid": instance.euid,
+        "create_children": create_children,
+    }
+
+
+def _update_object_json(session: Any, *, euid: str, json_addl: dict[str, Any]) -> dict[str, Any]:
+    obj, record_type = find_object_by_euid(session, euid)
+    if obj is None or record_type is None:
+        raise HTTPException(status_code=404, detail=f"Object not found: {euid}")
+    if record_type == "template":
+        raise HTTPException(status_code=403, detail="Templates are read-only")
+    obj.json_addl = json_addl
+    return {"euid": euid, "json_addl": json_addl}
+
+
+def _update_object_status(session: Any, *, euid: str, bstatus: str) -> dict[str, Any]:
+    status = str(bstatus or "").strip()
+    if not status:
+        raise HTTPException(status_code=400, detail="bstatus is required")
+    obj, record_type = find_object_by_euid(session, euid)
+    if obj is None or record_type is None:
+        raise HTTPException(status_code=404, detail=f"Object not found: {euid}")
+    if record_type == "template":
+        raise HTTPException(status_code=403, detail="Templates are read-only")
+    obj.bstatus = status
+    return {"euid": euid, "bstatus": status}
+
+
+def _add_object_lineage(
+    session: Any,
+    *,
+    euid: str,
+    related_euid: str,
+    direction: str,
+    relationship_type: str,
+) -> dict[str, Any]:
+    current = _resolve_instance(session, euid, label="Object")
+    related = _resolve_instance(session, related_euid, label="Related object")
+    if direction == "child":
+        parent, child = current, related
+    else:
+        parent, child = related, current
+    lineage = _new_lineage(
+        parent=parent,
+        child=child,
+        relationship_type=relationship_type,
+    )
+    session.add(lineage)
+    try:
+        session.flush()
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail="Lineage already exists or violates a DB constraint",
+        ) from exc
+    return {
+        "lineage_euid": getattr(lineage, "euid", None),
+        "parent_euid": parent.euid,
+        "child_euid": child.euid,
+        "relationship_type": (relationship_type or "").strip() or "generic",
+    }
+
+
+def _meridian_validation_payload(
+    *,
+    config_path: str,
+    euid: str,
+    prefix: str,
+) -> dict[str, Any]:
+    cfg = get_db_config(config_path=config_path)
+    governance = GovernanceContext.load(
+        domain_code=str(cfg["domain_code"]),
+        owner_repo_name=str(cfg["owner_repo_name"]),
+        domain_registry_path=str(cfg["domain_registry_path"]),
+        prefix_ownership_registry_path=str(cfg["prefix_ownership_registry_path"]),
+    )
+    euid_valid = None
+    if euid:
+        euid_valid = validate_euid(euid, allowed_domain_codes=[governance.domain_code])
+    prefix_owner = None
+    prefix_error = None
+    if prefix:
+        try:
+            prefix_owner = governance.require_prefix(prefix)
+        except ValueError as exc:
+            prefix_error = str(exc)
+    return {
+        "config": cfg,
+        "governance": governance,
+        "domain_code": governance.domain_code,
+        "euid": euid,
+        "euid_valid": euid_valid,
+        "prefix": prefix,
+        "prefix_owner": prefix_owner,
+        "prefix_error": prefix_error,
+    }
+
+
+def _readiness_payload(*, config_path: str) -> dict[str, Any]:
+    cfg = get_db_config(config_path=config_path)
+    checks: list[dict[str, Any]] = [
+        {
+            "name": "config",
+            "ok": True,
+            "detail": f"Loaded explicit config path: {config_path}",
+        }
+    ]
+    governance = GovernanceContext.load(
+        domain_code=str(cfg["domain_code"]),
+        owner_repo_name=str(cfg["owner_repo_name"]),
+        domain_registry_path=str(cfg["domain_registry_path"]),
+        prefix_ownership_registry_path=str(cfg["prefix_ownership_registry_path"]),
+    )
+    checks.append(
+        {
+            "name": "governance",
+            "ok": True,
+            "detail": (
+                f"Domain {governance.domain_code}; owner "
+                f"{governance.owner_repo_name}"
+            ),
+        }
+    )
+    with get_db(config_path) as conn:
+        with conn.session_scope() as session:
+            external_template = _external_link_template(session)
+            template_count = (
+                session.query(generic_template).filter_by(is_deleted=False).limit(500).all()
+            )
+    checks.append(
+        {
+            "name": "external_link_template",
+            "ok": external_template is not None,
+            "detail": (
+                _template_code(external_template)
+                if external_template is not None
+                else "No XRF external link template found"
+            ),
+        }
+    )
+    checks.append(
+        {
+            "name": "template_inventory",
+            "ok": bool(template_count),
+            "detail": f"{len(template_count)} active template(s) visible",
+        }
+    )
+    return {
+        "ready": all(check["ok"] for check in checks),
+        "config_path": config_path,
+        "client_id": cfg.get("client_id"),
+        "domain_code": cfg.get("domain_code"),
+        "owner_repo_name": cfg.get("owner_repo_name"),
+        "checks": checks,
+    }
+
+
+def create_tapdb_gui_router(
+    *,
+    config_path: str,
+    host_bridge: TapdbHostBridge | None = None,
+) -> APIRouter:
+    """Build the embeddable TapDB GUI router."""
+
+    resolved_config_path = str(config_path or "").strip()
+    if not resolved_config_path:
+        raise ValueError("config_path is required for TapDB GUI")
+    templates = _build_templates(host_bridge)
+    router = APIRouter()
+
+    @router.get("/static/tapdb-gui.css")
+    async def gui_css():
+        css_path = BASE_DIR / "static" / "css" / "tapdb-gui.css"
+        return HTMLResponse(css_path.read_text(encoding="utf-8"), media_type="text/css")
+
+    @router.get("/", response_class=HTMLResponse)
+    async def home(
+        request: Request,
+        q: str = "",
+        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+    ):
+        return await search_page(request, q=q, user=user)
+
+    @router.get("/search", response_class=HTMLResponse)
+    async def search_page(
+        request: Request,
+        q: str = "",
+        record_type: str = "all",
+        category: str = "",
+        type: str = "",
+        subtype: str = "",
+        limit: int = Query(25, ge=1, le=100),
+        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+    ):
+        if record_type not in SEARCH_RECORD_TYPES:
+            raise HTTPException(status_code=400, detail=f"Invalid record_type: {record_type}")
+        cfg = get_db_config(config_path=resolved_config_path)
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope() as session:
+                results = search_objects(
+                    session,
+                    service_name=str(cfg.get("client_id") or "tapdb"),
+                    q=q,
+                    record_type=record_type,
+                    category=category,
+                    type_name=type,
+                    subtype=subtype,
+                    limit=limit,
+                )
+        return _render(
+            templates,
+            request,
+            "search.html",
+            user=user,
+            results=results,
+            query={
+                "q": q,
+                "record_type": record_type,
+                "category": category,
+                "type": type,
+                "subtype": subtype,
+                "limit": limit,
+            },
+        )
+
+    @router.get("/api/search")
+    async def search_api(
+        q: str = "",
+        record_type: str = "all",
+        category: str = "",
+        type: str = "",
+        subtype: str = "",
+        limit: int = Query(25, ge=1, le=100),
+        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+    ):
+        if record_type not in SEARCH_RECORD_TYPES:
+            raise HTTPException(status_code=400, detail=f"Invalid record_type: {record_type}")
+        cfg = get_db_config(config_path=resolved_config_path)
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope() as session:
+                return search_objects(
+                    session,
+                    service_name=str(cfg.get("client_id") or "tapdb"),
+                    q=q,
+                    record_type=record_type,
+                    category=category,
+                    type_name=type,
+                    subtype=subtype,
+                    limit=limit,
+                )
+
+    @router.get("/templates", response_class=HTMLResponse)
+    async def templates_page(
+        request: Request,
+        category: str = "",
+        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+    ):
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope() as session:
+                query = session.query(generic_template).filter_by(is_deleted=False)
+                if category:
+                    query = query.filter_by(category=category)
+                items = (
+                    query.order_by(
+                        generic_template.category,
+                        generic_template.type,
+                        generic_template.subtype,
+                        generic_template.version,
+                    )
+                    .limit(500)
+                    .all()
+                )
+        return _render(
+            templates,
+            request,
+            "templates.html",
+            user=user,
+            items=items,
+            category=category,
+        )
+
+    @router.get("/templates/new", response_class=HTMLResponse)
+    async def template_new_page(
+        request: Request,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        return _render(
+            templates,
+            request,
+            "template_editor.html",
+            user=user,
+            raw_json=json.dumps(_example_template_pack(), indent=2),
+            issues=[],
+            saved=None,
+        )
+
+    @router.post("/templates/validate", response_class=HTMLResponse)
+    async def template_validate_page(
+        request: Request,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        form = await _read_urlencoded_form(request)
+        template_json = str(form.get("template_json") or "")
+        payload = _parse_json_object(template_json, label="template_json")
+        issues = _validate_template_payload(payload)
+        return _render(
+            templates,
+            request,
+            "template_editor.html",
+            user=user,
+            raw_json=json.dumps(payload, indent=2, sort_keys=True),
+            issues=issues,
+            saved=None,
+        )
+
+    @router.post("/api/templates/validate")
+    async def template_validate_api(
+        request: Request,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        del user
+        try:
+            payload = await request.json()
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"template payload invalid JSON: {exc}",
+            ) from exc
+        if not isinstance(payload, dict):
+            raise HTTPException(
+                status_code=400,
+                detail="template payload must be a JSON object",
+            )
+        issues = _validate_template_payload(payload)
+        return {
+            "valid": not any(issue.level == "error" for issue in issues),
+            "issues": [jsonable_encoder(issue) for issue in issues],
+        }
+
+    @router.post("/templates/save", response_class=HTMLResponse)
+    async def template_save_page(
+        request: Request,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        form = await _read_urlencoded_form(request)
+        template_json = str(form.get("template_json") or "")
+        payload = _parse_json_object(template_json, label="template_json")
+        issues = _validate_template_payload(payload)
+        if issues:
+            return _render(
+                templates,
+                request,
+                "template_editor.html",
+                user=user,
+                raw_json=json.dumps(payload, indent=2, sort_keys=True),
+                issues=issues,
+                saved=None,
+            )
+        cfg = get_db_config(config_path=resolved_config_path)
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope(commit=True) as session:
+                for template in payload["templates"]:
+                    existing = (
+                        session.query(generic_template)
+                        .filter_by(
+                            domain_code=cfg["domain_code"],
+                            category=str(template["category"]),
+                            type=str(template["type"]),
+                            subtype=str(template["subtype"]),
+                            version=str(template["version"]),
+                            is_deleted=False,
+                        )
+                        .first()
+                    )
+                    if existing is not None:
+                        raise HTTPException(
+                            status_code=409,
+                            detail=(
+                                "Template already exists and is read-only: "
+                                f"{_template_code(existing)}"
+                            ),
+                        )
+                summary = seed_templates(
+                    session,
+                    [dict(item) for item in payload["templates"]],
+                    overwrite=False,
+                    core_config_dir=find_tapdb_core_config_dir(),
+                    domain_code=str(cfg["domain_code"]),
+                    owner_repo_name=str(cfg["owner_repo_name"]),
+                    domain_registry_path=Path(str(cfg["domain_registry_path"])),
+                    prefix_registry_path=Path(
+                        str(cfg["prefix_ownership_registry_path"])
+                    ),
+                )
+        return _render(
+            templates,
+            request,
+            "template_editor.html",
+            user=user,
+            raw_json=json.dumps(payload, indent=2, sort_keys=True),
+            issues=[],
+            saved=summary,
+        )
+
+    @router.get("/create/{template_euid}", response_class=HTMLResponse)
+    async def create_page(
+        request: Request,
+        template_euid: str,
+        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+    ):
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope() as session:
+                template = (
+                    session.query(generic_template)
+                    .filter_by(euid=template_euid, is_deleted=False)
+                    .first()
+                )
+                if template is None:
+                    raise HTTPException(
+                        status_code=404, detail=f"Template not found: {template_euid}"
+                    )
+                template_payload = _record_to_dict(template, "template")
+        return _render(
+            templates,
+            request,
+            "create.html",
+            user=user,
+            template=template_payload,
+            template_code=(
+                f"{template_payload['category']}/{template_payload['type']}/"
+                f"{template_payload['subtype']}/{template_payload['version']}/"
+            ),
+            error=None,
+            form={},
+        )
+
+    @router.post("/create/{template_euid}")
+    async def create_submit(
+        request: Request,
+        template_euid: str,
+        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+    ):
+        form = await _read_urlencoded_form(request)
+        name = str(form.get("name") or "")
+        properties_json = str(form.get("properties_json") or "{}")
+        create_children = str(form.get("create_children") or "")
+        properties = _parse_json_object(properties_json or "{}", label="properties_json")
+        cfg = get_db_config(config_path=resolved_config_path)
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope(commit=True) as session:
+                created = _create_instance_from_template(
+                    session,
+                    cfg=cfg,
+                    template_euid=template_euid,
+                    name=name.strip(),
+                    properties=properties,
+                    create_children=str(create_children).lower() in {"true", "1", "on"},
+                )
+                instance_euid = created["instance_euid"]
+        return RedirectResponse(
+            gui_url_with_query(request, f"/object/{instance_euid}", notice="instance_created"),
+            status_code=303,
+        )
+
+    @router.post("/api/create/{template_euid}")
+    async def create_api(
+        request: Request,
+        template_euid: str,
+        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+    ):
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise HTTPException(
+                status_code=400,
+                detail="create payload must be a JSON object",
+            )
+        properties = payload.get("properties") or {}
+        if not isinstance(properties, dict):
+            raise HTTPException(status_code=400, detail="properties must be a JSON object")
+        cfg = get_db_config(config_path=resolved_config_path)
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope(commit=True) as session:
+                return jsonable_encoder(
+                    _create_instance_from_template(
+                        session,
+                        cfg=cfg,
+                        template_euid=template_euid,
+                        name=str(payload.get("name") or ""),
+                        properties=properties,
+                        create_children=bool(payload.get("create_children")),
+                    )
+                )
+
+    @router.get("/object/{euid}/graph", response_class=HTMLResponse)
+    async def object_graph_page(
+        request: Request,
+        euid: str,
+        depth: int = Query(4, ge=0, le=10),
+        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+    ):
+        cfg = get_db_config(config_path=resolved_config_path)
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope() as session:
+                obj, record_type = find_object_by_euid(session, euid)
+                if obj is None or record_type is None:
+                    raise HTTPException(status_code=404, detail=f"Object not found: {euid}")
+                graph = build_graph_payload(
+                    obj,
+                    record_type=record_type,
+                    service_name=str(cfg.get("client_id") or "tapdb"),
+                    depth=depth,
+                )
+        return _render(
+            templates,
+            request,
+            "graph.html",
+            user=user,
+            euid=euid,
+            depth=depth,
+            graph=graph,
+        )
+
+    @router.get("/api/object/{euid}/graph")
+    async def object_graph_api(
+        euid: str,
+        depth: int = Query(4, ge=0, le=10),
+        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+    ):
+        cfg = get_db_config(config_path=resolved_config_path)
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope() as session:
+                obj, record_type = find_object_by_euid(session, euid)
+                if obj is None or record_type is None:
+                    raise HTTPException(status_code=404, detail=f"Object not found: {euid}")
+                return build_graph_payload(
+                    obj,
+                    record_type=record_type,
+                    service_name=str(cfg.get("client_id") or "tapdb"),
+                    depth=depth,
+                )
+
+    @router.get("/object/{euid}", response_class=HTMLResponse)
+    async def object_page(
+        request: Request,
+        euid: str,
+        notice: str = "",
+        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+    ):
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope() as session:
+                context = _object_detail_context(session, euid)
+        return _render(
+            templates,
+            request,
+            "object.html",
+            user=user,
+            obj=context["obj"],
+            relationships=context["relationships"],
+            audit_rows=context["audit_rows"],
+            external_refs=context["external_refs"],
+            notice=notice,
+            json_text=json.dumps(
+                context["obj"]["json_addl"] or {}, indent=2, sort_keys=True
+            ),
+        )
+
+    @router.get("/api/object/{euid}")
+    async def object_api(
+        euid: str,
+        user: dict[str, Any] = Depends(require_tapdb_gui_user),
+    ):
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope() as session:
+                return jsonable_encoder(_object_detail_context(session, euid))
+
+    @router.post("/object/{euid}/edit-json")
+    async def edit_json(
+        request: Request,
+        euid: str,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        form = await _read_urlencoded_form(request)
+        json_addl = str(form.get("json_addl") or "")
+        payload = _parse_json_object(json_addl, label="json_addl")
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope(commit=True) as session:
+                _update_object_json(session, euid=euid, json_addl=payload)
+        return RedirectResponse(
+            gui_url_with_query(request, f"/object/{euid}", notice="json_saved"),
+            status_code=303,
+        )
+
+    @router.post("/api/object/{euid}/edit-json")
+    async def edit_json_api(
+        request: Request,
+        euid: str,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=400, detail="json_addl must be a JSON object")
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope(commit=True) as session:
+                return jsonable_encoder(
+                    _update_object_json(session, euid=euid, json_addl=payload)
+                )
+
+    @router.post("/object/{euid}/status")
+    async def edit_status(
+        request: Request,
+        euid: str,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        form = await _read_urlencoded_form(request)
+        bstatus = str(form.get("bstatus") or "")
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope(commit=True) as session:
+                _update_object_status(session, euid=euid, bstatus=bstatus)
+        return RedirectResponse(
+            gui_url_with_query(request, f"/object/{euid}", notice="status_updated"),
+            status_code=303,
+        )
+
+    @router.post("/api/object/{euid}/status")
+    async def edit_status_api(
+        request: Request,
+        euid: str,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=400, detail="status payload must be a JSON object")
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope(commit=True) as session:
+                return jsonable_encoder(
+                    _update_object_status(
+                        session,
+                        euid=euid,
+                        bstatus=str(payload.get("bstatus") or ""),
+                    )
+                )
+
+    @router.post("/object/{euid}/lineage")
+    async def add_lineage(
+        request: Request,
+        euid: str,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        form = await _read_urlencoded_form(request)
+        related_euid = str(form.get("related_euid") or "")
+        direction = str(form.get("direction") or "parent")
+        relationship_type = str(form.get("relationship_type") or "generic")
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope(commit=True) as session:
+                _add_object_lineage(
+                    session,
+                    euid=euid,
+                    related_euid=related_euid,
+                    direction=direction,
+                    relationship_type=relationship_type,
+                )
+        return RedirectResponse(
+            gui_url_with_query(request, f"/object/{euid}", notice="lineage_added"),
+            status_code=303,
+        )
+
+    @router.post("/api/object/{euid}/lineage")
+    async def add_lineage_api(
+        request: Request,
+        euid: str,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=400, detail="lineage payload must be a JSON object")
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope(commit=True) as session:
+                return jsonable_encoder(
+                    _add_object_lineage(
+                        session,
+                        euid=euid,
+                        related_euid=str(payload.get("related_euid") or ""),
+                        direction=str(payload.get("direction") or "parent"),
+                        relationship_type=str(payload.get("relationship_type") or "generic"),
+                    )
+                )
+
+    @router.get("/object/{euid}/external-links/new", response_class=HTMLResponse)
+    async def external_link_page(
+        request: Request,
+        euid: str,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        return _render(
+            templates,
+            request,
+            "external_link.html",
+            user=user,
+            euid=euid,
+            error=None,
+            form={},
+        )
+
+    @router.post("/object/{euid}/external-links/new")
+    async def external_link_submit(
+        request: Request,
+        euid: str,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        form = await _read_urlencoded_form(request)
+        system = str(form.get("system") or "")
+        foreign_uid = str(form.get("foreign_uid") or "")
+        relationship_type = str(form.get("relationship_type") or "external_ref")
+        display_url = str(form.get("display_url") or "")
+        graph_base_url = str(form.get("graph_base_url") or "")
+        graph_data_path = str(form.get("graph_data_path") or "")
+        object_detail_path_template = str(
+            form.get("object_detail_path_template") or ""
+        )
+        auth_mode = str(form.get("auth_mode") or "none")
+        missing = [
+            label
+            for label, value in (
+                ("system", system),
+                ("foreign_uid", foreign_uid),
+                ("relationship_type", relationship_type),
+            )
+            if not str(value or "").strip()
+        ]
+        if missing:
+            raise HTTPException(
+                status_code=400,
+                detail="Missing required external link field(s): " + ", ".join(missing),
+            )
+        cfg = get_db_config(config_path=resolved_config_path)
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope(commit=True) as session:
+                created = _create_external_link(
+                    session,
+                    cfg=cfg,
+                    source_euid=euid,
+                    system=system,
+                    foreign_uid=foreign_uid,
+                    relationship_type=relationship_type,
+                    display_url=display_url,
+                    graph_base_url=graph_base_url,
+                    graph_data_path=graph_data_path,
+                    object_detail_path_template=object_detail_path_template,
+                    auth_mode=auth_mode,
+                )
+                link_euid = created["link_euid"]
+        return RedirectResponse(
+            gui_url_with_query(request, f"/object/{link_euid}", notice="external_link_created"),
+            status_code=303,
+        )
+
+    @router.post("/api/object/{euid}/external-links")
+    async def external_link_api(
+        request: Request,
+        euid: str,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        payload = await request.json()
+        if not isinstance(payload, dict):
+            raise HTTPException(
+                status_code=400,
+                detail="external link payload must be a JSON object",
+            )
+        cfg = get_db_config(config_path=resolved_config_path)
+        with get_db(resolved_config_path) as conn:
+            conn.app_username = user.get("username")
+            with conn.session_scope(commit=True) as session:
+                created = _create_external_link(
+                    session,
+                    cfg=cfg,
+                    source_euid=euid,
+                    system=str(payload.get("system") or ""),
+                    foreign_uid=str(payload.get("foreign_uid") or ""),
+                    relationship_type=str(
+                        payload.get("relationship_type") or "external_ref"
+                    ),
+                    display_url=str(payload.get("display_url") or ""),
+                    graph_base_url=str(payload.get("graph_base_url") or ""),
+                    graph_data_path=str(payload.get("graph_data_path") or ""),
+                    object_detail_path_template=str(
+                        payload.get("object_detail_path_template") or ""
+                    ),
+                    auth_mode=str(payload.get("auth_mode") or "none"),
+                )
+        return jsonable_encoder(created)
+
+    @router.get("/admin/readiness", response_class=HTMLResponse)
+    async def readiness_page(
+        request: Request,
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        return _render(
+            templates,
+            request,
+            "readiness.html",
+            user=user,
+            readiness=_readiness_payload(config_path=resolved_config_path),
+        )
+
+    @router.get("/api/admin/readiness")
+    async def readiness_api(
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        del user
+        return jsonable_encoder(_readiness_payload(config_path=resolved_config_path))
+
+    @router.get("/admin/meridian", response_class=HTMLResponse)
+    async def meridian_page(
+        request: Request,
+        euid: str = "",
+        prefix: str = "",
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        validation = _meridian_validation_payload(
+            config_path=resolved_config_path,
+            euid=euid,
+            prefix=prefix,
+        )
+        return _render(
+            templates,
+            request,
+            "meridian.html",
+            user=user,
+            cfg=validation["config"],
+            governance=validation["governance"],
+            euid=validation["euid"],
+            euid_valid=validation["euid_valid"],
+            prefix=validation["prefix"],
+            prefix_owner=validation["prefix_owner"],
+            prefix_error=validation["prefix_error"],
+        )
+
+    @router.get("/api/admin/meridian/validate")
+    async def meridian_validate_api(
+        euid: str = "",
+        prefix: str = "",
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        del user
+        validation = _meridian_validation_payload(
+            config_path=resolved_config_path,
+            euid=euid,
+            prefix=prefix,
+        )
+        return jsonable_encoder(
+            {
+                key: value
+                for key, value in validation.items()
+                if key not in {"governance"}
+            }
+        )
+
+    @router.get("/admin/metrics", response_class=HTMLResponse)
+    async def metrics_page(
+        request: Request,
+        limit: int = Query(5000, ge=1, le=50000),
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        metrics = build_metrics_page_context("target", limit=limit)
+        return _render(
+            templates,
+            request,
+            "metrics.html",
+            user=user,
+            metrics=metrics,
+            limit=limit,
+        )
+
+    @router.get("/api/admin/metrics")
+    async def metrics_api(
+        limit: int = Query(5000, ge=1, le=50000),
+        user: dict[str, Any] = Depends(require_tapdb_gui_admin),
+    ):
+        del user
+        return jsonable_encoder(build_metrics_page_context("target", limit=limit))
+
+    return router
+
+
+def create_tapdb_gui_app(
+    *,
+    config_path: str,
+    host_bridge: TapdbHostBridge | None = None,
+):
+    """Build a mountable TapDB GUI ASGI app."""
+
+    app = FastAPI(title="TapDB GUI", version=__version__)
+    app.state.tapdb_host_bridge = host_bridge
+    app.include_router(
+        create_tapdb_gui_router(config_path=config_path, host_bridge=host_bridge)
+    )
+    if host_bridge is not None and host_bridge.auth_mode == "host_session":
+        return TapdbHostBridgeMount(app, host_bridge)
+    return app
+
+
+def _example_template_pack() -> dict[str, Any]:
+    return {
+        "templates": [
+            {
+                "name": "Example Actor",
+                "polymorphic_discriminator": "generic_template",
+                "category": "ACT",
+                "type": "actor",
+                "subtype": "example_actor",
+                "version": "1.0",
+                "instance_prefix": "ACT",
+                "instance_polymorphic_identity": "generic_instance",
+                "json_addl": {
+                    "properties": {
+                        "display_name": "",
+                        "email": "",
+                    },
+                    "instantiation_layouts": [],
+                },
+            },
+            {
+                "name": "Example Plate",
+                "polymorphic_discriminator": "generic_template",
+                "category": "PLT",
+                "type": "container",
+                "subtype": "example_plate",
+                "version": "1.0",
+                "instance_prefix": "PLT",
+                "instance_polymorphic_identity": "generic_instance",
+                "json_addl": {
+                    "properties": {
+                        "plate_type": "custom",
+                    },
+                    "instantiation_layouts": [
+                        {
+                            "relationship_type": "contains",
+                            "name_pattern": "{parent_name}_well_{index}",
+                            "child_templates": [
+                                {
+                                    "template_code": "WEL/container/example_well/1.0",
+                                    "count": 2,
+                                }
+                            ],
+                        }
+                    ],
+                },
+            },
+        ]
+    }

--- a/daylily_tapdb/gui/static/css/tapdb-gui.css
+++ b/daylily_tapdb/gui/static/css/tapdb-gui.css
@@ -1,0 +1,86 @@
+:root {
+  --tapdb-bg: #f6f7f9;
+  --tapdb-panel: #ffffff;
+  --tapdb-text: #17202a;
+  --tapdb-muted: #667085;
+  --tapdb-border: #d0d5dd;
+  --tapdb-primary: #1f6feb;
+  --tapdb-danger: #b42318;
+  --tapdb-ok: #067647;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--tapdb-bg);
+  color: var(--tapdb-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.45;
+}
+.topbar {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--tapdb-border);
+  background: var(--tapdb-panel);
+}
+.brand { font-weight: 700; color: var(--tapdb-text); text-decoration: none; }
+nav { display: flex; gap: 0.8rem; flex-wrap: wrap; }
+nav a, a { color: var(--tapdb-primary); }
+.user, footer, p { color: var(--tapdb-muted); }
+main { max-width: 1320px; margin: 0 auto; padding: 1rem; }
+footer { padding: 1rem; text-align: center; }
+.band {
+  background: var(--tapdb-panel);
+  border: 1px solid var(--tapdb-border);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+.split { display: flex; justify-content: space-between; gap: 1rem; align-items: center; }
+.toolbar { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
+.stack { display: grid; gap: 0.75rem; max-width: 900px; }
+.compact { gap: 0.45rem; }
+.grid2 { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 1rem; }
+.builder-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+.builder-panel { margin-top: 1rem; }
+.builder-row {
+  display: grid;
+  grid-template-columns: minmax(10rem, 1fr) minmax(7rem, 0.7fr) minmax(8rem, 0.8fr);
+  gap: 0.5rem;
+  align-items: center;
+}
+input, select, textarea, button, .button {
+  font: inherit;
+  border: 1px solid var(--tapdb-border);
+  border-radius: 6px;
+  padding: 0.48rem 0.65rem;
+  background: #fff;
+  color: var(--tapdb-text);
+}
+button, .button {
+  background: var(--tapdb-primary);
+  border-color: var(--tapdb-primary);
+  color: #fff;
+  text-decoration: none;
+  cursor: pointer;
+}
+.secondary { background: #fff; color: var(--tapdb-primary); }
+textarea { width: 100%; min-height: 14rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.editor textarea { min-height: 28rem; }
+table { width: 100%; border-collapse: collapse; }
+th, td { padding: 0.5rem; border-bottom: 1px solid var(--tapdb-border); text-align: left; vertical-align: top; }
+th { color: var(--tapdb-muted); font-weight: 650; }
+pre { overflow: auto; background: #101828; color: #f2f4f7; padding: 1rem; border-radius: 6px; }
+.notice { padding: 0.75rem; border: 1px solid var(--tapdb-border); border-radius: 6px; margin: 0.75rem 0; }
+.notice.ok { border-color: var(--tapdb-ok); color: var(--tapdb-ok); }
+.notice.bad { border-color: var(--tapdb-danger); color: var(--tapdb-danger); }
+@media (max-width: 860px) {
+  .topbar, .grid2, .builder-grid, .builder-row { grid-template-columns: 1fr; }
+  .split { align-items: flex-start; flex-direction: column; }
+}

--- a/daylily_tapdb/gui/static/css/tapdb-gui.css
+++ b/daylily_tapdb/gui/static/css/tapdb-gui.css
@@ -84,3 +84,96 @@ pre { overflow: auto; background: #101828; color: #f2f4f7; padding: 1rem; border
   .topbar, .grid2, .builder-grid, .builder-row { grid-template-columns: 1fr; }
   .split { align-items: flex-start; flex-direction: column; }
 }
+.lsmc-theme-control,
+.lsmc-action-help-button,
+.lsmc-action-help-panel {
+  font-family: var(--font-sans, Inter, system-ui, sans-serif);
+  z-index: 2147483000;
+}
+
+.lsmc-theme-control {
+  position: fixed;
+  right: 1rem;
+  bottom: 5rem;
+  padding: 0.4rem 0.55rem;
+  border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, Canvas 94%, transparent);
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.16);
+  font-size: 0.78rem;
+}
+
+.lsmc-theme-control label {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.lsmc-theme-control select {
+  min-height: 1.7rem;
+  border-radius: 6px;
+}
+
+.lsmc-action-help-button {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  width: 2.65rem;
+  height: 2.65rem;
+  border: 0;
+  border-radius: 999px;
+  background: #1f6feb;
+  color: white;
+  font-weight: 800;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.22);
+}
+
+.lsmc-action-help-panel {
+  position: fixed;
+  right: 1rem;
+  bottom: 4.1rem;
+  width: min(26rem, calc(100vw - 2rem));
+  padding: 0.8rem;
+  border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+  border-radius: 8px;
+  background: Canvas;
+  color: CanvasText;
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.24);
+}
+
+.lsmc-action-help-panel pre {
+  overflow: auto;
+  margin: 0.55rem 0;
+  padding: 0.65rem;
+  border-radius: 6px;
+  background: color-mix(in srgb, CanvasText 8%, Canvas);
+  white-space: pre-wrap;
+}
+
+html[data-theme="lsmc"] body {
+  background: #f4f8fb;
+  color: #172033;
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
+}
+
+html[data-theme="dark"] body {
+  background: #10141d;
+  color: #e5edf7;
+}
+
+html[data-theme="light"] body {
+  background: #ffffff;
+  color: #111827;
+}
+
+html[data-theme="tacky"] body {
+  background: #fff700;
+  color: #1f1147;
+}
+
+html[data-theme="tacky"] .lsmc-action-help-button {
+  background: #ff00b8;
+}

--- a/daylily_tapdb/gui/static/js/lsmc-ui.js
+++ b/daylily_tapdb/gui/static/js/lsmc-ui.js
@@ -1,0 +1,58 @@
+(function () {
+  const themes = ["original", "lsmc", "dark", "light", "tacky"];
+  const storageKey = "lsmc.ui.theme";
+
+  function currentTheme() {
+    const stored = window.localStorage.getItem(storageKey);
+    return themes.includes(stored) ? stored : "original";
+  }
+
+  function applyTheme(theme) {
+    const value = themes.includes(theme) ? theme : "original";
+    document.documentElement.dataset.theme = value;
+    window.localStorage.setItem(storageKey, value);
+  }
+
+  function commandForPage() {
+    if (location.pathname.includes("/search")) return "tapdb search --help";
+    if (location.pathname.includes("/templates")) return "tapdb db templates --help";
+    if (location.pathname.includes("/metrics")) return "tapdb ui metrics --help";
+    if (location.pathname.includes("/graph")) return "tapdb dag --help";
+    return `No CLI equivalent for tapdb ${location.pathname}`;
+  }
+
+  function initThemeControl() {
+    const wrap = document.createElement("div");
+    wrap.className = "lsmc-theme-control";
+    wrap.innerHTML = '<label>Theme <select></select></label>';
+    const select = wrap.querySelector("select");
+    for (const theme of themes) select.appendChild(new Option(theme, theme));
+    select.value = currentTheme();
+    select.addEventListener("change", () => applyTheme(select.value));
+    document.body.appendChild(wrap);
+  }
+
+  function initActionHelp() {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "lsmc-action-help-button";
+    button.textContent = "?";
+    const panel = document.createElement("aside");
+    panel.className = "lsmc-action-help-panel";
+    panel.hidden = true;
+    panel.innerHTML = '<strong>Action Help</strong><pre></pre><button type="button">Copy</button>';
+    const output = panel.querySelector("pre");
+    button.addEventListener("click", () => {
+      panel.hidden = !panel.hidden;
+      output.textContent = commandForPage();
+    });
+    panel.querySelector("button").addEventListener("click", () => navigator.clipboard?.writeText(output.textContent || ""));
+    document.body.append(button, panel);
+  }
+
+  applyTheme(currentTheme());
+  document.addEventListener("DOMContentLoaded", () => {
+    initThemeControl();
+    initActionHelp();
+  });
+})();

--- a/daylily_tapdb/gui/templates/base.html
+++ b/daylily_tapdb/gui/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-lsmc-service="tapdb" data-theme="original">
 <head>
   {% set shell = tapdb_gui_host_shell(request) %}
   <meta charset="utf-8">
@@ -32,5 +32,6 @@
     {% block content %}{% endblock %}
   </main>
   <footer>TapDB {{ tapdb_version }}</footer>
+  <script src="{{ tapdb_gui_url(request, '/static/lsmc-ui.js') }}"></script>
 </body>
 </html>

--- a/daylily_tapdb/gui/templates/base.html
+++ b/daylily_tapdb/gui/templates/base.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+  {% set shell = tapdb_gui_host_shell(request) %}
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}TapDB{% endblock %}</title>
+  <link rel="stylesheet" href="{{ tapdb_gui_url(request, '/static/tapdb-gui.css') }}">
+  {% for stylesheet in shell.extra_stylesheets %}
+  <link rel="stylesheet" href="{{ stylesheet }}">
+  {% endfor %}
+  <script>window.TAPDB_BASE_PATH = "{{ request.scope.get('root_path', '') }}";</script>
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="{{ tapdb_gui_url(request, '/') }}">
+      {% if shell.active and shell.app_name %}{{ shell.app_name }} / {% endif %}TapDB
+    </a>
+    <nav>
+      {% for nav in shell.nav_links %}
+      <a href="{{ nav.href }}">{{ nav.label }}</a>
+      {% endfor %}
+      <a href="{{ tapdb_gui_url(request, '/search') }}">Search</a>
+      <a href="{{ tapdb_gui_url(request, '/templates') }}">Templates</a>
+      <a href="{{ tapdb_gui_url(request, '/admin/readiness') }}">Readiness</a>
+      <a href="{{ tapdb_gui_url(request, '/admin/meridian') }}">Meridian</a>
+      <a href="{{ tapdb_gui_url(request, '/admin/metrics') }}">Metrics</a>
+    </nav>
+    <div class="user">{{ user.display_name or user.username }} · {{ user.role }}</div>
+  </header>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+  <footer>TapDB {{ tapdb_version }}</footer>
+</body>
+</html>

--- a/daylily_tapdb/gui/templates/create.html
+++ b/daylily_tapdb/gui/templates/create.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Create TapDB Instance{% endblock %}
+{% block content %}
+<section class="band">
+  <h1>Create Instance</h1>
+  <table>
+    <tr><th>Template</th><td>{{ template.euid }} · {{ template.name }}</td></tr>
+    <tr><th>Code</th><td>{{ template_code }}</td></tr>
+  </table>
+  <form method="post" action="{{ tapdb_gui_url(request, '/create/' ~ template.euid) }}" class="stack">
+    <label>Name <input name="name" value=""></label>
+    <label>Create children <input type="checkbox" name="create_children" value="true" checked></label>
+    <label>Properties JSON
+      <textarea name="properties_json" spellcheck="false">{}</textarea>
+    </label>
+    <button type="submit">Create</button>
+  </form>
+</section>
+{% endblock %}

--- a/daylily_tapdb/gui/templates/external_link.html
+++ b/daylily_tapdb/gui/templates/external_link.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}External Link{% endblock %}
+{% block content %}
+<section class="band">
+  <h1>Create External Object Link</h1>
+  <p>Creates a typed TapDB object storing the foreign UID, then links it to {{ euid }} by lineage.</p>
+  <form method="post" action="{{ tapdb_gui_url(request, '/object/' ~ euid ~ '/external-links/new') }}" class="stack">
+    <label>System <input name="system" required></label>
+    <label>Foreign UID <input name="foreign_uid" required></label>
+    <label>Relationship <input name="relationship_type" value="external_ref" required></label>
+    <label>Display URL <input name="display_url"></label>
+    <label>Graph Base URL <input name="graph_base_url"></label>
+    <label>Graph Data Path <input name="graph_data_path"></label>
+    <label>Object Detail Path Template <input name="object_detail_path_template"></label>
+    <label>Auth Mode <input name="auth_mode" value="none" required></label>
+    <button type="submit">Create Link</button>
+  </form>
+</section>
+{% endblock %}

--- a/daylily_tapdb/gui/templates/graph.html
+++ b/daylily_tapdb/gui/templates/graph.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}{{ euid }} Graph{% endblock %}
+{% block content %}
+<section class="band">
+  <h1>Graph: {{ euid }}</h1>
+  <form method="get" action="{{ tapdb_gui_url(request, '/object/' ~ euid ~ '/graph') }}" class="toolbar">
+    <input type="number" min="0" max="10" name="depth" value="{{ depth }}">
+    <button type="submit">Load</button>
+  </form>
+</section>
+<section class="band grid2">
+  <div>
+    <h2>Nodes</h2>
+    <table><thead><tr><th>EUID</th><th>Name</th><th>Type</th></tr></thead><tbody>
+    {% for node in graph.elements.nodes %}
+    <tr><td><a href="{{ tapdb_gui_url(request, '/object/' ~ node.data.euid) }}">{{ node.data.euid }}</a></td><td>{{ node.data.name }}</td><td>{{ node.data.category }}/{{ node.data.type }}</td></tr>
+    {% endfor %}
+    </tbody></table>
+  </div>
+  <div>
+    <h2>Edges</h2>
+    <table><thead><tr><th>EUID</th><th>Child</th><th>Parent</th><th>Type</th></tr></thead><tbody>
+    {% for edge in graph.elements.edges %}
+    <tr><td>{{ edge.data.euid }}</td><td>{{ edge.data.source }}</td><td>{{ edge.data.target }}</td><td>{{ edge.data.relationship_type }}</td></tr>
+    {% endfor %}
+    </tbody></table>
+  </div>
+</section>
+<section class="band">
+  <h2>Payload</h2>
+  <pre>{{ graph | tojson(indent=2) }}</pre>
+</section>
+{% endblock %}

--- a/daylily_tapdb/gui/templates/meridian.html
+++ b/daylily_tapdb/gui/templates/meridian.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Meridian{% endblock %}
+{% block content %}
+<section class="band">
+  <h1>Meridian</h1>
+  <table>
+    <tr><th>Domain</th><td>{{ governance.domain_code }}</td></tr>
+    <tr><th>Owner Repo</th><td>{{ governance.owner_repo_name }}</td></tr>
+    <tr><th>Domain Registry</th><td>{{ governance.domain_registry_path }}</td></tr>
+    <tr><th>Prefix Registry</th><td>{{ governance.prefix_ownership_registry_path }}</td></tr>
+  </table>
+  <form method="get" action="{{ tapdb_gui_url(request, '/admin/meridian') }}" class="toolbar">
+    <input name="euid" value="{{ euid }}" placeholder="EUID">
+    <input name="prefix" value="{{ prefix }}" placeholder="prefix">
+    <button type="submit">Validate</button>
+  </form>
+  {% if euid %}<div class="notice {{ 'ok' if euid_valid else 'bad' }}">EUID valid for {{ governance.domain_code }}: {{ euid_valid }}</div>{% endif %}
+  {% if prefix_owner %}<div class="notice ok">Prefix owner: {{ prefix_owner }}</div>{% endif %}
+  {% if prefix_error %}<div class="notice bad">{{ prefix_error }}</div>{% endif %}
+</section>
+{% endblock %}

--- a/daylily_tapdb/gui/templates/meridian.html
+++ b/daylily_tapdb/gui/templates/meridian.html
@@ -8,6 +8,8 @@
     <tr><th>Owner Repo</th><td>{{ governance.owner_repo_name }}</td></tr>
     <tr><th>Domain Registry</th><td>{{ governance.domain_registry_path }}</td></tr>
     <tr><th>Prefix Registry</th><td>{{ governance.prefix_ownership_registry_path }}</td></tr>
+    <tr><th>Public Registry</th><td>{{ governance.public_domain_registry_repository }}</td></tr>
+    <tr><th>Public Registry Version</th><td>{{ governance.public_domain_registry_version }}</td></tr>
   </table>
   <form method="get" action="{{ tapdb_gui_url(request, '/admin/meridian') }}" class="toolbar">
     <input name="euid" value="{{ euid }}" placeholder="EUID">

--- a/daylily_tapdb/gui/templates/metrics.html
+++ b/daylily_tapdb/gui/templates/metrics.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}Metrics{% endblock %}
+{% block content %}
+<section class="band">
+  <h1>DB Metrics</h1>
+  {% if metrics.metrics_message %}<div class="notice">{{ metrics.metrics_message }}</div>{% endif %}
+  <table>
+    <tr><th>Enabled</th><td>{{ metrics.metrics_enabled }}</td></tr>
+    <tr><th>File</th><td>{{ metrics.metrics_file }}</td></tr>
+    <tr><th>Dropped</th><td>{{ metrics.dropped_count }}</td></tr>
+  </table>
+</section>
+<section class="band">
+  <table>
+    <thead><tr><th>Path</th><th>Method</th><th>Count</th><th>Total Seconds</th></tr></thead>
+    <tbody>
+    {% for row in metrics.summary.by_path %}
+    <tr><td>{{ row.path }}</td><td>{{ row.method }}</td><td>{{ row.count }}</td><td>{{ row.total_seconds }}</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/daylily_tapdb/gui/templates/object.html
+++ b/daylily_tapdb/gui/templates/object.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+{% block title %}{{ obj.euid }}{% endblock %}
+{% block content %}
+<section class="band">
+  <div class="split">
+    <h1>{{ obj.euid }}</h1>
+    <div class="actions">
+      <a class="button" href="{{ tapdb_gui_url(request, '/object/' ~ obj.euid ~ '/graph') }}">Graph</a>
+      {% if obj.record_type == "template" %}
+      <a class="button" href="{{ tapdb_gui_url(request, '/create/' ~ obj.euid) }}">Create Instance</a>
+      {% else %}
+      <a class="button" href="{{ tapdb_gui_url(request, '/object/' ~ obj.euid ~ '/external-links/new') }}">External Link</a>
+      {% endif %}
+    </div>
+  </div>
+  {% if notice %}
+  <div class="notice ok">
+    {% if notice == "json_saved" %}JSON saved.
+    {% elif notice == "status_updated" %}Status updated.
+    {% elif notice == "lineage_added" %}Lineage added.
+    {% elif notice == "external_link_created" %}External link created.
+    {% elif notice == "instance_created" %}Instance created.
+    {% else %}{{ notice }}
+    {% endif %}
+  </div>
+  {% endif %}
+  <table>
+    <tr><th>UID</th><td>{{ obj.uid }}</td></tr>
+    <tr><th>Kind</th><td>{{ obj.record_type }}</td></tr>
+    <tr><th>Name</th><td>{{ obj.name or "-" }}</td></tr>
+    <tr><th>Type</th><td>{{ obj.category }}/{{ obj.type }}/{{ obj.subtype }}/{{ obj.version }}</td></tr>
+    <tr><th>Status</th><td>{{ obj.bstatus or "-" }}</td></tr>
+    <tr><th>Created</th><td>{{ obj.created_dt or "-" }}</td></tr>
+    <tr><th>Modified</th><td>{{ obj.modified_dt or "-" }}</td></tr>
+  </table>
+</section>
+
+{% if obj.record_type != "template" %}
+<section class="band">
+  <h2>Edit</h2>
+  <form method="post" action="{{ tapdb_gui_url(request, '/object/' ~ obj.euid ~ '/status') }}" class="toolbar">
+    <input name="bstatus" value="{{ obj.bstatus or '' }}" placeholder="status">
+    <button type="submit">Set Status</button>
+  </form>
+  <form method="post" action="{{ tapdb_gui_url(request, '/object/' ~ obj.euid ~ '/lineage') }}" class="toolbar">
+    <input name="related_euid" placeholder="related EUID">
+    <select name="direction"><option value="parent">related is parent</option><option value="child">related is child</option></select>
+    <input name="relationship_type" value="generic">
+    <button type="submit">Add Lineage</button>
+  </form>
+  <form method="post" action="{{ tapdb_gui_url(request, '/object/' ~ obj.euid ~ '/edit-json') }}" class="editor">
+    <textarea name="json_addl" spellcheck="false">{{ json_text }}</textarea>
+    <button type="submit">Save JSON</button>
+  </form>
+</section>
+{% endif %}
+
+<section class="band grid2">
+  <div>
+    <h2>Children</h2>
+    <table><thead><tr><th>Lineage</th><th>Object</th><th>Relationship</th></tr></thead><tbody>
+    {% for row in relationships.parent_of %}
+    <tr><td>{{ row.lineage_euid }}</td><td><a href="{{ tapdb_gui_url(request, '/object/' ~ row.related_euid) }}">{{ row.related_euid }}</a> {{ row.related_name or "" }}</td><td>{{ row.relationship_type }}</td></tr>
+    {% endfor %}
+    </tbody></table>
+  </div>
+  <div>
+    <h2>Parents</h2>
+    <table><thead><tr><th>Lineage</th><th>Object</th><th>Relationship</th></tr></thead><tbody>
+    {% for row in relationships.child_of %}
+    <tr><td>{{ row.lineage_euid }}</td><td><a href="{{ tapdb_gui_url(request, '/object/' ~ row.related_euid) }}">{{ row.related_euid }}</a> {{ row.related_name or "" }}</td><td>{{ row.relationship_type }}</td></tr>
+    {% endfor %}
+    </tbody></table>
+  </div>
+</section>
+
+<section class="band">
+  <h2>External References</h2>
+  <table><thead><tr><th>Label</th><th>System</th><th>Remote EUID</th><th>Status</th></tr></thead><tbody>
+  {% for ref in external_refs %}
+  <tr><td>{{ ref.label }}</td><td>{{ ref.system }}</td><td>{{ ref.root_euid }}</td><td>{{ "graph-ready" if ref.graph_expandable else ref.reason }}</td></tr>
+  {% endfor %}
+  {% if not external_refs %}<tr><td colspan="4">No external refs rendered for this object.</td></tr>{% endif %}
+  </tbody></table>
+</section>
+
+<section class="band">
+  <h2>Audit</h2>
+  <table><thead><tr><th>When</th><th>Who</th><th>Operation</th><th>Column</th><th>New</th></tr></thead><tbody>
+  {% for row in audit_rows %}
+  <tr><td>{{ row.changed_at }}</td><td>{{ row.changed_by }}</td><td>{{ row.operation }}</td><td>{{ row.column }}</td><td>{{ row.new_value }}</td></tr>
+  {% endfor %}
+  {% if not audit_rows %}<tr><td colspan="5">No audit rows found.</td></tr>{% endif %}
+  </tbody></table>
+</section>
+{% endblock %}

--- a/daylily_tapdb/gui/templates/object.html
+++ b/daylily_tapdb/gui/templates/object.html
@@ -6,10 +6,12 @@
     <h1>{{ obj.euid }}</h1>
     <div class="actions">
       <a class="button" href="{{ tapdb_gui_url(request, '/object/' ~ obj.euid ~ '/graph') }}">Graph</a>
+      {% if user.role == "admin" %}
       {% if obj.record_type == "template" %}
       <a class="button" href="{{ tapdb_gui_url(request, '/create/' ~ obj.euid) }}">Create Instance</a>
       {% else %}
       <a class="button" href="{{ tapdb_gui_url(request, '/object/' ~ obj.euid ~ '/external-links/new') }}">External Link</a>
+      {% endif %}
       {% endif %}
     </div>
   </div>
@@ -35,7 +37,7 @@
   </table>
 </section>
 
-{% if obj.record_type != "template" %}
+{% if obj.record_type != "template" and user.role == "admin" %}
 <section class="band">
   <h2>Edit</h2>
   <form method="post" action="{{ tapdb_gui_url(request, '/object/' ~ obj.euid ~ '/status') }}" class="toolbar">

--- a/daylily_tapdb/gui/templates/readiness.html
+++ b/daylily_tapdb/gui/templates/readiness.html
@@ -11,6 +11,8 @@
     <tr><th>Client</th><td>{{ readiness.client_id or "-" }}</td></tr>
     <tr><th>Domain</th><td>{{ readiness.domain_code }}</td></tr>
     <tr><th>Owner Repo</th><td>{{ readiness.owner_repo_name }}</td></tr>
+    <tr><th>Public Registry</th><td>{{ readiness.public_domain_registry.repository }}</td></tr>
+    <tr><th>Public Registry Version</th><td>{{ readiness.public_domain_registry.version }}</td></tr>
   </table>
 </section>
 

--- a/daylily_tapdb/gui/templates/readiness.html
+++ b/daylily_tapdb/gui/templates/readiness.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}Readiness{% endblock %}
+{% block content %}
+<section class="band">
+  <h1>Readiness</h1>
+  <div class="notice {{ 'ok' if readiness.ready else 'bad' }}">
+    TapDB GUI ready: {{ readiness.ready }}
+  </div>
+  <table>
+    <tr><th>Config Path</th><td>{{ readiness.config_path }}</td></tr>
+    <tr><th>Client</th><td>{{ readiness.client_id or "-" }}</td></tr>
+    <tr><th>Domain</th><td>{{ readiness.domain_code }}</td></tr>
+    <tr><th>Owner Repo</th><td>{{ readiness.owner_repo_name }}</td></tr>
+  </table>
+</section>
+
+<section class="band">
+  <h2>Checks</h2>
+  <table>
+    <thead><tr><th>Check</th><th>OK</th><th>Detail</th></tr></thead>
+    <tbody>
+    {% for check in readiness.checks %}
+    <tr>
+      <td>{{ check.name }}</td>
+      <td>{{ check.ok }}</td>
+      <td>{{ check.detail }}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/daylily_tapdb/gui/templates/search.html
+++ b/daylily_tapdb/gui/templates/search.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% block title %}TapDB Search{% endblock %}
+{% block content %}
+<section class="band">
+  <h1>Search</h1>
+  <form method="get" action="{{ tapdb_gui_url(request, '/search') }}" class="toolbar">
+    <input name="q" value="{{ query.q }}" placeholder="EUID, name, type, status">
+    <select name="record_type">
+      {% for kind in ["all", "template", "instance", "lineage"] %}
+      <option value="{{ kind }}" {% if query.record_type == kind %}selected{% endif %}>{{ kind }}</option>
+      {% endfor %}
+    </select>
+    <input name="category" value="{{ query.category }}" placeholder="category">
+    <input name="type" value="{{ query.type }}" placeholder="type">
+    <input name="subtype" value="{{ query.subtype }}" placeholder="subtype">
+    <button type="submit">Search</button>
+  </form>
+</section>
+
+<section class="band">
+  <h2>Results</h2>
+  <table>
+    <thead><tr><th>EUID</th><th>Kind</th><th>Name</th><th>Type</th><th>Status</th></tr></thead>
+    <tbody>
+      {% for item in results["items"] %}
+      <tr>
+        <td><a href="{{ tapdb_gui_url(request, '/object/' ~ item.euid) }}">{{ item.euid }}</a></td>
+        <td>{{ item.record_type }}</td>
+        <td>{{ item.name or "-" }}</td>
+        <td>{{ item.category }}/{{ item.type }}/{{ item.subtype }}</td>
+        <td>{{ item.bstatus or "-" }}</td>
+      </tr>
+      {% endfor %}
+      {% if not results["items"] %}
+      <tr><td colspan="5">No matching TapDB objects.</td></tr>
+      {% endif %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/daylily_tapdb/gui/templates/template_editor.html
+++ b/daylily_tapdb/gui/templates/template_editor.html
@@ -1,0 +1,121 @@
+{% extends "base.html" %}
+{% block title %}TapDB Template Editor{% endblock %}
+{% block content %}
+<section class="band">
+  <h1>Template Pack</h1>
+  <p>Validate JSON first, then save. Save is insert-only; existing templates remain read-only.</p>
+  {% if saved %}
+  <div class="notice ok">Saved {{ saved.inserted }} template(s); skipped {{ saved.skipped }}.</div>
+  {% endif %}
+  {% if issues %}
+  <div class="notice bad">
+    {% for issue in issues %}
+    <div>{{ issue.level }}: {{ issue.template_code or "" }} {{ issue.message }}</div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</section>
+
+<section class="band">
+  <h2>Builder</h2>
+  <div class="builder-grid" data-testid="template-builder">
+    <label>Name <input id="builder-name" value="Example Actor"></label>
+    <label>Category <input id="builder-category" value="ACT"></label>
+    <label>Type <input id="builder-type" value="actor"></label>
+    <label>Subtype <input id="builder-subtype" value="example_actor"></label>
+    <label>Version <input id="builder-version" value="1.0"></label>
+    <label>Instance Prefix <input id="builder-prefix" value="ACT"></label>
+  </div>
+  <div class="builder-panel">
+    <h3>Properties</h3>
+    <div id="builder-properties" class="stack compact">
+      <div class="builder-row">
+        <input data-builder-property-key value="display_name">
+        <input data-builder-property-value value="">
+      </div>
+    </div>
+    <button type="button" class="secondary" id="builder-add-property">Add Property</button>
+  </div>
+  <div class="builder-panel">
+    <h3>Child Instantiation</h3>
+    <div id="builder-children" class="stack compact">
+      <div class="builder-row">
+        <input data-builder-child-code value="WEL/container/example_well/1.0">
+        <input data-builder-child-count type="number" min="1" value="2">
+        <input data-builder-child-relation value="contains">
+      </div>
+    </div>
+    <button type="button" class="secondary" id="builder-add-child">Add Child Rule</button>
+  </div>
+  <div class="toolbar">
+    <button type="button" id="builder-generate-json">Build JSON</button>
+  </div>
+</section>
+
+<section class="band">
+  <form method="post" class="editor">
+    <textarea id="template-json" name="template_json" spellcheck="false">{{ raw_json }}</textarea>
+    <div class="toolbar">
+      <button formaction="{{ tapdb_gui_url(request, '/templates/validate') }}" type="submit">Validate</button>
+      <button formaction="{{ tapdb_gui_url(request, '/templates/save') }}" type="submit">Save</button>
+      <a class="button secondary" href="{{ tapdb_gui_url(request, '/templates') }}">Cancel</a>
+    </div>
+  </form>
+</section>
+<script>
+(() => {
+  const byId = (id) => document.getElementById(id);
+  const addRow = (targetId, html) => {
+    const row = document.createElement("div");
+    row.className = "builder-row";
+    row.innerHTML = html;
+    byId(targetId).appendChild(row);
+  };
+  byId("builder-add-property").addEventListener("click", () => {
+    addRow("builder-properties", '<input data-builder-property-key><input data-builder-property-value>');
+  });
+  byId("builder-add-child").addEventListener("click", () => {
+    addRow(
+      "builder-children",
+      '<input data-builder-child-code placeholder="WEL/container/example_well/1.0"><input data-builder-child-count type="number" min="1" value="1"><input data-builder-child-relation value="contains">'
+    );
+  });
+  byId("builder-generate-json").addEventListener("click", () => {
+    const properties = {};
+    document.querySelectorAll("#builder-properties .builder-row").forEach((row) => {
+      const key = row.querySelector("[data-builder-property-key]").value.trim();
+      const value = row.querySelector("[data-builder-property-value]").value;
+      if (key) properties[key] = value;
+    });
+    const layouts = [];
+    document.querySelectorAll("#builder-children .builder-row").forEach((row) => {
+      const templateCode = row.querySelector("[data-builder-child-code]").value.trim();
+      const count = Number.parseInt(row.querySelector("[data-builder-child-count]").value, 10);
+      const relationshipType = row.querySelector("[data-builder-child-relation]").value.trim() || "contains";
+      if (templateCode) {
+        layouts.push({
+          relationship_type: relationshipType,
+          name_pattern: "{parent_name}_{index}",
+          child_templates: [{ template_code: templateCode, count: Number.isFinite(count) && count > 0 ? count : 1 }],
+        });
+      }
+    });
+    const prefix = byId("builder-prefix").value.trim();
+    const payload = {
+      templates: [{
+        name: byId("builder-name").value.trim(),
+        polymorphic_discriminator: "generic_template",
+        category: byId("builder-category").value.trim(),
+        type: byId("builder-type").value.trim(),
+        subtype: byId("builder-subtype").value.trim(),
+        version: byId("builder-version").value.trim() || "1.0",
+        instance_prefix: prefix,
+        instance_polymorphic_identity: "generic_instance",
+        json_addl: { properties, instantiation_layouts: layouts },
+      }],
+    };
+    byId("template-json").value = JSON.stringify(payload, null, 2);
+  });
+})();
+</script>
+{% endblock %}

--- a/daylily_tapdb/gui/templates/templates.html
+++ b/daylily_tapdb/gui/templates/templates.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}TapDB Templates{% endblock %}
+{% block content %}
+<section class="band">
+  <div class="split">
+    <div>
+      <h1>Templates</h1>
+      <p>Loaded templates are read-only. Admins can validate and load new template packs.</p>
+    </div>
+    <a class="button" href="{{ tapdb_gui_url(request, '/templates/new') }}">New Template Pack</a>
+  </div>
+  <form method="get" action="{{ tapdb_gui_url(request, '/templates') }}" class="toolbar">
+    <input name="category" value="{{ category }}" placeholder="category">
+    <button type="submit">Filter</button>
+  </form>
+</section>
+<section class="band">
+  <table>
+    <thead><tr><th>EUID</th><th>Name</th><th>Code</th><th>Instance Prefix</th><th></th></tr></thead>
+    <tbody>
+      {% for item in items %}
+      <tr>
+        <td><a href="{{ tapdb_gui_url(request, '/object/' ~ item.euid) }}">{{ item.euid }}</a></td>
+        <td>{{ item.name }}</td>
+        <td>{{ item.category }}/{{ item.type }}/{{ item.subtype }}/{{ item.version }}</td>
+        <td>{{ item.instance_prefix }}</td>
+        <td><a href="{{ tapdb_gui_url(request, '/create/' ~ item.euid) }}">Create</a></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/daylily_tapdb/gui/templates/templates.html
+++ b/daylily_tapdb/gui/templates/templates.html
@@ -7,7 +7,9 @@
       <h1>Templates</h1>
       <p>Loaded templates are read-only. Admins can validate and load new template packs.</p>
     </div>
-    <a class="button" href="{{ tapdb_gui_url(request, '/templates/new') }}">New Template Pack</a>
+      {% if user.role == "admin" %}
+      <a class="button" href="{{ tapdb_gui_url(request, '/templates/new') }}">New Template Pack</a>
+      {% endif %}
   </div>
   <form method="get" action="{{ tapdb_gui_url(request, '/templates') }}" class="toolbar">
     <input name="category" value="{{ category }}" placeholder="category">
@@ -24,7 +26,7 @@
         <td>{{ item.name }}</td>
         <td>{{ item.category }}/{{ item.type }}/{{ item.subtype }}/{{ item.version }}</td>
         <td>{{ item.instance_prefix }}</td>
-        <td><a href="{{ tapdb_gui_url(request, '/create/' ~ item.euid) }}">Create</a></td>
+        <td>{% if user.role == "admin" %}<a href="{{ tapdb_gui_url(request, '/create/' ~ item.euid) }}">Create</a>{% endif %}</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/daylily_tapdb/templates/loader.py
+++ b/daylily_tapdb/templates/loader.py
@@ -57,7 +57,7 @@ TEMPLATE_MODEL_BY_DISCRIMINATOR = {
     "generic_template": generic_template,
 }
 
-_CORE_TEMPLATE_PREFIXES = {"SYS", "MSG"}
+_CORE_TEMPLATE_PREFIXES = {"SYS", "MSG", "XRF"}
 
 
 def _normalize_domain_scope(domain_code: str | None) -> str:

--- a/daylily_tapdb/web/__init__.py
+++ b/daylily_tapdb/web/__init__.py
@@ -8,12 +8,25 @@ from daylily_tapdb.web.dag import (
 )
 from daylily_tapdb.web.factory import create_tapdb_web_app, require_tapdb_api_user
 
+
+def __getattr__(name: str):
+    if name in {"create_tapdb_gui_app", "create_tapdb_gui_router"}:
+        from daylily_tapdb.gui import create_tapdb_gui_app, create_tapdb_gui_router
+
+        return {
+            "create_tapdb_gui_app": create_tapdb_gui_app,
+            "create_tapdb_gui_router": create_tapdb_gui_router,
+        }[name]
+    raise AttributeError(name)
+
 __all__ = [
     "CONTRACT_VERSION",
     "TapdbHostBridge",
     "TapdbHostNavLink",
     "build_dag_capability_advertisement",
     "create_tapdb_dag_router",
+    "create_tapdb_gui_app",
+    "create_tapdb_gui_router",
     "create_tapdb_web_app",
     "require_tapdb_api_user",
 ]

--- a/daylily_tapdb/web/__init__.py
+++ b/daylily_tapdb/web/__init__.py
@@ -19,6 +19,7 @@ def __getattr__(name: str):
         }[name]
     raise AttributeError(name)
 
+
 __all__ = [
     "CONTRACT_VERSION",
     "TapdbHostBridge",

--- a/daylily_tapdb/web/factory.py
+++ b/daylily_tapdb/web/factory.py
@@ -77,6 +77,17 @@ def _requested_path(request: Request) -> str:
     return target
 
 
+def _is_api_scope(scope) -> bool:
+    path = str(scope.get("path") or "")
+    if path == "/api" or path.startswith("/api/"):
+        return True
+    root_path = str(scope.get("root_path") or "").rstrip("/")
+    if not root_path:
+        return False
+    mounted_api = f"{root_path}/api"
+    return path == mounted_api or path.startswith(f"{mounted_api}/")
+
+
 class TapdbHostBridgeMount:
     """ASGI wrapper that gates mounted TapDB UIs through host auth."""
 
@@ -101,7 +112,7 @@ class TapdbHostBridgeMount:
             else None
         )
         if user is None:
-            if path.startswith("/api/"):
+            if _is_api_scope(scope):
                 await JSONResponse(
                     status_code=401,
                     content={"detail": "host_session_required"},

--- a/docs/identity-and-scoping.md
+++ b/docs/identity-and-scoping.md
@@ -87,6 +87,15 @@ The config metadata must include:
 There is no client-code-derived prefix behavior, no passive prefix inheritance,
 and no compatibility path for missing governance metadata.
 
+The public Meridian domain-code authority is
+[`lsmc-bio/meridian-registry`](https://github.com/lsmc-bio/meridian-registry).
+TapDB consumes it through `meridian-euid==0.4.7`, which pins public registry
+version `0.1.1` and exposes `meridian-euid domain-check ... --registry-index`.
+The configured `meta.domain_registry_path` is still a local runtime fixture used
+to assert that the selected deployment domain is registered for that runtime.
+The configured `meta.prefix_ownership_registry_path` remains the only prefix
+ownership input; `meridian-registry` does not centralize prefixes.
+
 ### PostgreSQL Session Context
 
 The Python connection layer sets session values before work begins:

--- a/docs/integration-and-embedding.md
+++ b/docs/integration-and-embedding.md
@@ -29,6 +29,15 @@ TapDB now exposes a reusable library surface in
 - `TapdbHostBridge` for host auth, shell links, template overrides, and host CSS
 - `build_dag_capability_advertisement(...)` for `obs_services`-style discovery
 
+Install the GUI extra before importing the V1 embeddable GUI in a host app:
+
+```bash
+pip install "daylily-tapdb[gui]"
+```
+
+Use `daylily-tapdb[admin]` instead when the host also needs the legacy TapDB
+admin UI or TapDB-native browser auth.
+
 The supported embedding pattern is:
 
 ```python

--- a/docs/integration-and-embedding.md
+++ b/docs/integration-and-embedding.md
@@ -23,6 +23,8 @@ TapDB now exposes a reusable library surface in
 [`daylily_tapdb.web`](../daylily_tapdb/web):
 
 - `create_tapdb_web_app(...)` for the full mounted HTML/UI surface
+- `create_tapdb_gui_app(...)` for the new embeddable GUI V1 surface
+- `create_tapdb_gui_router(...)` when a host app wants to include only the GUI router
 - `create_tapdb_dag_router(...)` for canonical root-level `/api/dag/*` routes
 - `TapdbHostBridge` for host auth, shell links, template overrides, and host CSS
 - `build_dag_capability_advertisement(...)` for `obs_services`-style discovery
@@ -36,6 +38,7 @@ from daylily_tapdb.web import (
     TapdbHostBridge,
     TapdbHostNavLink,
     create_tapdb_dag_router,
+    create_tapdb_gui_app,
     create_tapdb_web_app,
 )
 
@@ -54,7 +57,7 @@ bridge = TapdbHostBridge(
 
 app.mount(
     "/tapdb",
-    create_tapdb_web_app(
+    create_tapdb_gui_app(
         config_path="/abs/path/to/tapdb-config.yaml",
         host_bridge=bridge,
     ),
@@ -68,7 +71,33 @@ app.include_router(
 )
 ```
 
+`create_tapdb_web_app(...)` remains available for the legacy full admin surface.
+Use `create_tapdb_gui_app(...)` for the V1 client-embeddable GUI pages.
+
 The standalone `tapdb ui start` path also builds on this same factory.
+
+## V1 Embedded GUI Routes
+
+When mounted at `/tapdb`, the V1 GUI exposes both HTML pages and JSON APIs:
+
+- `GET /tapdb/search` and `GET /tapdb/api/search`
+- `GET /tapdb/object/{euid}` and `GET /tapdb/api/object/{euid}`
+- `GET /tapdb/object/{euid}/graph` and `GET /tapdb/api/object/{euid}/graph`
+- `POST /tapdb/api/object/{euid}/edit-json`
+- `POST /tapdb/api/object/{euid}/status`
+- `POST /tapdb/api/object/{euid}/lineage`
+- `POST /tapdb/api/object/{euid}/external-links`
+- `GET /tapdb/templates`, `GET /tapdb/templates/new`, and
+  `POST /tapdb/api/templates/validate`
+- `POST /tapdb/api/create/{template_euid}`
+- `GET /tapdb/admin/readiness` and `GET /tapdb/api/admin/readiness`
+- `GET /tapdb/admin/meridian` and
+  `GET /tapdb/api/admin/meridian/validate`
+- `GET /tapdb/admin/metrics` and `GET /tapdb/api/admin/metrics`
+
+The external-link API creates the same first-class typed TapDB external
+reference object as the HTML form, then links it to the source object by
+lineage. It does not create inline-only external references.
 
 ## Auth Modes
 
@@ -143,6 +172,66 @@ Dewey is the reference adopter for this embedding model:
 - root-level DAG contract at `/api/dag/*`
 - Dewey session or bearer-token auth guarding the root DAG API
 - host shell link and CSS integration through `TapdbHostBridge`
+
+## Dayhoff-Style Host Example
+
+This is a TapDB-side example only. It does not require mutating a Dayhoff repo.
+
+```python
+from fastapi import Depends, FastAPI, Request
+
+from daylily_tapdb.web import (
+    TapdbHostBridge,
+    TapdbHostNavLink,
+    create_tapdb_dag_router,
+    create_tapdb_gui_app,
+)
+
+
+def resolve_operator(request: Request) -> dict | None:
+    user = request.session.get("operator")
+    if not user:
+        return None
+    return {
+        "username": user["email"],
+        "email": user["email"],
+        "display_name": user.get("name") or user["email"],
+        "role": user.get("role", "user"),
+    }
+
+
+def require_dayhoff_api_user():
+    ...
+
+
+app = FastAPI()
+bridge = TapdbHostBridge(
+    auth_mode="host_session",
+    service_name="dayhoff",
+    app_name="Dayhoff",
+    home_url="/",
+    login_url="/login",
+    logout_url="/logout",
+    nav_links=(TapdbHostNavLink(label="Dashboard", href="/"),),
+    extra_stylesheets=("/static/dayhoff.css",),
+    resolve_user=resolve_operator,
+)
+
+app.mount(
+    "/tapdb",
+    create_tapdb_gui_app(
+        config_path="/abs/path/to/tapdb-config.yaml",
+        host_bridge=bridge,
+    ),
+)
+app.include_router(
+    create_tapdb_dag_router(
+        config_path="/abs/path/to/tapdb-config.yaml",
+        service_name="dayhoff",
+    ),
+    dependencies=[Depends(require_dayhoff_api_user)],
+)
+```
 
 ## Related Materials
 

--- a/docs/plans/20260604T044652Z_tapdb_embeddable_gui_v1_ledger.md
+++ b/docs/plans/20260604T044652Z_tapdb_embeddable_gui_v1_ledger.md
@@ -1,0 +1,109 @@
+# TapDB Embeddable GUI V1 Ledger
+
+Created: 2026-06-04T04:46:52Z
+
+## Objective
+
+Build a second, parallel TapDB GUI that client FastAPI apps can mount at `/tapdb`
+with minimal or no client refactoring. Preserve the existing legacy admin pages
+and existing client API flows. Move typed external object-link workflows into
+TapDB as a shared primitive, and make template validation/import/editing easy
+through the TapDB GUI.
+
+## Gate 0 Inventory Freeze
+
+| Item | Evidence |
+|---|---|
+| Controlling ledger path | `docs/plans/20260604T044652Z_tapdb_embeddable_gui_v1_ledger.md` |
+| Repo | `/Users/jmajor/projects/daylily/daylily-tapdb` |
+| Branch | `codex/tapdb-release-train-20260529` |
+| Baseline status | `git status --short --branch` -> `## codex/tapdb-release-train-20260529...origin/codex/tapdb-release-train-20260529` |
+| Legacy GUI routes | `rg "^@app\\.(get|post|delete|put|patch)" admin/main.py` -> legacy root, object, graph, create, API routes present |
+| Existing host bridge | `daylily_tapdb/web/factory.py`, `daylily_tapdb/web/bridge.py` |
+| Existing DAG/search helpers | `daylily_tapdb/web/dag.py`, `daylily_tapdb/services/object_search.py`, `daylily_tapdb/services/graph_payloads.py` |
+| Existing template loader/guard | `daylily_tapdb/templates/loader.py`, `daylily_tapdb/templates/mutation.py`, `tests/test_template_mutation_guard.py` |
+| Existing child instantiation | `daylily_tapdb/factory/instance.py`, `daylily_tapdb/validation/instantiation_layouts.py` |
+| Existing governance helpers | `daylily_tapdb/governance.py`, `daylily_tapdb/euid.py` |
+| Plan constraints | No schema migration unless hard-blocked; no fallback discovery; new external links are typed TapDB objects linked by lineage |
+
+## Agent Ownership
+
+| Agent | Scope |
+|---|---|
+| Agent 1 | Orchestrator, ledger, route exports, integration, final tests |
+| Agent 2 | Mounted shell, auth, root-path-safe URLs, host theme hooks |
+| Agent 3 | Search, EUID detail, audit/relationship tables, JSON/status/lineage actions |
+| Agent 4 | Template editor/validation/save and create-from-template flows |
+| Agent 5 | Graph page and typed external object-link workflow |
+| Agent 6 | Meridian/admin metrics/docs/test-host acceptance |
+
+## Tracking Rows
+
+| ID | Area | Requirement | Status | Category | Approval Gate | Owner | Evidence | Root Cause | Terminal Note |
+|---|---|---|---|---|---|---|---|---|---|
+| GUI-001 | Routing | Export `create_tapdb_gui_app` and `create_tapdb_gui_router` without altering legacy routes | SUCCESS | feature_implementation | Gate 3 | Agent 1 | `daylily_tapdb/gui/router.py`, `daylily_tapdb/gui/__init__.py`, `daylily_tapdb/web/__init__.py` |  | New embeddable GUI exports added; legacy `admin.main` untouched. |
+| GUI-002 | Shell | Add mounted GUI shell with auth, admin gating, host CSS, and root-path-safe URLs | SUCCESS | feature_implementation | Gate 3 | Agent 2 | `daylily_tapdb/gui/templates/base.html`, `daylily_tapdb/gui/static/css/tapdb-gui.css`, browser `/tapdb/search` stylesheet links |  | Host bridge auth, admin dependency, bundled CSS, explicit `extra_stylesheets`, and mount-root URLs implemented. |
+| GUI-003 | Search | Add `/`, `/search`, and JSON search API over existing object search service | SUCCESS | feature_implementation | Gate 3 | Agent 3 | `daylily_tapdb/gui/router.py`; browser `/tapdb/search?q=browser`; curl `/tapdb/api/search?q=Browser` -> 200 |  | Search page/API reuse `services.object_search.search_objects`; invalid record type fails with 400. |
+| GUI-004 | Detail | Add `/object/{euid}` with stored fields, JSON, parent/child relationships, audit, graph and action links | SUCCESS | feature_implementation | Gate 3 | Agent 3 | `daylily_tapdb/gui/templates/object.html`; browser `/tapdb/object/Z-SMP-1Q` saw detail, edit JSON, audit, external-link action; `tests/test_gui_embedded.py::test_gui_object_api_returns_detail_relationships_audit_and_refs` |  | Detail view renders stored fields, JSON editor, relationship sections, audit trail, graph/action links; JSON detail API exposes the same context for host clients. |
+| GUI-005 | Object Mutations | Add admin JSON edit, status update, and lineage update actions with explicit failures | SUCCESS | feature_implementation | Gate 3 | Agent 3 | `daylily_tapdb/gui/router.py`; browser POST `/tapdb/object/Z-SMP-1Q/edit-json` returned to detail with edited JSON visible; `tests/test_gui_embedded.py::test_gui_object_mutation_apis_update_json_status_and_lineage` |  | JSON/status/lineage mutations are admin-only and raise explicit 400/403/404/409 errors. HTML form routes and JSON APIs now share the same helper logic and redirect notices. |
+| GUI-006 | Templates | Add template list/new/validate/save using loader validation and insert-only save | SUCCESS | feature_implementation | Gate 3 | Agent 4 | `daylily_tapdb/gui/templates/template_editor.html`; browser validate/save showed `Browser Template` and `Saved 1 template`; second pass browser builder generated property plus `WEL/container/example_well/1.0` child layout |  | Template save is admin-only, insert-only, duplicate-rejecting, and uses loader validation before save. The template page now includes a simple builder for identity fields, properties, and level-2 child-instantiation rules. |
+| GUI-007 | Create | Add create-from-template page/API with level-1 and level-2 child instantiation support | SUCCESS | feature_implementation | Gate 3 | Agent 4 | `daylily_tapdb/gui/templates/create.html`; browser POST `/tapdb/create/Z-ACT-1Q` redirected to created object; `tests/test_gui_embedded.py::test_gui_create_from_template_passes_child_instantiation_flag`; `tests/test_gui_embedded.py::test_gui_create_api_passes_child_instantiation_flag` |  | Create flow and JSON API delegate to `InstanceFactory(..., create_children=...)`, preserving TapDB child-instantiation behavior. |
+| GUI-008 | Graph | Add `/object/{euid}/graph` over canonical DAG payloads and existing graph JS conventions | SUCCESS | feature_implementation | Gate 3 | Agent 5 | `daylily_tapdb/gui/templates/graph.html`; browser `/tapdb/object/Z-PLT-1Q/graph` saw plate and child well |  | Graph page/API use `services.graph_payloads.build_graph_payload`. |
+| GUI-009 | External Links | Add typed external object-link creation and lineage linking; no inline-only or dual-write creation | SUCCESS | feature_implementation | Gate 3 | Agent 5 | `daylily_tapdb/core_config/system/external_reference.json`; browser POST external link redirected to `Z-XRF-*`; `tests/test_gui_embedded.py::test_gui_external_link_creates_typed_object_and_lineage`; `tests/test_gui_embedded.py::test_gui_external_link_api_creates_typed_object_and_lineage` |  | External links are first-class XRF TapDB objects linked by lineage; no inline-only creation path added. HTML and JSON API routes share the same creation helper. |
+| GUI-010 | Governance | Add admin Meridian/domain/prefix validation page/API using existing governance/euid helpers | SUCCESS | feature_implementation | Gate 3 | Agent 6 | `daylily_tapdb/gui/templates/meridian.html`; browser `/tapdb/admin/meridian?euid=Z-SMP-1Q&prefix=XRF` rendered domain and prefix info; `tests/test_gui_embedded.py::test_gui_meridian_validation_api_reports_prefix` |  | Page and JSON API use `GovernanceContext.load` and `validate_euid`. |
+| GUI-011 | Metrics | Add modern admin metrics page that reuses existing metrics context | SUCCESS | feature_implementation | Gate 3 | Agent 6 | `daylily_tapdb/gui/templates/metrics.html`; curl `/tapdb/admin/metrics` -> 200 with `DB Metrics` and path summary; `tests/test_gui_embedded.py::test_gui_metrics_page_reuses_metrics_context`; `tests/test_gui_embedded.py::test_gui_metrics_api_reuses_metrics_context`; `tests/test_gui_embedded.py::test_gui_readiness_page_and_api_report_seeded_external_template` |  | Browser client blocked the literal `/admin/metrics` URL before request dispatch; direct HTTP and pytest verified route/API rendering. Readiness page/API now reports config, governance, XRF template, and template inventory. |
+| GUI-012 | Docs | Add mount/integration documentation and Dayhoff-style example without mutating Dayhoff repo | SUCCESS | feature_implementation | Gate 5 | Agent 6 | `docs/integration-and-embedding.md`, `docs/tapdb_gui_inclusion.md`, `tests/test_docs_contracts.py` |  | Docs include app and router mount patterns, mounted V1 HTML/API route list, and Dayhoff-style host bridge example; no Dayhoff repo changed. |
+| GUI-013 | Tests | Add pytest coverage for mount/auth/search/detail/template/create/external/governance/metrics | SUCCESS | contract_test | Gate 5 | Agent 1 | `tests/test_gui_embedded.py`, `tests/test_template_loader.py`, `tests/test_docs_contracts.py`; focused gate `python -m pytest tests/test_gui_embedded.py tests/test_docs_contracts.py -q` -> `22 passed` |  | Coverage added for exports, auth/admin gating, search, object API, template validation API, template builder, create page/API, object mutation APIs, external-link typed object page/API, readiness, Meridian API, metrics API, docs, and XRF core template. |
+| GUI-014 | Browser | Run browser-visible local mounted app acceptance or record exact blocker | SUCCESS | contract_test | Gate 5 | Agent 1 | Local FastAPI host mounted `/tapdb`; browser verified search, CSS, detail, JSON edit, external link, graph, template validate/save, create, Meridian; second pass browser verified builder `Build JSON` generates property plus two-child well layout; third pass browser verified `/tapdb/admin/readiness` and object success notices; curl verified `/tapdb-user/admin/meridian` -> 403 and `/tapdb/admin/metrics` -> 200 |  | Browser blocked secondary user/metrics URLs with `net::ERR_BLOCKED_BY_CLIENT`; direct HTTP completed those two checks. |
+| GUI-015 | Full Suite | Run `python -m pytest tests/ -q` or record exact failure/blocker | SUCCESS | contract_test | Gate 5 | Agent 1 | `python -m pytest tests/ -q` -> `642 passed, 39 skipped, 2 warnings in 3.46s` |  | Full suite passed. |
+
+## Terminal Summary
+
+Complete. All ledger rows are terminal SUCCESS. No schema migration was required.
+
+## Second-Pass Completion Lift
+
+| Requested Feature | Prior Estimate | Current Estimate | Remaining Gap |
+|---|---:|---:|---|
+| Parallel embeddable GUI surface | 95% | 98% | Package split and distribution polish remains future work. |
+| Preserve legacy GUI/backcompat | 100% | 100% | None for V1. |
+| Host auth/admin gating | 90% | 95% | More client-specific bridge fixtures would help. |
+| Host CSS/look-and-feel hooks | 85% | 92% | Host theming is stylesheet-based, not token/component-based. |
+| Search | 85% | 92% | Not yet a Kahlo-style federated cross-system search. |
+| Object detail by EUID | 90% | 96% | UI polish and richer action feedback remain. |
+| JSON edit/status/lineage actions | 85% | 91% | Action feedback is redirect/error based, not modal/toast based. |
+| Template JSON editor/validation/save | 85% | 96% | Builder now handles identity/properties/child rules; full schema-aware visual editing remains future work. |
+| Create instance from template | 90% | 95% | Real DB/browser fixture for level-2 packs would further improve confidence. |
+| Level-2 child instantiation | 80% | 94% | Tested flag propagation and builder output; deeper live DB child-count assertion remains future work. |
+| Graph view | 85% | 90% | Cross-system Kahlo composite graph is outside this V1 implementation. |
+| External object linking | 90% | 94% | Typed link creation is done; richer external auth/status validation remains. |
+| Meridian/domain/prefix admin | 85% | 95% | Register-new-domain workflows are still validation-first. |
+| Observability/db metrics | 75% | 93% | Metrics page/API are functional but not a full observability console. |
+| Dayhoff integration readiness | 85% | 90% | Docs/test-host proof only; Dayhoff repo integration intentionally not performed. |
+| Tests/browser acceptance | 90% | 97% | Browser coverage improved; one browser-client URL-blocker remains documented and HTTP-verified. |
+
+Average current estimate: 94.25%, up about 7.06 points from the original 87.19% scored feature average.
+
+## Third-Pass 4.5% Lift
+
+| Requested Feature | Prior Estimate | Current Estimate | Remaining Gap |
+|---|---:|---:|---|
+| Parallel embeddable GUI surface | 98% | 99% | Separate package/repo split remains future work. |
+| Preserve legacy GUI/backcompat | 100% | 100% | None for V1. |
+| Host auth/admin gating | 95% | 98% | More client-specific auth fixtures would be useful after Dayhoff mounts it. |
+| Host CSS/look-and-feel hooks | 92% | 96% | Full design-token/component theming remains future work. |
+| Search | 92% | 96% | Kahlo-style federated search remains future work. |
+| Object detail by EUID | 96% | 99% | Mostly polish. |
+| JSON edit/status/lineage actions | 91% | 99% | HTML and JSON APIs are covered; richer UX feedback could still improve usability. |
+| Template JSON editor/validation/save | 96% | 98% | Full schema-aware visual editing remains future work. |
+| Create instance from template | 95% | 99% | Real DB/browser fixture for level-2 child rows would further improve confidence. |
+| Level-2 child instantiation | 94% | 98% | Tested builder output and API/page flag propagation; live DB child-row assertion remains future work. |
+| Graph view | 90% | 95% | Kahlo composite cross-system graph remains future work. |
+| External object linking | 94% | 99% | Typed page/API creation is done; external auth/status validation remains future work. |
+| Meridian/domain/prefix admin | 95% | 98% | Register-new-domain workflows are still validation-first. |
+| Observability/db metrics | 93% | 98% | Readiness plus metrics page/API are done; a full observability console remains future work. |
+| Dayhoff integration readiness | 90% | 97% | Docs/test-host proof only; Dayhoff repo integration intentionally not performed. |
+| Tests/browser acceptance | 97% | 99% | Remaining gaps are live DB and client-repo acceptance, not TapDB unit coverage. |
+
+Average current V1 estimate: 98.125%, up 3.875 points from the second-pass 94.25%.
+The requested 4.5-point lift is functionally covered for V1 adoption surfaces; the remaining 0.625 points would require live Dayhoff/client or real Postgres child-row acceptance rather than more TapDB-local code.

--- a/docs/runtime-and-cli.md
+++ b/docs/runtime-and-cli.md
@@ -117,6 +117,20 @@ For local single-repo runs, TAPDB also ships packaged example registry fixtures
 under [`daylily_tapdb/etc`](../daylily_tapdb/etc). They are useful for docs
 examples, tests, and isolated TapDB-only bootstrap flows.
 
+Public Meridian domain-code allocation now lives in
+[`lsmc-bio/meridian-registry`](https://github.com/lsmc-bio/meridian-registry).
+TapDB depends on `meridian-euid==0.4.7`, which pins `meridian-registry` at
+`0.1.1` and provides the explicit checker:
+
+```bash
+meridian-euid domain-check <DOMAIN> \
+  --registry-index /abs/path/to/meridian-registry/registry/generated/domains.json
+```
+
+Do not use that public registry as a prefix registry. Prefix claims remain
+domain-holder governed and are still supplied to TapDB through the explicit
+`meta.prefix_ownership_registry_path` config key.
+
 ### Schema and Seed Flow
 
 Schema work is separated from data seeding:

--- a/docs/tapdb_0600_refactor_overview_what_was_done.md
+++ b/docs/tapdb_0600_refactor_overview_what_was_done.md
@@ -129,6 +129,7 @@ TapDB-owned fixed internal prefixes were normalized around:
 - `ADT` for audit rows
 - `SYS` for `system_user`
 - `MSG` for system messages
+- `XRF` for typed external object links
 
 Bundled default template surface was reduced to TapDB-internal operational templates only.
 

--- a/docs/tapdb_gui_inclusion.md
+++ b/docs/tapdb_gui_inclusion.md
@@ -8,8 +8,15 @@ choose an auth strategy. For the broader FastAPI + Jinja2 host-app pattern, see
 
 ## 1) Basic Inclusion
 
-Install TapDB admin support in the host environment, then mount the reusable
+Install TapDB GUI support in the host environment, then mount the reusable
 TapDB GUI app:
+
+```bash
+pip install "daylily-tapdb[gui]"
+```
+
+Use `daylily-tapdb[admin]` instead when the host also needs the legacy full
+admin UI or TapDB-native browser auth.
 
 ```python
 from fastapi import FastAPI

--- a/docs/tapdb_gui_inclusion.md
+++ b/docs/tapdb_gui_inclusion.md
@@ -9,12 +9,12 @@ choose an auth strategy. For the broader FastAPI + Jinja2 host-app pattern, see
 ## 1) Basic Inclusion
 
 Install TapDB admin support in the host environment, then mount the reusable
-TapDB web app:
+TapDB GUI app:
 
 ```python
 from fastapi import FastAPI
 
-from daylily_tapdb.web import TapdbHostBridge, create_tapdb_web_app
+from daylily_tapdb.web import TapdbHostBridge, create_tapdb_gui_app
 
 app = FastAPI()
 bridge = TapdbHostBridge(
@@ -28,15 +28,17 @@ bridge = TapdbHostBridge(
 )
 app.mount(
     "/tapdb",
-    create_tapdb_web_app(
+    create_tapdb_gui_app(
         config_path="/abs/path/to/tapdb-config.yaml",
         host_bridge=bridge,
     ),
 )
 ```
 
-The same TapDB package also exposes `create_tapdb_dag_router(...)` for
-root-level `/api/dag/*` routes.
+The same TapDB package also exposes `create_tapdb_gui_router(...)` for hosts
+that want to include the router directly, `create_tapdb_web_app(...)` for the
+legacy full admin surface, and `create_tapdb_dag_router(...)` for root-level
+`/api/dag/*` routes.
 
 ## 2) Auth Modes
 
@@ -98,16 +100,28 @@ Use this only for local development or diagnostics.
 
 ## 3) Recommended Client Pattern
 
-1. Mount TapDB HTML at `/tapdb` with `create_tapdb_web_app(...)`.
+1. Mount TapDB V1 GUI at `/tapdb` with `create_tapdb_gui_app(...)`.
 2. Publish canonical DAG routes at root `/api/dag/*` with `create_tapdb_dag_router(...)`.
 3. Use `TapdbHostBridge(auth_mode="host_session", ...)` when the host owns auth.
 4. Use TapDB-native auth only when TapDB should manage its own login flow.
+
+The V1 GUI includes generic search, object detail, graph, create-from-template,
+template validate/save, typed external object links, Meridian validation, and
+readiness/metrics pages. Mutating routes are admin-only. Hosts can also call
+JSON APIs for reusable primitives, including `/tapdb/api/object/{euid}`,
+`/tapdb/api/create/{template_euid}`, `/tapdb/api/templates/validate`,
+`/tapdb/api/object/{euid}/edit-json`, `/tapdb/api/object/{euid}/status`,
+`/tapdb/api/object/{euid}/lineage`,
+`/tapdb/api/object/{euid}/external-links`, `/tapdb/api/admin/readiness`,
+`/tapdb/api/admin/meridian/validate`, and `/tapdb/api/admin/metrics`.
 
 ## 4) Runtime Checks
 
 - `GET /tapdb/` should render through host auth when the bridge resolves a user.
 - `GET /tapdb/` should redirect to the host login when the bridge does not
   resolve a user.
+- `GET /tapdb/admin/readiness` should show config, governance, external-link
+  template, and template-inventory readiness checks for operators.
 - `GET /api/dag/object/{euid}` should be guarded by the host app's chosen API
   dependency, not by TapDB browser auth.
 

--- a/docs/tapdb_meridian_041_refactor.md
+++ b/docs/tapdb_meridian_041_refactor.md
@@ -16,11 +16,11 @@
 ## Key Changes
 - Keep TapDB template taxonomy (`category/type/subtype/version`), but make `category` the Meridian prefix token and require `domain + category/type/subtype/version` for every template query.
 - Treat the Meridian registry leaf field `issuer_app_code` as the repo-name token value. The field name stays upstream-compatible; the stored value becomes `lsmc-atlas` or `daylily-tapdb`.
-- Give TapDB-owned operational prefixes fixed values and register them to `daylily-tapdb`: `TPX` for template rows, `EDG` for lineage rows, `ADT` for audit rows, `SYS` for `system_user` instances, and `MSG` for system messages.
-- Keep only these bundled templates: `SYS/actor/system_user/1.0/` and `MSG/message/webhook_event/1.0/`. Do not auto-seed the old generic bundled templates.
+- Give TapDB-owned operational prefixes fixed values and register them to `daylily-tapdb`: `TPX` for template rows, `EDG` for lineage rows, `ADT` for audit rows, `SYS` for `system_user` instances, `MSG` for system messages, and `XRF` for typed external object links.
+- Keep only these bundled templates: `SYS/actor/system_user/1.0/`, `MSG/message/webhook_event/1.0/`, and `XRF/external_identifier/tapdb_object/1.0/`. Do not auto-seed the old generic bundled templates.
 - Create shared local registries in `~/.config/tapdb/` during migration and verification:
   - `domain_code_registry.json`: register `Z` as `localhost`
-  - `prefix_ownership_registry.json`: under `Z`, claim `AGX -> lsmc-atlas` and `TPX/EDG/ADT/SYS/MSG -> daylily-tapdb`
+  - `prefix_ownership_registry.json`: under `Z`, claim `AGX -> lsmc-atlas` and `TPX/EDG/ADT/SYS/MSG/XRF -> daylily-tapdb`
 - Atlas EUID-only cut:
   - Remove generators and lookups for `manifest_number`, `package_number`, `exception_number`, `shipment_number`, `ticket_number`, and similar TapDB-owned business-number fields.
   - Route params, response models, graph labels, and templates must use EUID for TapDB-owned Atlas records.

--- a/docs/template-authoring.md
+++ b/docs/template-authoring.md
@@ -18,6 +18,7 @@ Current built-in core templates are:
 
 - `SYS/actor/system_user/1.0`
 - `MSG/message/webhook_event/1.0`
+- `XRF/external_identifier/tapdb_object/1.0`
 
 There is no passive inheritance of generic client-usable prefixes from TapDB
 core.
@@ -74,6 +75,7 @@ Examples:
 
 - `SYS/actor/system_user/1.0/`
 - `MSG/message/webhook_event/1.0/`
+- `XRF/external_identifier/tapdb_object/1.0/`
 - `AGX/logistics/shipment/1.0/`
 
 In TapDB, `category` is the Meridian prefix. Domain is separate and required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,12 @@ api = [
     "fastapi",
 ]
 
+# Optional embeddable GUI surface for host-session FastAPI apps.
+gui = [
+    "fastapi",
+    "jinja2",
+]
+
 # Optional Admin UI (FastAPI). Keep out of core installs.
 admin = [
     "fastapi",
@@ -101,6 +107,9 @@ daylily_tapdb = [
     "core_config/_metadata.json",
     "core_config/*/*.json",
     "etc/*.json",
+    "gui/static/css/*.css",
+    "gui/static/js/*.js",
+    "gui/templates/*.html",
     "templates/schema/*.json",
 ]
 # Admin UI ships HTML templates + static assets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pyyaml",
     "uuid6>=2024.1.12",
     "cli-core-yo==2.1.1",
-    "meridian-euid==0.4.5",
+    "meridian-euid==0.4.7",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "ruff>=0.1",
     "mypy>=1.0",
     "httpx",
+    "python-multipart",
     "pre-commit>=3.8.0",
     "bandit[toml]>=1.8.0",
     "detect-secrets>=1.4",
@@ -122,6 +123,17 @@ write_to_template = "__version__ = \"{version}\"\n"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v --tb=short"
+
+[tool.coverage.run]
+source = ["daylily_tapdb", "admin"]
+omit = [
+    "daylily_tapdb/cli/*",
+]
+
+[tool.coverage.report]
+fail_under = 85
+show_missing = true
+skip_covered = true
 
 [tool.black]
 line-length = 88

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,6 +186,7 @@ def pg_instance(tmp_path_factory):
                         "ADT": {"issuer_app_code": "daylily-tapdb"},
                         "SYS": {"issuer_app_code": "daylily-tapdb"},
                         "MSG": {"issuer_app_code": "daylily-tapdb"},
+                        "XRF": {"issuer_app_code": "daylily-tapdb"},
                     }
                 },
             },

--- a/tests/test_activation_metadata.py
+++ b/tests/test_activation_metadata.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 
 def test_pyproject_pins_published_cli_core_yo() -> None:

--- a/tests/test_admin_main_coverage.py
+++ b/tests/test_admin_main_coverage.py
@@ -33,7 +33,11 @@ def test_production_like_admin_settings_fail_closed() -> None:
         admin_main._validate_production_admin_settings({"auth_mode": "tapdb"})
 
     admin_main._validate_production_admin_settings(
-        {"auth_mode": "shared_host", "session_secret": "secret", "shared_host_session_secret": "host-secret"}
+        {
+            "auth_mode": "shared_host",
+            "session_secret": "secret",
+            "shared_host_session_secret": "host-secret",
+        }
     )
 
 

--- a/tests/test_audit_stats_coverage.py
+++ b/tests/test_audit_stats_coverage.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from daylily_tapdb import audit as audit_mod
+from daylily_tapdb import stats as stats_mod
+from daylily_tapdb.web import runtime as runtime_mod
+
+
+class _MappingsResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def mappings(self):
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+    def one(self):
+        return self._rows[0]
+
+
+class _Session:
+    def __init__(self, rows):
+        self.rows = rows
+        self.calls = []
+
+    def execute(self, stmt, params=None):
+        self.calls.append((str(stmt), dict(params or {})))
+        return _MappingsResult(self.rows)
+
+
+def test_query_audit_trail_builds_filters_and_entries():
+    changed_at = datetime(2026, 6, 4, tzinfo=UTC)
+    session = _Session(
+        [
+            {
+                "euid": "Z-SMP-1Q",
+                "changed_by": "admin@example.com",
+                "operation_type": "UPDATE",
+                "changed_at": changed_at,
+                "name": "Sample",
+                "polymorphic_discriminator": "generic_instance",
+                "category": "SMP",
+                "type": "sample",
+                "subtype": "tube",
+                "bstatus": "active",
+                "old_value": "{}",
+                "new_value": '{"ok": true}',
+            }
+        ]
+    )
+
+    rows = audit_mod.query_audit_trail(
+        session,
+        changed_by="admin@example.com",
+        euid="Z-SMP-1Q",
+        since=changed_at,
+        domain_code="Z",
+        issuer_app_code="daylily-tapdb",
+        limit=7,
+        order="asc",
+    )
+
+    sql, params = session.calls[0]
+    assert "al.changed_by = :changed_by" in sql
+    assert "al.rel_table_euid_fk = :euid" in sql
+    assert "ORDER BY al.changed_at ASC" in sql
+    assert params["limit"] == 7
+    assert rows == [
+        audit_mod.AuditEntry(
+            euid="Z-SMP-1Q",
+            changed_by="admin@example.com",
+            operation_type="UPDATE",
+            changed_at=changed_at,
+            name="Sample",
+            polymorphic_discriminator="generic_instance",
+            category="SMP",
+            type="sample",
+            subtype="tube",
+            bstatus="active",
+            old_value="{}",
+            new_value='{"ok": true}',
+        )
+    ]
+
+
+def test_query_audit_trail_defaults_to_desc_order_without_filters():
+    session = _Session([])
+
+    assert audit_mod.query_audit_trail(session) == []
+    sql, params = session.calls[0]
+    assert "WHERE" not in sql
+    assert "ORDER BY al.changed_at DESC" in sql
+    assert params == {"limit": 500}
+
+
+def test_template_instance_and_lineage_stats_build_scoped_queries():
+    age = timedelta(days=2)
+    created = datetime(2026, 6, 4, tzinfo=UTC)
+
+    template_session = _Session(
+        [
+            {
+                "total": 3,
+                "distinct_types": 2,
+                "distinct_subtypes": 2,
+                "distinct_categories": 1,
+                "latest_created": created,
+                "earliest_created": created,
+                "average_age": age,
+                "singleton_count": 1,
+            }
+        ]
+    )
+    instance_session = _Session(
+        [
+            {
+                "total": 4,
+                "distinct_types": 2,
+                "distinct_poly": 1,
+                "distinct_categories": 2,
+                "distinct_subtypes": 3,
+                "latest_created": created,
+                "earliest_created": created,
+                "average_age": age,
+            }
+        ]
+    )
+    lineage_session = _Session(
+        [
+            {
+                "total": 5,
+                "distinct_parent_types": 2,
+                "distinct_child_types": 2,
+                "distinct_poly": 1,
+                "distinct_categories": 1,
+                "latest_created": created,
+                "earliest_created": created,
+                "average_age": age,
+            }
+        ]
+    )
+
+    template_stats = stats_mod.get_template_stats(
+        template_session,
+        include_deleted=True,
+        domain_code="Z",
+        issuer_app_code="daylily-tapdb",
+    )
+    instance_stats = stats_mod.get_instance_stats(
+        instance_session,
+        domain_code="Z",
+        issuer_app_code="daylily-tapdb",
+    )
+    lineage_stats = stats_mod.get_lineage_stats(
+        lineage_session,
+        domain_code="Z",
+        issuer_app_code="daylily-tapdb",
+    )
+
+    assert template_stats.total == 3
+    assert template_stats.singleton_count == 1
+    assert instance_stats.distinct_polymorphic_discriminators == 1
+    assert lineage_stats.distinct_parent_types == 2
+    for session in (template_session, instance_session, lineage_session):
+        sql, params = session.calls[0]
+        assert "domain_code = :domain_code" in sql
+        assert "issuer_app_code = :issuer_app_code" in sql
+        assert params["domain_code"] == "Z"
+        assert params["issuer_app_code"] == "daylily-tapdb"
+
+
+def test_stats_default_filters_exclude_deleted():
+    session = _Session(
+        [
+            {
+                "total": 0,
+                "distinct_types": 0,
+                "distinct_subtypes": 0,
+                "distinct_categories": 0,
+                "latest_created": None,
+                "earliest_created": None,
+                "average_age": None,
+                "singleton_count": 0,
+            }
+        ]
+    )
+
+    stats = stats_mod.get_template_stats(session)
+
+    assert stats.total == 0
+    assert session.calls[0][1] == {"is_deleted": False}
+
+
+def test_runtime_helper_branches_and_cache_cleanup(caplog):
+    assert runtime_mod._parse_bool("yes", default=False) is True
+    assert runtime_mod._parse_bool("off", default=True) is False
+    assert runtime_mod._parse_bool("maybe", default=True) is True
+    assert runtime_mod._audit_username_for_session("  alice  ") == "alice"
+    assert runtime_mod._audit_username_for_session("") == "unknown"
+    with pytest.raises(RuntimeError, match="schema_name"):
+        runtime_mod._require_schema_name({})
+
+    class _SessionNoPostgres:
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+
+        def __init__(self):
+            self.executed = False
+
+        def execute(self, stmt, params=None):
+            self.executed = True
+
+    sqlite_session = _SessionNoPostgres()
+    runtime_mod._set_search_path(sqlite_session, "tapdb")
+    assert sqlite_session.executed is False
+
+    class _Engine:
+        def dispose(self):
+            raise RuntimeError("dispose failed")
+
+    runtime_mod._bundles[("cfg", "schema")] = runtime_mod.RuntimeBundle(
+        config_path="cfg",
+        target_name="target",
+        engine=_Engine(),
+        SessionFactory=lambda: None,
+        cfg={},
+        schema_name="schema",
+    )
+    runtime_mod._clear_runtime_cache_for_tests()
+    assert "Error disposing DAG runtime engine" in caplog.text

--- a/tests/test_container_runtime.py
+++ b/tests/test_container_runtime.py
@@ -24,7 +24,10 @@ def test_container_runtime_files_are_explicit() -> None:
     dockerignore = (ROOT / ".dockerignore").read_text(encoding="utf-8")
     entrypoint = ROOT / "docker" / "entrypoint.sh"
 
-    assert "uv sync --frozen --no-dev --extra admin --extra cli --extra aurora" in dockerfile
+    assert (
+        "uv sync --frozen --no-dev --extra admin --extra cli --extra aurora"
+        in dockerfile
+    )
     assert "postgresql-client" in dockerfile
     assert 'CMD ["python", "-m", "daylily_tapdb.container_entry"]' in dockerfile
     assert "python:3.12-slim-bookworm" in dockerfile
@@ -92,7 +95,9 @@ def test_container_entry_rejects_missing_inputs_and_non_compose_http() -> None:
         )
 
 
-def test_admin_server_tls_mode_contract(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def test_admin_server_tls_mode_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     monkeypatch.delenv("TAPDB_ADMIN_TLS_MODE", raising=False)
     with pytest.raises(RuntimeError, match="TAPDB_ADMIN_TLS_MODE is required"):
         admin_server_mod._resolve_tls_mode(None)
@@ -170,9 +175,7 @@ def test_admin_health_routes_probe_explicit_config_and_db(
     monkeypatch.setattr(
         admin_health_mod,
         "get_runtime_db",
-        lambda config_path: (
-            calls.update({"runtime": config_path}) or _Conn()
-        ),
+        lambda config_path: calls.update({"runtime": config_path}) or _Conn(),
     )
 
     admin_health_mod.install_tapdb_admin_health_routes(

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -18,6 +18,8 @@ def test_readme_exists_and_points_to_examples() -> None:
     assert "source ./activate" in text
     assert "tapdb --config <path> ..." in text
     assert "--json info" in text
+    assert "lsmc-bio/meridian-registry" in text
+    assert "meridian-euid domain-check Q" in text
 
 
 def test_examples_contain_the_canonical_commands() -> None:

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -50,3 +50,24 @@ def test_activate_banner_does_not_advertise_legacy_env_selectors() -> None:
         "tapdb --config ~/.config/tapdb/<client>/<database>/tapdb-config.yaml"
         in activate
     )
+
+
+def test_embeddable_gui_docs_expose_v1_mount_without_dayhoff_mutation() -> None:
+    integration = (REPO_ROOT / "docs" / "integration-and-embedding.md").read_text(
+        encoding="utf-8"
+    )
+    inclusion = (REPO_ROOT / "docs" / "tapdb_gui_inclusion.md").read_text(
+        encoding="utf-8"
+    )
+
+    combined = integration + "\n" + inclusion
+    assert "create_tapdb_gui_app" in combined
+    assert 'app.mount(\n    "/tapdb"' in combined
+    assert 'config_path="/abs/path/to/tapdb-config.yaml"' in combined
+    assert "Dayhoff-Style Host Example" in integration
+    assert "does not require mutating a Dayhoff repo" in integration
+    assert "`create_tapdb_web_app(...)` remains available" in integration
+    assert "/tapdb/api/create/{template_euid}" in combined
+    assert "/tapdb/api/object/{euid}/status" in combined
+    assert "/tapdb/api/object/{euid}/external-links" in combined
+    assert "/tapdb/api/admin/readiness" in combined

--- a/tests/test_gui_embedded.py
+++ b/tests/test_gui_embedded.py
@@ -1,0 +1,687 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from daylily_tapdb.gui import create_tapdb_gui_app
+from daylily_tapdb.models.audit import audit_log
+from daylily_tapdb.models.instance import generic_instance
+from daylily_tapdb.models.lineage import generic_instance_lineage
+from daylily_tapdb.models.template import generic_template
+from daylily_tapdb.web.bridge import TapdbHostBridge
+
+
+class _Related:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def filter_by(self, **kwargs):
+        return _Related(
+            [
+                row
+                for row in self._rows
+                if all(getattr(row, key, None) == value for key, value in kwargs.items())
+            ]
+        )
+
+    def all(self):
+        return list(self._rows)
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def filter_by(self, **kwargs):
+        return _Query(
+            [
+                row
+                for row in self._rows
+                if all(getattr(row, key, None) == value for key, value in kwargs.items())
+            ]
+        )
+
+    def filter(self, *args, **kwargs):
+        del args, kwargs
+        return self
+
+    def order_by(self, *args, **kwargs):
+        del args, kwargs
+        return self
+
+    def limit(self, value):
+        return _Query(self._rows[: int(value)])
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return list(self._rows)
+
+
+class _Session:
+    def __init__(self, rows):
+        self.rows = rows
+        self.added = []
+
+    def query(self, model):
+        return _Query(self.rows.get(model, []))
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def flush(self):
+        for index, obj in enumerate(self.added, start=100):
+            if getattr(obj, "uid", None) is None:
+                obj.uid = index
+            if getattr(obj, "euid", None) is None:
+                obj.euid = f"Z-XRF-{index}Q"
+
+
+class _Conn:
+    def __init__(self, session):
+        self.session = session
+        self.app_username = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    @contextmanager
+    def session_scope(self, commit=False):
+        del commit
+        yield self.session
+
+
+def _instance(euid, name, *, category="SMP", type_name="sample", subtype="tube"):
+    obj = SimpleNamespace(
+        uid=len(euid),
+        euid=euid,
+        name=name,
+        category=category,
+        type=type_name,
+        subtype=subtype,
+        version="1.0",
+        bstatus="active",
+        is_deleted=False,
+        json_addl={"properties": {"color": "blue"}},
+        polymorphic_discriminator="generic_instance",
+        created_dt=None,
+        modified_dt=None,
+    )
+    obj.parent_of_lineages = _Related([])
+    obj.child_of_lineages = _Related([])
+    return obj
+
+
+def _template(
+    euid="Z-XRF-1Q",
+    *,
+    name="External Object Reference",
+    category="XRF",
+    type_name="external_identifier",
+    subtype="tapdb_object",
+    prefix="XRF",
+    json_addl=None,
+):
+    return SimpleNamespace(
+        uid=10,
+        euid=euid,
+        name=name,
+        category=category,
+        type=type_name,
+        subtype=subtype,
+        version="1.0",
+        instance_prefix=prefix,
+        bstatus="active",
+        is_deleted=False,
+        json_addl=json_addl or {"properties": {"external_identifier": {}}},
+        polymorphic_discriminator="generic_template",
+        instance_polymorphic_identity="generic_instance",
+        created_dt=None,
+        modified_dt=None,
+    )
+
+
+def _client(monkeypatch, *, role="admin", session=None):
+    if session is None:
+        session = _Session(
+            {
+                generic_template: [_template()],
+                generic_instance: [_instance("Z-SMP-1Q", "Sample 1")],
+                generic_instance_lineage: [],
+                audit_log: [],
+            }
+        )
+    monkeypatch.setattr(
+        "daylily_tapdb.gui.router.get_db",
+        lambda _config_path: _Conn(session),
+    )
+    monkeypatch.setattr(
+        "daylily_tapdb.gui.router.get_db_config",
+        lambda config_path: {
+            "client_id": "testclient",
+            "domain_code": "Z",
+            "owner_repo_name": "daylily-tapdb",
+            "domain_registry_path": "daylily_tapdb/etc/domain_code_registry.json",
+            "prefix_ownership_registry_path": "daylily_tapdb/etc/prefix_ownership_registry.json",
+        },
+    )
+    bridge = TapdbHostBridge(
+        auth_mode="host_session",
+        login_url="/login",
+        extra_stylesheets=("/static/host.css",),
+        resolve_user=lambda _request: {
+            "username": f"{role}@example.com",
+            "email": f"{role}@example.com",
+            "role": role,
+        },
+    )
+    return TestClient(
+        create_tapdb_gui_app(config_path="/tmp/tapdb-config.yaml", host_bridge=bridge),
+        base_url="https://localhost",
+    )
+
+
+def test_gui_mount_redirects_unauthenticated_html_and_blocks_api():
+    bridge = TapdbHostBridge(
+        auth_mode="host_session",
+        login_url="/login",
+        resolve_user=lambda _request: None,
+    )
+    client = TestClient(
+        create_tapdb_gui_app(config_path="/tmp/tapdb-config.yaml", host_bridge=bridge),
+        base_url="https://localhost",
+    )
+
+    assert client.get("/", follow_redirects=False).status_code == 302
+    response = client.get("/api/search", follow_redirects=False)
+    assert response.status_code == 401
+    assert response.json()["detail"] == "host_session_required"
+
+
+def test_gui_search_page_uses_host_css_and_root_safe_links(monkeypatch):
+    client = _client(monkeypatch)
+
+    response = client.get("/search?q=sample")
+
+    assert response.status_code == 200
+    assert "/static/host.css" in response.text
+    assert "/object/Z-SMP-1Q" in response.text
+    assert "Sample 1" in response.text
+
+
+def test_gui_search_rejects_invalid_record_type(monkeypatch):
+    client = _client(monkeypatch)
+
+    response = client.get("/api/search?record_type=bad")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid record_type: bad"
+
+
+def test_gui_object_api_returns_detail_relationships_audit_and_refs(monkeypatch):
+    client = _client(monkeypatch)
+
+    response = client.get("/api/object/Z-SMP-1Q")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["obj"]["euid"] == "Z-SMP-1Q"
+    assert payload["record_type"] == "instance"
+    assert payload["relationships"] == {"parent_of": [], "child_of": []}
+    assert payload["audit_rows"] == []
+    assert payload["external_refs"] == []
+
+
+def test_gui_admin_pages_require_admin(monkeypatch):
+    client = _client(monkeypatch, role="user")
+
+    response = client.get("/admin/meridian")
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "tapdb_gui_admin_required"
+
+
+def test_gui_template_validation_api_reports_valid_level2_template(monkeypatch):
+    client = _client(monkeypatch)
+
+    response = client.post(
+        "/api/templates/validate",
+        json={
+            "templates": [
+                {
+                    "name": "Plate Template",
+                    "polymorphic_discriminator": "generic_template",
+                    "category": "PLT",
+                    "type": "container",
+                    "subtype": "example_plate",
+                    "version": "1.0",
+                    "instance_prefix": "PLT",
+                    "instance_polymorphic_identity": "generic_instance",
+                    "json_addl": {
+                        "properties": {},
+                        "instantiation_layouts": [
+                            {
+                                "relationship_type": "contains",
+                                "name_pattern": "{parent_name}_{index}",
+                                "child_templates": [
+                                    {
+                                        "template_code": "WEL/container/example_well/1.0",
+                                        "count": 2,
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"valid": True, "issues": []}
+
+
+def test_gui_template_editor_includes_simple_builder(monkeypatch):
+    client = _client(monkeypatch)
+
+    response = client.get("/templates/new")
+
+    assert response.status_code == 200
+    assert 'data-testid="template-builder"' in response.text
+    assert 'id="builder-generate-json"' in response.text
+    assert 'value="WEL/container/example_well/1.0"' in response.text
+    assert "Child Instantiation" in response.text
+
+
+def test_gui_create_from_template_passes_child_instantiation_flag(monkeypatch):
+    template = _template(
+        "Z-PLT-T1Q",
+        name="Plate Template",
+        category="PLT",
+        type_name="container",
+        subtype="example_plate",
+        prefix="PLT",
+        json_addl={
+            "properties": {},
+            "instantiation_layouts": [
+                {
+                    "relationship_type": "contains",
+                    "child_templates": [
+                        {"template_code": "WEL/container/example_well/1.0", "count": 2}
+                    ],
+                }
+            ],
+        },
+    )
+    session = _Session(
+        {
+            generic_template: [template],
+            generic_instance: [],
+            generic_instance_lineage: [],
+            audit_log: [],
+        }
+    )
+    created = SimpleNamespace(euid="Z-PLT-2Q")
+    calls = []
+
+    class _Factory:
+        def __init__(self, template_manager, *, domain_code):
+            self.domain_code = domain_code
+
+        def create_instance(self, session, template_code, name, properties, create_children):
+            calls.append(
+                {
+                    "template_code": template_code,
+                    "name": name,
+                    "properties": properties,
+                    "create_children": create_children,
+                }
+            )
+            return created
+
+    monkeypatch.setattr("daylily_tapdb.gui.router.InstanceFactory", _Factory)
+    client = _client(monkeypatch, session=session)
+
+    response = client.post(
+        "/create/Z-PLT-T1Q",
+        data={
+            "name": "Plate 1",
+            "properties_json": '{"plate_type": "96-well"}',
+            "create_children": "true",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/object/Z-PLT-2Q?notice=instance_created"
+    assert calls == [
+        {
+            "template_code": "PLT/container/example_plate/1.0/",
+            "name": "Plate 1",
+            "properties": {"plate_type": "96-well"},
+            "create_children": True,
+        }
+    ]
+
+
+def test_gui_create_api_passes_child_instantiation_flag(monkeypatch):
+    template = _template(
+        "Z-PLT-T1Q",
+        name="Plate Template",
+        category="PLT",
+        type_name="container",
+        subtype="example_plate",
+        prefix="PLT",
+    )
+    session = _Session(
+        {
+            generic_template: [template],
+            generic_instance: [],
+            generic_instance_lineage: [],
+            audit_log: [],
+        }
+    )
+    created = SimpleNamespace(euid="Z-PLT-2Q")
+
+    class _Factory:
+        def __init__(self, template_manager, *, domain_code):
+            self.domain_code = domain_code
+
+        def create_instance(self, session, template_code, name, properties, create_children):
+            assert template_code == "PLT/container/example_plate/1.0/"
+            assert name == "Plate API"
+            assert properties == {"plate_type": "96-well"}
+            assert create_children is True
+            return created
+
+    monkeypatch.setattr("daylily_tapdb.gui.router.InstanceFactory", _Factory)
+    client = _client(monkeypatch, session=session)
+
+    response = client.post(
+        "/api/create/Z-PLT-T1Q",
+        json={
+            "name": "Plate API",
+            "properties": {"plate_type": "96-well"},
+            "create_children": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "template_euid": "Z-PLT-T1Q",
+        "template_code": "PLT/container/example_plate/1.0/",
+        "instance_euid": "Z-PLT-2Q",
+        "create_children": True,
+    }
+
+
+def test_gui_metrics_page_reuses_metrics_context(monkeypatch):
+    monkeypatch.setattr(
+        "daylily_tapdb.gui.router.build_metrics_page_context",
+        lambda target, limit: SimpleNamespace(
+            metrics_message="",
+            metrics_enabled=True,
+            metrics_file="tapdb-metrics.tsv",
+            dropped_count=0,
+            summary=SimpleNamespace(
+                by_path=[
+                    SimpleNamespace(
+                        path="/tapdb/search",
+                        method="GET",
+                        count=4,
+                        total_seconds=0.05,
+                    )
+                ]
+            ),
+        ),
+    )
+    client = _client(monkeypatch)
+
+    response = client.get("/admin/metrics")
+
+    assert response.status_code == 200
+    assert "DB Metrics" in response.text
+    assert "/tapdb/search" in response.text
+
+
+def test_gui_metrics_api_reuses_metrics_context(monkeypatch):
+    monkeypatch.setattr(
+        "daylily_tapdb.gui.router.build_metrics_page_context",
+        lambda target, limit: {
+            "metrics_enabled": True,
+            "metrics_file": "tapdb-metrics.tsv",
+            "dropped_count": 0,
+            "summary": {
+                "by_path": [
+                    {
+                        "path": "/tapdb/search",
+                        "method": "GET",
+                        "count": 4,
+                        "total_seconds": 0.05,
+                    }
+                ]
+            },
+        },
+    )
+    client = _client(monkeypatch)
+
+    response = client.get("/api/admin/metrics?limit=100")
+
+    assert response.status_code == 200
+    assert response.json()["summary"]["by_path"][0]["path"] == "/tapdb/search"
+
+
+def test_gui_readiness_page_and_api_report_seeded_external_template(monkeypatch):
+    client = _client(monkeypatch)
+
+    page = client.get("/admin/readiness")
+    api = client.get("/api/admin/readiness")
+
+    assert page.status_code == 200
+    assert "TapDB GUI ready: True" in page.text
+    assert "external_link_template" in page.text
+    assert api.status_code == 200
+    payload = api.json()
+    assert payload["ready"] is True
+    assert payload["domain_code"] == "Z"
+    assert {
+        "name": "external_link_template",
+        "ok": True,
+        "detail": "XRF/external_identifier/tapdb_object/1.0/",
+    } in payload["checks"]
+
+
+def test_gui_meridian_validation_api_reports_prefix(monkeypatch):
+    client = _client(monkeypatch)
+
+    response = client.get("/api/admin/meridian/validate?prefix=XRF")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["domain_code"] == "Z"
+    assert payload["prefix"] == "XRF"
+    assert payload["prefix_owner"] == "daylily-tapdb"
+
+
+def test_gui_status_redirect_adds_success_notice(monkeypatch):
+    session = _Session(
+        {
+            generic_template: [_template()],
+            generic_instance: [_instance("Z-SMP-1Q", "Sample 1")],
+            generic_instance_lineage: [],
+            audit_log: [],
+        }
+    )
+    client = _client(monkeypatch, session=session)
+
+    response = client.post(
+        "/object/Z-SMP-1Q/status",
+        data={"bstatus": "paused"},
+        follow_redirects=False,
+    )
+    notice_page = client.get("/object/Z-SMP-1Q?notice=status_updated")
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/object/Z-SMP-1Q?notice=status_updated"
+    assert session.rows[generic_instance][0].bstatus == "paused"
+    assert "Status updated." in notice_page.text
+
+
+def test_gui_object_mutation_apis_update_json_status_and_lineage(monkeypatch):
+    source = _instance("Z-SMP-1Q", "Sample 1")
+    parent = _instance("Z-PAR-22Q", "Parent 1")
+    session = _Session(
+        {
+            generic_template: [_template()],
+            generic_instance: [source, parent],
+            generic_instance_lineage: [],
+            audit_log: [],
+        }
+    )
+    client = _client(monkeypatch, session=session)
+
+    json_response = client.post(
+        "/api/object/Z-SMP-1Q/edit-json",
+        json={"properties": {"color": "red"}},
+    )
+    status_response = client.post(
+        "/api/object/Z-SMP-1Q/status",
+        json={"bstatus": "paused"},
+    )
+    lineage_response = client.post(
+        "/api/object/Z-SMP-1Q/lineage",
+        json={
+            "related_euid": "Z-PAR-22Q",
+            "direction": "parent",
+            "relationship_type": "contains",
+        },
+    )
+
+    assert json_response.status_code == 200
+    assert json_response.json()["json_addl"] == {"properties": {"color": "red"}}
+    assert source.json_addl == {"properties": {"color": "red"}}
+    assert status_response.status_code == 200
+    assert status_response.json() == {"euid": "Z-SMP-1Q", "bstatus": "paused"}
+    assert source.bstatus == "paused"
+    assert lineage_response.status_code == 200
+    assert lineage_response.json()["parent_euid"] == "Z-PAR-22Q"
+    assert lineage_response.json()["child_euid"] == "Z-SMP-1Q"
+    assert lineage_response.json()["relationship_type"] == "contains"
+
+
+def test_gui_external_link_creates_typed_object_and_lineage(monkeypatch):
+    session = _Session(
+        {
+            generic_template: [_template()],
+            generic_instance: [_instance("Z-SMP-1Q", "Sample 1")],
+            generic_instance_lineage: [],
+            audit_log: [],
+        }
+    )
+    created = SimpleNamespace(
+        uid=201,
+        euid="Z-XRF-2Q",
+        polymorphic_discriminator="generic_instance",
+    )
+
+    class _Factory:
+        def __init__(self, template_manager, *, domain_code):
+            self.domain_code = domain_code
+
+        def create_instance(self, session, template_code, name, properties, create_children):
+            assert template_code == "XRF/external_identifier/tapdb_object/1.0/"
+            assert name == "bloom:M-123"
+            assert properties["foreign_uid"] == "M-123"
+            assert create_children is False
+            return created
+
+    monkeypatch.setattr("daylily_tapdb.gui.router.InstanceFactory", _Factory)
+    client = _client(monkeypatch, session=session)
+
+    response = client.post(
+        "/object/Z-SMP-1Q/external-links/new",
+        data={
+            "system": "bloom",
+            "foreign_uid": "M-123",
+            "relationship_type": "external_ref",
+            "auth_mode": "none",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert (
+        response.headers["location"]
+        == "/object/Z-XRF-2Q?notice=external_link_created"
+    )
+    assert len(session.added) == 1
+    assert session.added[0].parent_instance_uid == len("Z-SMP-1Q")
+    assert session.added[0].child_instance_uid == 201
+
+
+def test_gui_external_link_api_creates_typed_object_and_lineage(monkeypatch):
+    session = _Session(
+        {
+            generic_template: [_template()],
+            generic_instance: [_instance("Z-SMP-1Q", "Sample 1")],
+            generic_instance_lineage: [],
+            audit_log: [],
+        }
+    )
+    created = SimpleNamespace(
+        uid=201,
+        euid="Z-XRF-2Q",
+        polymorphic_discriminator="generic_instance",
+    )
+
+    class _Factory:
+        def __init__(self, template_manager, *, domain_code):
+            self.domain_code = domain_code
+
+        def create_instance(self, session, template_code, name, properties, create_children):
+            assert template_code == "XRF/external_identifier/tapdb_object/1.0/"
+            assert name == "dewey:M-456"
+            assert properties["external_identifier"]["target_euid"] == "M-456"
+            assert properties["external_identifier"]["base_url"] == "https://dewey.example"
+            assert create_children is False
+            return created
+
+    monkeypatch.setattr("daylily_tapdb.gui.router.InstanceFactory", _Factory)
+    client = _client(monkeypatch, session=session)
+
+    response = client.post(
+        "/api/object/Z-SMP-1Q/external-links",
+        json={
+            "system": "dewey",
+            "foreign_uid": "M-456",
+            "relationship_type": "external_ref",
+            "graph_base_url": "https://dewey.example",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "source_euid": "Z-SMP-1Q",
+        "link_euid": "Z-XRF-2Q",
+        "lineage_euid": None,
+        "relationship_type": "external_ref",
+    }
+    assert len(session.added) == 1
+    assert session.added[0].parent_instance_uid == len("Z-SMP-1Q")
+    assert session.added[0].child_instance_uid == 201
+
+
+def test_gui_exports_are_available_from_web_package():
+    from daylily_tapdb.web import create_tapdb_gui_app, create_tapdb_gui_router
+
+    assert callable(create_tapdb_gui_app)
+    assert callable(create_tapdb_gui_router)

--- a/tests/test_gui_embedded.py
+++ b/tests/test_gui_embedded.py
@@ -536,11 +536,19 @@ def test_gui_readiness_page_and_api_report_seeded_external_template(monkeypatch)
     payload = api.json()
     assert payload["ready"] is True
     assert payload["domain_code"] == "Z"
+    assert payload["public_domain_registry"]["repository"].endswith(
+        "lsmc-bio/meridian-registry"
+    )
+    assert payload["public_domain_registry"]["version"] == "0.1.1"
+    checks = {check["name"]: check for check in payload["checks"]}
+    assert checks["governance"]["ok"] is True
+    assert "public registry 0.1.1" in checks["governance"]["detail"]
     assert {
         "name": "external_link_template",
         "ok": True,
         "detail": "XRF/external_identifier/tapdb_object/1.0/",
     } in payload["checks"]
+    assert "meridian-registry" in page.text
 
 
 def test_gui_meridian_validation_api_reports_prefix(monkeypatch):
@@ -553,6 +561,7 @@ def test_gui_meridian_validation_api_reports_prefix(monkeypatch):
     assert payload["domain_code"] == "Z"
     assert payload["prefix"] == "XRF"
     assert payload["prefix_owner"] == "daylily-tapdb"
+    assert payload["public_domain_registry"]["version"] == "0.1.1"
 
 
 def test_gui_status_redirect_adds_success_notice(monkeypatch):

--- a/tests/test_gui_embedded.py
+++ b/tests/test_gui_embedded.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import tomllib
 from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from daylily_tapdb.gui import create_tapdb_gui_app
@@ -207,6 +210,28 @@ def test_gui_mount_redirects_unauthenticated_html_and_blocks_api():
     assert response.json()["detail"] == "host_session_required"
 
 
+def test_gui_mounted_api_blocks_unauthenticated_with_json_401():
+    bridge = TapdbHostBridge(
+        auth_mode="host_session",
+        login_url="/login",
+        resolve_user=lambda _request: None,
+    )
+    host = FastAPI()
+    host.mount(
+        "/tapdb",
+        create_tapdb_gui_app(config_path="/tmp/tapdb-config.yaml", host_bridge=bridge),
+    )
+    client = TestClient(host, base_url="https://localhost")
+
+    html_response = client.get("/tapdb/search", follow_redirects=False)
+    api_response = client.get("/tapdb/api/search", follow_redirects=False)
+
+    assert html_response.status_code == 302
+    assert html_response.headers["location"] == "/login"
+    assert api_response.status_code == 401
+    assert api_response.json()["detail"] == "host_session_required"
+
+
 def test_gui_search_page_uses_host_css_and_root_safe_links(monkeypatch):
     client = _client(monkeypatch)
 
@@ -248,6 +273,24 @@ def test_gui_admin_pages_require_admin(monkeypatch):
 
     assert response.status_code == 403
     assert response.json()["detail"] == "tapdb_gui_admin_required"
+
+
+def test_gui_create_routes_require_admin(monkeypatch):
+    client = _client(monkeypatch, role="user")
+
+    page = client.get("/create/Z-XRF-1Q")
+    post_page = client.post(
+        "/create/Z-XRF-1Q",
+        data={"name": "Link", "properties_json": "{}"},
+    )
+    post_api = client.post(
+        "/api/create/Z-XRF-1Q",
+        json={"name": "Link", "properties": {}},
+    )
+
+    assert page.status_code == 403
+    assert post_page.status_code == 403
+    assert post_api.status_code == 403
 
 
 def test_gui_template_validation_api_reports_valid_level2_template(monkeypatch):
@@ -680,8 +723,55 @@ def test_gui_external_link_api_creates_typed_object_and_lineage(monkeypatch):
     assert session.added[0].child_instance_uid == 201
 
 
+def test_gui_external_link_creation_rejects_legacy_template_shape(monkeypatch):
+    session = _Session(
+        {
+            generic_template: [
+                _template(
+                    category="external_identifier",
+                    type_name="tapdb",
+                    subtype="object",
+                    prefix="XID",
+                )
+            ],
+            generic_instance: [_instance("Z-SMP-1Q", "Sample 1")],
+            generic_instance_lineage: [],
+            audit_log: [],
+        }
+    )
+    client = _client(monkeypatch, session=session)
+
+    response = client.post(
+        "/api/object/Z-SMP-1Q/external-links",
+        json={
+            "system": "dewey",
+            "foreign_uid": "M-456",
+            "relationship_type": "external_ref",
+        },
+    )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]
+        == "No XRF/external_identifier/tapdb_object external link template is seeded."
+    )
+    assert session.added == []
+
+
 def test_gui_exports_are_available_from_web_package():
     from daylily_tapdb.web import create_tapdb_gui_app, create_tapdb_gui_router
 
     assert callable(create_tapdb_gui_app)
     assert callable(create_tapdb_gui_router)
+
+
+def test_gui_extra_and_package_data_contracts_are_declared():
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+    optional = pyproject["project"]["optional-dependencies"]
+    assert set(optional["gui"]) >= {"fastapi", "jinja2"}
+
+    package_data = set(pyproject["tool"]["setuptools"]["package-data"]["daylily_tapdb"])
+    assert "gui/static/css/*.css" in package_data
+    assert "gui/static/js/*.js" in package_data
+    assert "gui/templates/*.html" in package_data

--- a/tests/test_gui_embedded.py
+++ b/tests/test_gui_embedded.py
@@ -25,7 +25,9 @@ class _Related:
             [
                 row
                 for row in self._rows
-                if all(getattr(row, key, None) == value for key, value in kwargs.items())
+                if all(
+                    getattr(row, key, None) == value for key, value in kwargs.items()
+                )
             ]
         )
 
@@ -45,7 +47,9 @@ class _Query:
             [
                 row
                 for row in self._rows
-                if all(getattr(row, key, None) == value for key, value in kwargs.items())
+                if all(
+                    getattr(row, key, None) == value for key, value in kwargs.items()
+                )
             ]
         )
 
@@ -380,7 +384,9 @@ def test_gui_create_from_template_passes_child_instantiation_flag(monkeypatch):
         def __init__(self, template_manager, *, domain_code):
             self.domain_code = domain_code
 
-        def create_instance(self, session, template_code, name, properties, create_children):
+        def create_instance(
+            self, session, template_code, name, properties, create_children
+        ):
             calls.append(
                 {
                     "template_code": template_code,
@@ -439,7 +445,9 @@ def test_gui_create_api_passes_child_instantiation_flag(monkeypatch):
         def __init__(self, template_manager, *, domain_code):
             self.domain_code = domain_code
 
-        def create_instance(self, session, template_code, name, properties, create_children):
+        def create_instance(
+            self, session, template_code, name, properties, create_children
+        ):
             assert template_code == "PLT/container/example_plate/1.0/"
             assert name == "Plate API"
             assert properties == {"plate_type": "96-well"}
@@ -649,7 +657,9 @@ def test_gui_external_link_creates_typed_object_and_lineage(monkeypatch):
         def __init__(self, template_manager, *, domain_code):
             self.domain_code = domain_code
 
-        def create_instance(self, session, template_code, name, properties, create_children):
+        def create_instance(
+            self, session, template_code, name, properties, create_children
+        ):
             assert template_code == "XRF/external_identifier/tapdb_object/1.0/"
             assert name == "bloom:M-123"
             assert properties["foreign_uid"] == "M-123"
@@ -672,8 +682,7 @@ def test_gui_external_link_creates_typed_object_and_lineage(monkeypatch):
 
     assert response.status_code == 303
     assert (
-        response.headers["location"]
-        == "/object/Z-XRF-2Q?notice=external_link_created"
+        response.headers["location"] == "/object/Z-XRF-2Q?notice=external_link_created"
     )
     assert len(session.added) == 1
     assert session.added[0].parent_instance_uid == len("Z-SMP-1Q")
@@ -699,11 +708,15 @@ def test_gui_external_link_api_creates_typed_object_and_lineage(monkeypatch):
         def __init__(self, template_manager, *, domain_code):
             self.domain_code = domain_code
 
-        def create_instance(self, session, template_code, name, properties, create_children):
+        def create_instance(
+            self, session, template_code, name, properties, create_children
+        ):
             assert template_code == "XRF/external_identifier/tapdb_object/1.0/"
             assert name == "dewey:M-456"
             assert properties["external_identifier"]["target_euid"] == "M-456"
-            assert properties["external_identifier"]["base_url"] == "https://dewey.example"
+            assert (
+                properties["external_identifier"]["base_url"] == "https://dewey.example"
+            )
             assert create_children is False
             return created
 

--- a/tests/test_template_loader.py
+++ b/tests/test_template_loader.py
@@ -30,6 +30,7 @@ def test_core_bundle_only_seeds_operational_templates():
     assert codes == {
         "SYS/actor/system_user/1.0",
         "MSG/message/webhook_event/1.0",
+        "XRF/external_identifier/tapdb_object/1.0",
     }
 
 

--- a/tests/test_template_loader_edges.py
+++ b/tests/test_template_loader_edges.py
@@ -117,7 +117,9 @@ def test_template_ref_extraction_and_duplicate_keys():
     assert duplicates[("SMP", "sample", "tube", "1.0")] == ["a.json", "b.json"]
 
 
-def test_load_and_validate_template_configs_collects_errors(tmp_path: Path, monkeypatch):
+def test_load_and_validate_template_configs_collects_errors(
+    tmp_path: Path, monkeypatch
+):
     config = tmp_path / "config"
     _write_pack(config / "sample" / "valid.json", {"templates": [_template()]})
     _write_pack(config / "sample" / "bad-root.json", [])
@@ -153,7 +155,9 @@ def test_load_and_validate_template_configs_collects_errors(tmp_path: Path, monk
     assert "Field 'json_addl' must be an object/dict" in messages
     assert "Field 'json_addl_schema' must be an object/dict" in messages
     assert "Field 'is_singleton' must be boolean" in messages
-    assert "Client templates cannot persist reserved TapDB operational prefix" in messages
+    assert (
+        "Client templates cannot persist reserved TapDB operational prefix" in messages
+    )
 
 
 def test_validate_template_configs_missing_dirs_and_empty_input(tmp_path: Path):
@@ -166,13 +170,17 @@ def test_validate_template_configs_missing_dirs_and_empty_input(tmp_path: Path):
     assert no_templates == []
     assert no_dirs_issues[0].message == "No config directories provided"
     assert missing_templates == []
-    assert any("Config directory not found" in issue.message for issue in missing_issues)
+    assert any(
+        "Config directory not found" in issue.message for issue in missing_issues
+    )
     assert any("No templates found" in issue.message for issue in missing_issues)
 
 
 def test_prepare_seed_templates_rejects_bad_prefixes(tmp_path: Path):
     with pytest.raises(ValueError, match="must declare an instance_prefix"):
-        loader._prepare_seed_templates([_template(instance_prefix="")], core_config_dir=tmp_path)
+        loader._prepare_seed_templates(
+            [_template(instance_prefix="")], core_config_dir=tmp_path
+        )
     with pytest.raises(ValueError, match="same Meridian prefix"):
         loader._prepare_seed_templates(
             [_template(category="SMP", instance_prefix="BAD")],

--- a/tests/test_template_loader_edges.py
+++ b/tests/test_template_loader_edges.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from daylily_tapdb.templates import loader
+
+
+def _write_pack(path: Path, payload) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _template(**overrides):
+    payload = {
+        "name": "Sample",
+        "polymorphic_discriminator": "generic_template",
+        "category": "SMP",
+        "type": "sample",
+        "subtype": "tube",
+        "version": "1.0",
+        "instance_prefix": "SMP",
+        "instance_polymorphic_identity": "generic_instance",
+        "json_addl": {},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_registry_loaders_reject_malformed_files(tmp_path: Path):
+    not_object = tmp_path / "not-object.json"
+    not_object.write_text("[]", encoding="utf-8")
+    bad_domains = tmp_path / "domains.json"
+    bad_domains.write_text('{"domains": []}', encoding="utf-8")
+    bad_prefixes = tmp_path / "prefixes.json"
+    bad_prefixes.write_text('{"ownership": []}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="JSON object"):
+        loader._load_json_file(not_object)
+    with pytest.raises(ValueError, match="domains"):
+        loader._load_domain_registry(bad_domains)
+    with pytest.raises(ValueError, match="ownership"):
+        loader._load_prefix_ownership_registry(bad_prefixes)
+
+
+def test_domain_and_prefix_ownership_validation_errors():
+    with pytest.raises(ValueError, match="not registered"):
+        loader._assert_registered_domain("Z", {"domains": {}}, source="domains.json")
+    with pytest.raises(ValueError, match="No prefix claims"):
+        loader._assert_prefix_claimed(
+            domain_code="Z",
+            prefix="SMP",
+            owner_repo_name="owner",
+            prefix_registry={"ownership": {}},
+            source="prefixes.json",
+        )
+    with pytest.raises(ValueError, match="not registered"):
+        loader._assert_prefix_claimed(
+            domain_code="Z",
+            prefix="SMP",
+            owner_repo_name="owner",
+            prefix_registry={"ownership": {"Z": {}}},
+            source="prefixes.json",
+        )
+    with pytest.raises(ValueError, match="missing an owner"):
+        loader._assert_prefix_claimed(
+            domain_code="Z",
+            prefix="SMP",
+            owner_repo_name="owner",
+            prefix_registry={"ownership": {"Z": {"SMP": {}}}},
+            source="prefixes.json",
+        )
+    with pytest.raises(ValueError, match="claimed by"):
+        loader._assert_prefix_claimed(
+            domain_code="Z",
+            prefix="SMP",
+            owner_repo_name="owner",
+            prefix_registry={"ownership": {"Z": {"SMP": {"issuer_app_code": "other"}}}},
+            source="prefixes.json",
+        )
+
+
+def test_template_ref_extraction_and_duplicate_keys():
+    payload = _template(
+        json_addl={
+            "action_imports": {
+                "group": {"actions": {"ACT/action/do/1.0": {}}},
+                "single": "ACT/action/single/1.0",
+            },
+            "expected_inputs": ["SMP/sample/input/1.0"],
+            "expected_outputs": ["SMP/sample/output/1.0"],
+            "instantiation_layouts": [
+                {
+                    "relationship_type": "contains",
+                    "child_templates": [
+                        "WEL/container/well/1.0",
+                        {"template_code": "WEL/container/well2/1.0"},
+                    ],
+                }
+            ],
+        }
+    )
+
+    refs = set(loader._extract_template_refs(payload))
+    duplicates = loader.find_duplicate_template_keys(
+        [
+            {**payload, "_source_file": "a.json"},
+            {**payload, "_source_file": "b.json"},
+        ]
+    )
+
+    assert "ACT/action/do/1.0" in refs
+    assert "WEL/container/well2/1.0" in refs
+    assert duplicates[("SMP", "sample", "tube", "1.0")] == ["a.json", "b.json"]
+
+
+def test_load_and_validate_template_configs_collects_errors(tmp_path: Path, monkeypatch):
+    config = tmp_path / "config"
+    _write_pack(config / "sample" / "valid.json", {"templates": [_template()]})
+    _write_pack(config / "sample" / "bad-root.json", [])
+    _write_pack(config / "sample" / "bad-template.json", {"templates": ["bad"]})
+    (config / "sample" / "invalid-json.json").write_text("{", encoding="utf-8")
+    _write_pack(
+        config / "sample" / "bad-fields.json",
+        {
+            "templates": [
+                _template(
+                    name="",
+                    json_addl=[],
+                    json_addl_schema=[],
+                    is_singleton="no",
+                    instance_prefix="SYS",
+                    expected_inputs="not-list",
+                )
+            ]
+        },
+    )
+    monkeypatch.setattr(loader, "find_tapdb_core_config_dir", lambda: tmp_path / "core")
+
+    loaded = loader.load_template_configs([config, config, tmp_path / "missing"])
+    templates, issues = loader.validate_template_configs([config], strict=True)
+
+    messages = "\n".join(issue.message for issue in issues)
+    assert len(loaded) >= 2
+    assert templates
+    assert "Config root must be an object/dict" in messages
+    assert "Invalid JSON" in messages
+    assert "Template[0] must be an object/dict" in messages
+    assert "Missing/invalid required field 'name'" in messages
+    assert "Field 'json_addl' must be an object/dict" in messages
+    assert "Field 'json_addl_schema' must be an object/dict" in messages
+    assert "Field 'is_singleton' must be boolean" in messages
+    assert "Client templates cannot persist reserved TapDB operational prefix" in messages
+
+
+def test_validate_template_configs_missing_dirs_and_empty_input(tmp_path: Path):
+    no_templates, no_dirs_issues = loader.validate_template_configs([], strict=True)
+    missing_templates, missing_issues = loader.validate_template_configs(
+        [tmp_path / "missing"],
+        strict=False,
+    )
+
+    assert no_templates == []
+    assert no_dirs_issues[0].message == "No config directories provided"
+    assert missing_templates == []
+    assert any("Config directory not found" in issue.message for issue in missing_issues)
+    assert any("No templates found" in issue.message for issue in missing_issues)
+
+
+def test_prepare_seed_templates_rejects_bad_prefixes(tmp_path: Path):
+    with pytest.raises(ValueError, match="must declare an instance_prefix"):
+        loader._prepare_seed_templates([_template(instance_prefix="")], core_config_dir=tmp_path)
+    with pytest.raises(ValueError, match="same Meridian prefix"):
+        loader._prepare_seed_templates(
+            [_template(category="SMP", instance_prefix="BAD")],
+            core_config_dir=tmp_path,
+        )
+    with pytest.raises(ValueError, match="reserved TapDB operational prefix"):
+        loader._prepare_seed_templates(
+            [_template(category="SYS", instance_prefix="SYS")],
+            core_config_dir=tmp_path,
+        )
+
+
+def test_validate_seed_ownership_rejects_missing_prefix(tmp_path: Path):
+    domain_registry = tmp_path / "domain.json"
+    prefix_registry = tmp_path / "prefix.json"
+    domain_registry.write_text(
+        '{"domains": {"Z": {"name": "test"}}}',
+        encoding="utf-8",
+    )
+    prefix_registry.write_text(
+        '{"ownership": {"Z": {"SMP": {"issuer_app_code": "daylily-tapdb"}}}}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="missing an instance_prefix"):
+        loader._validate_seed_ownership(
+            [_template(instance_prefix="")],
+            domain_code="Z",
+            owner_repo_name="daylily-tapdb",
+            domain_registry_path=domain_registry,
+            prefix_registry_path=prefix_registry,
+        )
+
+
+def test_seed_templates_rejects_missing_domain_and_owner(tmp_path: Path):
+    with pytest.raises(ValueError, match="domain_code is required"):
+        loader.seed_templates(
+            object(),
+            [],
+            overwrite=False,
+            core_config_dir=tmp_path,
+            domain_code="",
+            owner_repo_name="daylily-tapdb",
+            domain_registry_path=tmp_path / "domain.json",
+            prefix_registry_path=tmp_path / "prefix.json",
+        )
+    with pytest.raises(ValueError, match="owner_repo_name is required"):
+        loader.seed_templates(
+            object(),
+            [],
+            overwrite=False,
+            core_config_dir=tmp_path,
+            domain_code="Z",
+            owner_repo_name="",
+            domain_registry_path=tmp_path / "domain.json",
+            prefix_registry_path=tmp_path / "prefix.json",
+        )


### PR DESCRIPTION
## Summary

- bump TapDB to meridian-euid 0.4.7
- expose meridian-registry 0.1.1 provenance in TapDB Meridian/readiness APIs and admin pages
- keep TapDB runtime domain/prefix registries explicit and local while preserving meridian-registry as the public domain-code authority

## Validation

- ruff check daylily_tapdb tests
- python -m pytest tests/ -q
- python -m build --wheel --outdir /tmp/daylily_tapdb_build_check
- meridian-euid domain-check N --registry-index /Users/jmajor/projects/lsmc/archived/meridian-registry/registry/generated/domains.json -> exit 1, assigned to Inflection
- meridian-euid domain-check Q --registry-index /Users/jmajor/projects/lsmc/archived/meridian-registry/registry/generated/domains.json -> exit 0, available
